### PR TITLE
refactor(global): Migrate type declaration imports to ES module syntax

### DIFF
--- a/apps/docs/modules.d.ts
+++ b/apps/docs/modules.d.ts
@@ -1,5 +1,6 @@
-/// <reference path="../../node_modules/@ecopages/core/src/declarations.d.ts" />
-/// <reference path="../../node_modules/@ecopages/core/src/env.d.ts" />
+import '@ecopages/core/declarations';
+import '@ecopages/core/env';
+import '@ecopages/image-processor/types';
 
 declare module '*.mdx' {
 	const content: string;

--- a/examples/starter-ghtml/modules.d.ts
+++ b/examples/starter-ghtml/modules.d.ts
@@ -1,3 +1,3 @@
-/// <reference path="node_modules/@ecopages/core/src/declarations.d.ts" />
-/// <reference path="node_modules/@ecopages/core/src/env.d.ts" />
-/// <reference path="node_modules/@ecopages/scripts-injector/types.d.ts" />
+import '@ecopages/core/declarations';
+import '@ecopages/core/env';
+import '@ecopages/image-processor/types';

--- a/examples/starter-jsx/eco.config.ts
+++ b/examples/starter-jsx/eco.config.ts
@@ -7,7 +7,7 @@ import { postcssProcessorPlugin } from '@ecopages/postcss-processor';
 
 const config = await new ConfigBuilder()
 	.setRootDir(import.meta.dir)
-	.setBaseUrl(import.meta.env.ECOPAGES_BASE_URL || '')
+	.setBaseUrl(import.meta.env.ECOPAGES_BASE_URL)
 	.setIntegrations([
 		kitajsPlugin(),
 		mdxPlugin({

--- a/examples/starter-jsx/modules.d.ts
+++ b/examples/starter-jsx/modules.d.ts
@@ -1,5 +1,3 @@
-/// <reference path="node_modules/@ecopages/core/src/declarations.d.ts" />
-/// <reference path="node_modules/@ecopages/core/src/env.d.ts" />
-/// <reference path="node_modules/@ecopages/scripts-injector/types.d.ts" />
-/// <reference path="node_modules/@ecopages/image-processor" />
-/// <reference path="node_modules/@types/ecopages-image-processor/virtual-module.d.ts" />
+import '@ecopages/core/declarations';
+import '@ecopages/core/env';
+import '@ecopages/image-processor/types';

--- a/examples/starter-lit-jsx/eco.config.ts
+++ b/examples/starter-lit-jsx/eco.config.ts
@@ -6,7 +6,7 @@ import { postcssProcessorPlugin } from '@ecopages/postcss-processor';
 
 const config = await new ConfigBuilder()
 	.setRootDir(import.meta.dir)
-	.setBaseUrl(import.meta.env.ECOPAGES_BASE_URL || '')
+	.setBaseUrl(import.meta.env.ECOPAGES_BASE_URL)
 	.setIntegrations([
 		kitajsPlugin(),
 		litPlugin(),

--- a/examples/starter-lit-jsx/modules.d.ts
+++ b/examples/starter-lit-jsx/modules.d.ts
@@ -1,3 +1,3 @@
-/// <reference path="node_modules/@ecopages/core/src/declarations.d.ts" />
-/// <reference path="node_modules/@ecopages/core/src/env.d.ts" />
-/// <reference path="node_modules/@ecopages/scripts-injector/types.d.ts" />
+import '@ecopages/core/declarations';
+import '@ecopages/core/env';
+import '@ecopages/image-processor/types';

--- a/examples/starter-react/modules.d.ts
+++ b/examples/starter-react/modules.d.ts
@@ -1,2 +1,3 @@
-/// <reference path="node_modules/@ecopages/core/src/declarations.d.ts" />
-/// <reference path="node_modules/@ecopages/core/src/env.d.ts" />
+import '@ecopages/core/declarations';
+import '@ecopages/core/env';
+import '@ecopages/image-processor/types';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,12 @@
 			"require": "./src/index.ts",
 			"types": "./src/public-types.ts"
 		},
+		"./declarations": {
+			"types": "./src/declarations.d.ts"
+		},
+		"./env": {
+			"types": "./src/env.d.ts"
+		},
 		"./config-builder": {
 			"types": "./src/config/config-builder.ts",
 			"default": "./src/config/config-builder.ts"

--- a/packages/processors/image-processor/src/plugin.ts
+++ b/packages/processors/image-processor/src/plugin.ts
@@ -261,6 +261,18 @@ declare module "ecopages:images" {
 
 		FileUtils.writeFileSync(typesDir, content);
 		logger.debug('Generated types for virtual module', { typesDir });
+
+		const indexTypesDir = resolveGeneratedPath('types', {
+			root: this.context.rootDir,
+			module: this.name,
+			subPath: 'index.d.ts',
+			ensureDirExists: true,
+		});
+
+		const indexContent = 'import "./virtual-module.d.ts";';
+
+		FileUtils.writeFileSync(indexTypesDir, indexContent);
+		logger.debug('Generated index types for virtual module', { indexTypesDir });
 	}
 
 	/**

--- a/packages/processors/postcss-processor/ modules.d.ts
+++ b/packages/processors/postcss-processor/ modules.d.ts
@@ -1,2 +1,2 @@
-/// <reference path="../../../node_modules/@ecopages/core/src/declarations.d.ts" />
-/// <reference path="../../../node_modules/@ecopages/core/src/env.d.ts" />
+import '@ecopages/core/declarations';
+import '@ecopages/core/env';

--- a/playground/global/eco.config.ts
+++ b/playground/global/eco.config.ts
@@ -8,6 +8,7 @@ import { postcssProcessorPlugin } from '@ecopages/postcss-processor';
 
 export default await new ConfigBuilder()
 	.setRootDir(import.meta.dir)
+	.setBaseUrl(import.meta.env.ECOPAGES_BASE_URL)
 	.setIntegrations([
 		kitajsPlugin(),
 		litPlugin(),

--- a/playground/global/modules.d.ts
+++ b/playground/global/modules.d.ts
@@ -1,8 +1,6 @@
-/// <reference path="../../node_modules/@ecopages/core/src/declarations.d.ts" />
-/// <reference path="../../node_modules/@ecopages/core/src/env.d.ts" />
-/// <reference path="../../node_modules/@ecopages/scripts-injector/types.d.ts" />
-/// <reference path="../../node_modules/@ecopages/image-processor" />
-/// <reference path="node_modules/@types/ecopages-image-processor/virtual-module.d.ts" />
+import '@ecopages/core/declarations';
+import '@ecopages/core/env';
+import '@ecopages/scripts-injector/types';
 
 import type Alpine from 'alpinejs';
 

--- a/playground/react/modules.d.ts
+++ b/playground/react/modules.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="../../node_modules/@ecopages/core/src/declarations.d.ts" />
-/// <reference path="../../node_modules/@ecopages/core/src/env.d.ts" />
-/// <reference path="../../node_modules/@ecopages/image-processor/types.d.ts" />
-/// <reference path="node_modules/@types/ecopages-image-processor/virtual-module.d.ts" />
+import '@ecopages/core/declarations';
+import '@ecopages/core/env';
+import '@ecopages/image-processor/types';

--- a/playground/react/src/pages/mdx-test.mdx
+++ b/playground/react/src/pages/mdx-test.mdx
@@ -1,11 +1,11 @@
 import { Counter } from '@/components/counter';
 
 export const config = {
-    dependencies: {
-        components: [Counter],
-        stylesheets: ['./test-style.css']
-    }
-}
+	dependencies: {
+		components: [Counter],
+		stylesheets: ['./test-style.css'],
+	},
+};
 
 # Hello MDX
 


### PR DESCRIPTION
Migrate type declaration imports to ES module syntax, update eco.config baseUrl, and improve image processor type generation.