### PR TITLE
feature(#78) Updated naming

### DIFF
--- a/packages/core/jsr.json
+++ b/packages/core/jsr.json
@@ -7,7 +7,7 @@
 		"./bin": "./src/bin/ecopages.ts",
 		"./build-app": "./src/main/build-app.ts",
 		"./config-builder": "./src/main/config-builder.ts",
-		"./services/dependency-service": "./src/services/dependency.service.ts",
+		"./services/assets-dependency-service": "./src/services/assets-dependency-service.service.ts",
 		"./route-renderer/integration-renderer": "./src/route-renderer/integration-renderer.ts",
 		"./utils/add-base-url-to-pathname": "./src/utils/add-base-url-to-pathname.ts",
 		"./utils/deep-merge": "./src/utils/deep-merge.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,9 +47,9 @@
 			"types": "./src/main/config-builder.ts",
 			"default": "./src/main/config-builder.ts"
 		},
-		"./services/dependency-service": {
-			"types": "./src/services/dependency.service.ts",
-			"default": "./src/services/dependency.service.ts"
+		"./services/assets-dependency-service": {
+			"types": "./src/services/assets-dependency.service.ts",
+			"default": "./src/services/assets-dependency.service.ts"
 		},
 		"./route-renderer/integration-renderer": {
 			"types": "./src/route-renderer/integration-renderer.ts",

--- a/packages/core/src/main/build-app.ts
+++ b/packages/core/src/main/build-app.ts
@@ -6,8 +6,8 @@ import type { EcoPagesAppConfig } from '../internal-types.ts';
 import { AppBuilder } from '../main/app-builder.ts';
 import { ScriptsBuilder } from '../main/scripts-builder.ts';
 import { StaticPageGenerator } from '../main/static-page-generator.ts';
+import { AssetsDependencyService } from '../services/assets-dependency.service.ts';
 import { CssParserService } from '../services/css-parser.service.ts';
-import { DependencyService } from '../services/dependency.service.ts';
 import { HtmlTransformerService } from '../services/html-transformer.service.ts';
 
 const validateConfig = (config: unknown): EcoPagesAppConfig => {
@@ -45,7 +45,7 @@ export async function buildApp({
       appConfig,
       options: { watchMode: watch as boolean },
     }),
-    dependencyService: new DependencyService({ appConfig }),
+    assetsDependencyService: new AssetsDependencyService({ appConfig }),
     htmlTransformer: new HtmlTransformerService(),
     options: {
       watch: watch as boolean,

--- a/packages/core/src/plugins/integration-plugin.ts
+++ b/packages/core/src/plugins/integration-plugin.ts
@@ -1,21 +1,21 @@
 import type { EcoPagesAppConfig } from '../internal-types';
 import type { EcoPagesElement } from '../public-types';
 import type { IntegrationRenderer } from '../route-renderer/integration-renderer';
-import type { Dependency, DependencyService } from '../services/dependency.service';
+import type { AssetDependency, AssetsDependencyService } from '../services/assets-dependency.service';
 
 export interface IntegrationPluginConfig {
   name: string;
   extensions: string[];
-  dependencies?: Dependency[];
+  dependencies?: AssetDependency[];
 }
 
 export abstract class IntegrationPlugin<C = EcoPagesElement> {
   readonly name: string;
   readonly extensions: string[];
-  protected dependencies: Dependency[] = [];
+  protected dependencies: AssetDependency[] = [];
   protected options?: Record<string, unknown>;
   protected appConfig?: EcoPagesAppConfig;
-  protected dependencyService?: DependencyService;
+  protected assetsDependencyService?: AssetsDependencyService;
 
   constructor(config: IntegrationPluginConfig) {
     this.name = config.name;
@@ -27,11 +27,11 @@ export abstract class IntegrationPlugin<C = EcoPagesElement> {
     this.appConfig = appConfig;
   }
 
-  setDependencyService(dependencyService: DependencyService): void {
-    this.dependencyService = dependencyService;
+  setDependencyService(assetsDepenencyService: AssetsDependencyService): void {
+    this.assetsDependencyService = assetsDepenencyService;
   }
 
-  getDependencies(): Dependency[] {
+  getDependencies(): AssetDependency[] {
     return this.dependencies;
   }
 

--- a/packages/core/src/plugins/integration-plugin.ts
+++ b/packages/core/src/plugins/integration-plugin.ts
@@ -27,8 +27,8 @@ export abstract class IntegrationPlugin<C = EcoPagesElement> {
     this.appConfig = appConfig;
   }
 
-  setDependencyService(assetsDepenencyService: AssetsDependencyService): void {
-    this.assetsDependencyService = assetsDepenencyService;
+  setDependencyService(assetsDependencyService: AssetsDependencyService): void {
+    this.assetsDependencyService = assetsDependencyService;
   }
 
   getDependencies(): AssetDependency[] {

--- a/packages/core/src/plugins/processor.ts
+++ b/packages/core/src/plugins/processor.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import type { BunPlugin } from 'bun';
 import type { EcoPagesAppConfig } from '../internal-types';
-import type { Dependency } from '../services/dependency.service';
+import type { AssetDependency } from '../services/assets-dependency.service';
 import { FileUtils } from '../utils/file-utils.module';
 
 export interface ProcessorWatchConfig {
@@ -47,7 +47,7 @@ export interface ProcessorBuildPlugin {
 export abstract class Processor<TOptions = Record<string, unknown>> {
   static CACHE_DIR = '__cache__';
   readonly name: string;
-  protected dependencies: Dependency[] = [];
+  protected dependencies: AssetDependency[] = [];
   protected context?: ProcessorContext;
   protected options?: TOptions;
   protected watchConfig?: ProcessorWatchConfig;
@@ -103,7 +103,7 @@ export abstract class Processor<TOptions = Record<string, unknown>> {
     return this.watchConfig;
   }
 
-  getDependencies(): Dependency[] {
+  getDependencies(): AssetDependency[] {
     return this.dependencies;
   }
 

--- a/packages/core/src/services/assets-dependency.service.test.ts
+++ b/packages/core/src/services/assets-dependency.service.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { ConfigBuilder } from '../main/config-builder';
-import { DependencyHelpers, type DependencyProvider, DependencyService } from './dependency.service';
+import { AssetDependencyHelpers, AssetsDependencyService, type DependencyProvider } from './assets-dependency.service';
 
 describe('DependencyService', () => {
-  let service: DependencyService;
+  let service: AssetsDependencyService;
 
   beforeEach(async () => {
-    service = new DependencyService({
+    service = new AssetsDependencyService({
       appConfig: await new ConfigBuilder().setRootDir('test').setBaseUrl('.').build(),
     });
   });
@@ -17,10 +17,10 @@ describe('DependencyService', () => {
       getDependencies: () => [],
     };
 
-    service.addProvider(provider);
+    service.registerDependencies(provider);
     expect(await service.prepareDependencies()).toEqual([]);
 
-    service.removeProvider('test-provider');
+    service.unregisterDependencies('test-provider');
     expect(await service.prepareDependencies()).toEqual([]);
   });
 
@@ -28,14 +28,14 @@ describe('DependencyService', () => {
     const provider: DependencyProvider = {
       name: 'test-provider',
       getDependencies: () => [
-        DependencyHelpers.createPreBundledScriptDependency({
+        AssetDependencyHelpers.createPreBundledScriptAsset({
           srcUrl: '/dist/test.js',
           attributes: { type: 'module' },
         }),
       ],
     };
 
-    service.addProvider(provider);
+    service.registerDependencies(provider);
     const deps = await service.prepareDependencies();
 
     expect(deps).toHaveLength(1);
@@ -52,14 +52,14 @@ describe('DependencyService', () => {
     const provider: DependencyProvider = {
       name: 'inline-provider',
       getDependencies: () => [
-        DependencyHelpers.createInlineScriptDependency({
+        AssetDependencyHelpers.createInlineScriptAsset({
           content: inlineContent,
           position: 'head',
         }),
       ],
     };
 
-    service.addProvider(provider);
+    service.registerDependencies(provider);
     const deps = await service.prepareDependencies();
 
     expect(deps).toHaveLength(1);
@@ -76,18 +76,18 @@ describe('DependencyService', () => {
     const provider: DependencyProvider = {
       name: 'ordered-provider',
       getDependencies: () => [
-        DependencyHelpers.createPreBundledScriptDependency({
+        AssetDependencyHelpers.createPreBundledScriptAsset({
           srcUrl: '/first.js',
           position: 'head',
         }),
-        DependencyHelpers.createPreBundledScriptDependency({
+        AssetDependencyHelpers.createPreBundledScriptAsset({
           srcUrl: '/second.js',
           position: 'head',
         }),
       ],
     };
 
-    service.addProvider(provider);
+    service.registerDependencies(provider);
     const deps = await service.prepareDependencies();
 
     expect(deps).toHaveLength(2);
@@ -106,8 +106,8 @@ describe('DependencyService', () => {
       getDependencies: () => [],
     };
 
-    service.addProvider(provider1);
-    service.addProvider(provider2);
+    service.registerDependencies(provider1);
+    service.registerDependencies(provider2);
 
     const deps = await service.prepareDependencies();
     expect(deps).toEqual([]);
@@ -116,7 +116,7 @@ describe('DependencyService', () => {
 
 describe('DependencyHelpers', () => {
   it('should create inline script dependency', () => {
-    const dep = DependencyHelpers.createInlineScriptDependency({
+    const dep = AssetDependencyHelpers.createInlineScriptAsset({
       content: "console.log('test')",
       attributes: { id: 'test' },
     });
@@ -132,7 +132,7 @@ describe('DependencyHelpers', () => {
   });
 
   it('should create src script dependency', () => {
-    const dep = DependencyHelpers.createSrcScriptDependency({
+    const dep = AssetDependencyHelpers.createSrcScriptAsset({
       srcUrl: '/test.js',
       attributes: { defer: 'true' },
     });
@@ -147,7 +147,7 @@ describe('DependencyHelpers', () => {
   });
 
   it('should create inline stylesheet dependency', () => {
-    const dep = DependencyHelpers.createInlineStylesheetDependency({
+    const dep = AssetDependencyHelpers.createnlineStylesheetAsset({
       content: 'body { color: red; }',
       attributes: { id: 'test-style' },
     });
@@ -163,7 +163,7 @@ describe('DependencyHelpers', () => {
   });
 
   it('should create src stylesheet dependency', () => {
-    const dep = DependencyHelpers.createSrcStylesheetDependency({
+    const dep = AssetDependencyHelpers.createStylesheetAsset({
       srcUrl: '/test.css',
       attributes: { media: 'screen' },
     });

--- a/packages/core/src/services/assets-dependency.service.test.ts
+++ b/packages/core/src/services/assets-dependency.service.test.ts
@@ -147,7 +147,7 @@ describe('DependencyHelpers', () => {
   });
 
   it('should create inline stylesheet dependency', () => {
-    const dep = AssetDependencyHelpers.createnlineStylesheetAsset({
+    const dep = AssetDependencyHelpers.createInlineStylesheetAsset({
       content: 'body { color: red; }',
       attributes: { id: 'test-style' },
     });

--- a/packages/core/src/services/assets-dependency.service.ts
+++ b/packages/core/src/services/assets-dependency.service.ts
@@ -532,7 +532,7 @@ export class AssetDependencyHelpers {
    * @param options {@link InlineStylesheetAsset}
    * @returns
    */
-  static createnlineStylesheetAsset = ({
+  static createInlineStylesheetAsset = ({
     ...options
   }: CreateDependencyPartial<InlineStylesheetAsset, 'content' | 'attributes'>): StylesheetAsset => {
     return {

--- a/packages/core/src/services/html-transformer.service.test.ts
+++ b/packages/core/src/services/html-transformer.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import type { ProcessedDependency } from './dependency.service';
+import type { ResolvedAsset } from './assets-dependency.service';
 import { HtmlTransformerService } from './html-transformer.service';
 
 describe('HtmlTransformerService', () => {
@@ -10,7 +10,7 @@ describe('HtmlTransformerService', () => {
   };
 
   it('should inject script dependencies correctly', async () => {
-    const dependencies: ProcessedDependency[] = [
+    const dependencies: ResolvedAsset[] = [
       {
         provider: 'test',
         kind: 'script',
@@ -32,7 +32,7 @@ describe('HtmlTransformerService', () => {
   });
 
   it('should inject stylesheet dependencies correctly', async () => {
-    const dependencies: ProcessedDependency[] = [
+    const dependencies: ResolvedAsset[] = [
       {
         provider: 'test',
         kind: 'stylesheet',
@@ -53,7 +53,7 @@ describe('HtmlTransformerService', () => {
   });
 
   it('should handle both inline and src dependencies', async () => {
-    const dependencies: ProcessedDependency[] = [
+    const dependencies: ResolvedAsset[] = [
       {
         provider: 'test',
         kind: 'script',
@@ -83,7 +83,7 @@ describe('HtmlTransformerService', () => {
   });
 
   it('should preserve existing HTML content', async () => {
-    const dependencies: ProcessedDependency[] = [
+    const dependencies: ResolvedAsset[] = [
       {
         provider: 'test',
         kind: 'script',

--- a/packages/integrations/kitajs/src/kitajs.plugin.ts
+++ b/packages/integrations/kitajs/src/kitajs.plugin.ts
@@ -29,7 +29,7 @@ export class KitaHtmlPlugin extends IntegrationPlugin {
 
     return new KitaRenderer({
       appConfig: this.appConfig,
-      dependencyService: this.dependencyService,
+      assetsDependencyService: this.assetsDependencyService,
     });
   }
 }

--- a/packages/integrations/lit/src/lit.plugin.ts
+++ b/packages/integrations/lit/src/lit.plugin.ts
@@ -5,7 +5,7 @@
 
 import type { IntegrationRenderer } from '@ecopages/core';
 import { IntegrationPlugin, type IntegrationPluginConfig } from '@ecopages/core/plugins/integration-plugin';
-import { DependencyHelpers } from '@ecopages/core/services/dependency-service';
+import { AssetDependencyHelpers } from '@ecopages/core/services/assets-dependency-service';
 import { litElementHydrateScript } from './lit-element-hydrate';
 import { LitRenderer } from './lit-renderer';
 
@@ -24,7 +24,7 @@ export class LitPlugin extends IntegrationPlugin {
       name: PLUGIN_NAME,
       extensions: ['.lit.tsx'],
       dependencies: [
-        DependencyHelpers.createInlineScriptDependency({
+        AssetDependencyHelpers.createInlineScriptAsset({
           position: 'head',
           /**
            * BUG ALERT
@@ -49,7 +49,7 @@ export class LitPlugin extends IntegrationPlugin {
 
     return new LitRenderer({
       appConfig: this.appConfig,
-      dependencyService: this.dependencyService,
+      assetsDependencyService: this.assetsDependencyService,
     });
   }
 }

--- a/packages/integrations/mdx/src/mdx.plugin.ts
+++ b/packages/integrations/mdx/src/mdx.plugin.ts
@@ -27,7 +27,7 @@ export class MDXPlugin extends IntegrationPlugin {
 
     return new MDXRenderer({
       appConfig: this.appConfig,
-      dependencyService: this.dependencyService,
+      assetsDependencyService: this.assetsDependencyService,
     });
   }
 }

--- a/packages/integrations/react/src/react-renderer.ts
+++ b/packages/integrations/react/src/react-renderer.ts
@@ -12,7 +12,7 @@ import {
   type IntegrationRendererRenderOptions,
   type RouteRendererBody,
 } from '@ecopages/core';
-import { DependencyService } from '@ecopages/core/services/dependency-service';
+import { AssetsDependencyService } from '@ecopages/core/services/assets-dependency-service';
 import type { BunPlugin } from 'bun';
 import { type JSX, createElement } from 'react';
 import { renderToReadableStream } from 'react-dom/server';
@@ -63,7 +63,7 @@ interface ReactUrls {
  */
 export class ReactRenderer extends IntegrationRenderer<JSX.Element> {
   name = PLUGIN_NAME;
-  componentDirectory = DependencyService.DEPS_DIR;
+  componentDirectory = AssetsDependencyService.DEPS_DIR;
 
   private createHydrationScript(importPath: string) {
     return `import {hydrateRoot as hr, createElement as ce} from "react-dom/client";import c from "${importPath}";window.onload=()=>hr(document,ce(c))`;

--- a/packages/integrations/react/src/react.plugin.ts
+++ b/packages/integrations/react/src/react.plugin.ts
@@ -5,7 +5,7 @@
 
 import type { IntegrationRenderer } from '@ecopages/core';
 import { IntegrationPlugin, type IntegrationPluginConfig } from '@ecopages/core/plugins/integration-plugin';
-import { type Dependency, DependencyHelpers } from '@ecopages/core/services/dependency-service';
+import { type AssetDependency, AssetDependencyHelpers } from '@ecopages/core/services/assets-dependency-service';
 import { Logger } from '@ecopages/logger';
 import type { JSX } from 'react';
 import type React from 'react';
@@ -48,10 +48,10 @@ export class ReactPlugin extends IntegrationPlugin<React.JSX.Element> {
    * It is ossible to define which one should be included in the final bundle based on the environment.
    * @returns
    */
-  private generateDependencies(): Dependency[] {
+  private generateDependencies(): AssetDependency[] {
     if (import.meta.env.NODE_ENV === 'development') {
       return [
-        DependencyHelpers.createInlineScriptDependency({
+        AssetDependencyHelpers.createInlineScriptAsset({
           position: 'head',
           content: JSON.stringify(
             {
@@ -69,7 +69,7 @@ export class ReactPlugin extends IntegrationPlugin<React.JSX.Element> {
             type: 'importmap',
           },
         }),
-        DependencyHelpers.createNodeModuleScriptDependency({
+        AssetDependencyHelpers.createNodeModuleScriptAsset({
           position: 'head',
           importPath: '@ecopages/react/react-dev-esm.ts',
           attributes: {
@@ -77,7 +77,7 @@ export class ReactPlugin extends IntegrationPlugin<React.JSX.Element> {
             defer: '',
           },
         }),
-        DependencyHelpers.createNodeModuleScriptDependency({
+        AssetDependencyHelpers.createNodeModuleScriptAsset({
           position: 'head',
           importPath: '@ecopages/react/react-dom-esm.ts',
           attributes: {
@@ -89,7 +89,7 @@ export class ReactPlugin extends IntegrationPlugin<React.JSX.Element> {
     }
 
     return [
-      DependencyHelpers.createInlineScriptDependency({
+      AssetDependencyHelpers.createInlineScriptAsset({
         position: 'head',
         content: JSON.stringify(
           {
@@ -108,7 +108,7 @@ export class ReactPlugin extends IntegrationPlugin<React.JSX.Element> {
           defer: '',
         },
       }),
-      DependencyHelpers.createNodeModuleScriptDependency({
+      AssetDependencyHelpers.createNodeModuleScriptAsset({
         position: 'head',
         importPath: '@ecopages/react/react-esm.ts',
         attributes: {
@@ -116,7 +116,7 @@ export class ReactPlugin extends IntegrationPlugin<React.JSX.Element> {
           defer: '',
         },
       }),
-      DependencyHelpers.createNodeModuleScriptDependency({
+      AssetDependencyHelpers.createNodeModuleScriptAsset({
         position: 'head',
         importPath: '@ecopages/react/react-dom-esm.ts',
         attributes: {
@@ -134,7 +134,7 @@ export class ReactPlugin extends IntegrationPlugin<React.JSX.Element> {
 
     return new ReactRenderer({
       appConfig: this.appConfig,
-      dependencyService: this.dependencyService,
+      assetsDependencyService: this.assetsDependencyService,
     });
   }
 }

--- a/packages/processors/image-processor/src/plugin.ts
+++ b/packages/processors/image-processor/src/plugin.ts
@@ -11,7 +11,7 @@ import {
   type ProcessorConfig,
   type ProcessorWatchConfig,
 } from '@ecopages/core/plugins/processor';
-import { type Dependency, DependencyHelpers } from '@ecopages/core/services/dependency-service';
+import { type AssetDependency, AssetDependencyHelpers } from '@ecopages/core/services/assets-dependency-service';
 import { Logger } from '@ecopages/logger';
 import { createImagePlugin, createImagePluginBundler } from './bun-plugins';
 import { ImageProcessor } from './image-processor';
@@ -84,12 +84,12 @@ export class ImageProcessorPlugin extends Processor<ImageProcessorConfig> {
    * It is ossible to define which one should be included in the final bundle based on the environment.
    * @returns
    */
-  private generateDependencies(): Dependency[] {
-    const deps: Dependency[] = [];
+  private generateDependencies(): AssetDependency[] {
+    const deps: AssetDependency[] = [];
 
     if (import.meta.env.NODE_ENV === 'development') {
       deps.push(
-        DependencyHelpers.createInlineScriptDependency({
+        AssetDependencyHelpers.createInlineScriptAsset({
           content: `document.addEventListener("DOMContentLoaded",() => console.log("[@ecopages/image-processor] Processor is loaded"));`,
           attributes: {
             type: 'module',


### PR DESCRIPTION
The dependency collection service has been renamed to better reflect its responsibility:
- Changed DependencyService to AssetsDependencyService
- Updated all imports and references across integrations
- Maintained backward compatibility with existing plugins
