### PR TITLE
test(e2e): speed up include HMR specs

### DIFF
--- a/playground/kitchen-sink/e2e/includes-hmr.test.e2e.ts
+++ b/playground/kitchen-sink/e2e/includes-hmr.test.e2e.ts
@@ -6,8 +6,7 @@ import {
 	createHmrPhaseTimer,
 	startEcopagesHmrConnectionWatch,
 	installFullDocumentReloadWatcher,
-	assertNoMainFrameNavigation,
-	watchForMainFrameNavigation,
+	assertNoMainFrameNavigationAfterHmr,
 	gotoPath,
 	trackRuntimeErrors,
 } from './test-support';
@@ -16,6 +15,8 @@ const SEO_INCLUDE_FILE = fileURLToPath(new URL('../src/includes/seo.kita.tsx', i
 const EXPLICIT_TEAM_VIEW_FILE = fileURLToPath(new URL('../src/views/explicit-team-view.kita.tsx', import.meta.url));
 const SEO_SUFFIX = '[include-hmr]';
 const EXPLICIT_TEAM_SUFFIX = '[explicit-route-hmr]';
+const INCLUDE_HMR_TIMEOUT_MS = 8_000;
+const VIEW_HMR_TIMEOUT_MS = 5_000;
 
 function getSeoIncludeFile(projectMetadata: Record<string, unknown> | undefined) {
 	const isolatedAppDir = typeof projectMetadata?.isolatedAppDir === 'string' ? projectMetadata.isolatedAppDir : null;
@@ -81,29 +82,15 @@ test.describe('Source mutation HMR @hmr', () => {
 		timer.mark('navigation-ready');
 		await hmrReady;
 		timer.mark('hmr-connected');
-		const titleReadyTimeout = testInfo.project.name.includes('vite') ? 45_000 : 10_000;
-		let initialTitle = '';
-		await expect
-			.poll(
-				async () => {
-					const title = await page.title();
-					if (title.length > 0 && !title.startsWith('Loading ')) {
-						initialTitle = title;
-						return true;
-					}
-
-					return false;
-				},
-				{ timeout: titleReadyTimeout },
-			)
-			.toBe(true);
-		const navigationWatch = watchForMainFrameNavigation(page);
+		await expect(page.getByTestId('page-docs')).toBeVisible();
+		const initialTitle = await page.title();
+		expect(initialTitle.length).toBeGreaterThan(0);
 
 		fs.writeFileSync(seoIncludeFile, patchSeoTitle(originalSeoInclude, SEO_SUFFIX), 'utf-8');
 		timer.mark('mutation-applied');
-		await expect(page).toHaveTitle(`${initialTitle} ${SEO_SUFFIX}`, { timeout: 10_000 });
+		await expect(page).toHaveTitle(`${initialTitle} ${SEO_SUFFIX}`, { timeout: INCLUDE_HMR_TIMEOUT_MS });
 		timer.mark('title-updated');
-		await assertNoMainFrameNavigation(navigationWatch);
+		await assertNoMainFrameNavigationAfterHmr(page);
 
 		runtime.assertClean();
 	});
@@ -120,7 +107,6 @@ test.describe('Source mutation HMR @hmr', () => {
 		timer.mark('hmr-connected');
 		await expect(page.getByRole('heading', { name: 'Explicit routes can still feel native.' })).toBeVisible();
 
-		const navigationWatch = watchForMainFrameNavigation(page);
 		fs.writeFileSync(
 			explicitTeamViewFile,
 			patchExplicitRouteHeading(originalExplicitTeamView, EXPLICIT_TEAM_SUFFIX),
@@ -129,9 +115,9 @@ test.describe('Source mutation HMR @hmr', () => {
 		timer.mark('mutation-applied');
 		await expect(
 			page.getByRole('heading', { name: `Explicit routes can still feel native. ${EXPLICIT_TEAM_SUFFIX}` }),
-		).toBeVisible({ timeout: 10_000 });
+		).toBeVisible({ timeout: VIEW_HMR_TIMEOUT_MS });
 		timer.mark('heading-updated');
-		await assertNoMainFrameNavigation(navigationWatch);
+		await assertNoMainFrameNavigationAfterHmr(page);
 
 		runtime.assertClean();
 	});

--- a/playground/kitchen-sink/e2e/test-support.ts
+++ b/playground/kitchen-sink/e2e/test-support.ts
@@ -262,22 +262,20 @@ export function createHmrPhaseTimer(testName: string) {
 }
 
 /** Installs a reload detector before navigation so it survives document replacements. */
-export async function installFullDocumentReloadWatcher(page: Page, timeout = 10_000) {
-	await page.addInitScript((timeoutMs) => {
+export async function installFullDocumentReloadWatcher(page: Page) {
+	await page.addInitScript(() => {
 		const state = { detected: false, done: false };
 		(window as EcoNavigationWindow & { __ecopagesReloadWatch?: typeof state }).__ecopagesReloadWatch = state;
 		const initialNavigationCount = performance.getEntriesByType('navigation').length;
-		const startedAt = performance.now();
 
 		const poll = () => {
-			const entries = performance.getEntriesByType('navigation');
-			if (entries.slice(initialNavigationCount).some((entry) => entry.type === 'reload')) {
-				state.detected = true;
-				state.done = true;
+			if (state.done) {
 				return;
 			}
 
-			if (performance.now() - startedAt >= timeoutMs) {
+			const entries = performance.getEntriesByType('navigation');
+			if (entries.slice(initialNavigationCount).some((entry) => entry.type === 'reload')) {
+				state.detected = true;
 				state.done = true;
 				return;
 			}
@@ -286,10 +284,56 @@ export async function installFullDocumentReloadWatcher(page: Page, timeout = 10_
 		};
 
 		poll();
-	}, timeout);
+	});
 }
 
-/** Tracks whether the main document performs a full reload during an HMR update. */
+/** Ends reload observation early and returns whether a full document reload was detected. */
+export async function finalizeMainFrameNavigationWatch(page: Page): Promise<boolean> {
+	return page.evaluate(() => {
+		const state = (
+			window as EcoNavigationWindow & {
+				__ecopagesReloadWatch?: { detected?: boolean; done?: boolean };
+			}
+		).__ecopagesReloadWatch;
+
+		if (state) {
+			state.done = true;
+		}
+
+		return state?.detected === true;
+	});
+}
+
+/**
+ * Asserts HMR refreshed in-place without a full reload.
+ *
+ * Finalizes the reload watcher immediately after the content assertion instead of
+ * waiting for the legacy 10s observation window to expire.
+ */
+export async function assertNoMainFrameNavigationAfterHmr(page: Page, settleMs = 250) {
+	await expect
+		.poll(
+			async () =>
+				page.evaluate(() => {
+					const state = (
+						window as EcoNavigationWindow & {
+							__ecopagesReloadWatch?: { detected?: boolean };
+						}
+					).__ecopagesReloadWatch;
+					return state?.detected === true;
+				}),
+			{
+				timeout: settleMs,
+				intervals: [25, 50, 100],
+			},
+		)
+		.toBe(false);
+
+	const reloaded = await finalizeMainFrameNavigationWatch(page);
+	expect(reloaded, 'expected current-page refresh without a full document reload').toBe(false);
+}
+
+/** @deprecated Prefer {@link assertNoMainFrameNavigationAfterHmr} — this waits until the reload watch times out when no reload occurs. */
 export function watchForMainFrameNavigation(page: Page, timeout = 10_000) {
 	return page
 		.waitForFunction(


### PR DESCRIPTION
## Summary
- Fix ~10s per-test waste: `watchForMainFrameNavigation` waited for the reload watcher's 10s timeout even when HMR succeeded without a full reload
- Add `assertNoMainFrameNavigationAfterHmr()` to finalize the reload watch right after the content assertion (~250ms settle)
- Simplify include test setup: wait for `page-docs` test id instead of a long title poll (removed vite-specific 45s poll path)
- Keep realistic HMR assertion timeouts (8s include title, 5s explicit route heading)

## Before / after (per test, all 4 HMR hosts)
| Host | Before | After |
|------|--------|-------|
| bun-hmr | ~12–18s | ~4.5–5.5s |
| node-hmr | ~12–15s | ~4.7–5.1s |
| vite-*-hmr | ~12–15s | ~4.6–6.3s |

## Test plan
- [x] `node e2e/scripts/playwright/run-e2e.mjs --kitchen-sink-only --grep @hmr` (8/8 passed)

## Dependencies
None.