### PR TITLE
perf(e2e): restore batch parallelism for preview and dev

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -25,8 +25,9 @@ Only set these when debugging or tuning CI. Normal `pnpm test:e2e` does not requ
 | Variable                          | Values           | Effect                                                                                |
 | --------------------------------- | ---------------- | ------------------------------------------------------------------------------------- |
 | `ECOPAGES_E2E_TIMING`             | `true`           | Log per-batch wall-clock as `[e2e-timing]`                                            |
-| `ECOPAGES_E2E_SERVER_CONCURRENCY` | positive integer | Cap parallel kitchen-sink **preview** isolated servers (default `min(N, floor(N/2))`) |
-| `ECOPAGES_E2E_DEV_CONCURRENCY`    | positive integer | Cap parallel kitchen-sink **dev** processes (default `1`)                             |
+| `ECOPAGES_E2E_SERVER_CONCURRENCY` | positive integer | Cap parallel kitchen-sink **preview** isolated servers (default `availableParallelism()`) |
+| `ECOPAGES_E2E_DEV_CONCURRENCY`    | positive integer | Cap parallel kitchen-sink **dev** processes (default `min(2, availableParallelism())`)    |
+| `ECOPAGES_E2E_HMR_CONCURRENCY`      | positive integer | Cap parallel kitchen-sink **HMR** processes (default `1` — parallel boot is unstable)     |
 
 ### Local debugging
 

--- a/e2e/scripts/playwright/run-e2e.mjs
+++ b/e2e/scripts/playwright/run-e2e.mjs
@@ -13,25 +13,26 @@ const playwrightCliPath = require.resolve('@playwright/test/cli');
 const e2eTempDir = path.join(repoRoot, '.e2e-tmp');
 const maxBatchConcurrency = Math.max(1, availableParallelism());
 
-function resolveServerConcurrency() {
-	const configured = Number(process.env.ECOPAGES_E2E_SERVER_CONCURRENCY);
+function resolveBatchConcurrency(envName, fallback) {
+	const configured = Number(process.env[envName]);
 	if (Number.isInteger(configured) && configured > 0) {
-		return configured;
+		return Math.min(configured, maxBatchConcurrency);
 	}
 
-	return Math.max(1, Math.min(maxBatchConcurrency, Math.floor(maxBatchConcurrency / 2) || 1));
+	return Math.min(fallback, maxBatchConcurrency);
+}
+
+function resolveServerConcurrency() {
+	return resolveBatchConcurrency('ECOPAGES_E2E_SERVER_CONCURRENCY', maxBatchConcurrency);
 }
 
 const maxServerConcurrency = resolveServerConcurrency();
 const kitchenSinkPreviewConcurrency = maxServerConcurrency;
-const kitchenSinkDevConcurrency = Math.max(
-	1,
-	Math.min(
-		Number(process.env.ECOPAGES_E2E_DEV_CONCURRENCY) > 0 ? Number(process.env.ECOPAGES_E2E_DEV_CONCURRENCY) : 1,
-		maxServerConcurrency,
-	),
+const kitchenSinkDevConcurrency = resolveBatchConcurrency(
+	'ECOPAGES_E2E_DEV_CONCURRENCY',
+	Math.min(2, maxServerConcurrency),
 );
-const kitchenSinkHmrConcurrency = 1;
+const kitchenSinkHmrConcurrency = resolveBatchConcurrency('ECOPAGES_E2E_HMR_CONCURRENCY', 1);
 const e2eTimingEnabled = process.env.ECOPAGES_E2E_TIMING === 'true';
 const e2eTimingEntries = [];
 

--- a/e2e/scripts/playwright/run-e2e.test.ts
+++ b/e2e/scripts/playwright/run-e2e.test.ts
@@ -128,8 +128,13 @@ describe('run-e2e wrapper planning', () => {
 		}
 	});
 
-	it('defaults kitchen-sink dev concurrency to one shared-workspace server at a time', () => {
-		expect(kitchenSinkCapabilityGroups[1]?.concurrency).toBe(1);
+	it('defaults kitchen-sink dev batch concurrency to min(2, server cap)', () => {
+		expect(kitchenSinkCapabilityGroups[1]?.concurrency).toBeLessThanOrEqual(2);
+		expect(kitchenSinkCapabilityGroups[1]?.concurrency).toBeGreaterThan(0);
+	});
+
+	it('keeps kitchen-sink hmr batch concurrency serial by default', () => {
+		expect(kitchenSinkCapabilityGroups[2]?.concurrency).toBe(1);
 	});
 
 	it('maps each kitchen-sink HMR project to a unique workspace while sharing read-only workspaces', () => {


### PR DESCRIPTION
## Summary
- Raise kitchen-sink **preview** batch concurrency default from `floor(N/2)` to `availableParallelism()`
- Raise kitchen-sink **dev** batch concurrency default from `1` to `min(2, availableParallelism())`
- Keep **HMR** batch concurrency at `1` — parallel HMR server boot hit 180s webServer timeouts
- Add shared `resolveBatchConcurrency()` helper and document `ECOPAGES_E2E_HMR_CONCURRENCY`

In-project Playwright workers stay unchanged: dev/HMR remain `workers: 1` per e2e plan.

## What we tried
| Change | Result |
|--------|--------|
| Preview cap = N | OK (unchanged behavior, higher cap on multi-core) |
| Dev batch = N (4 parallel servers) | Failed — vite dev servers timed out |
| Dev batch = 2 | OK — all @content tests passed |
| HMR batch = N | Failed — 3/4 webServer boot timeouts |
| HMR batch = 1 | OK |

## Test plan
- [x] `pnpm exec vitest run --project shared-core e2e/scripts/playwright/run-e2e.test.ts`
- [x] `pnpm test:e2e:smoke` (@stress)
- [x] `node e2e/scripts/playwright/run-e2e.mjs --kitchen-sink-only --grep @content`
- [x] `node e2e/scripts/playwright/run-e2e.mjs --kitchen-sink-only --grep @hmr`

## Dependencies
None — independent of simplification PRs.