### PR TITLE
perf(build): coalesce in-flight identical Rolldown builds

### DIFF
--- a/packages/core/src/build/build-runtime.test.ts
+++ b/packages/core/src/build/build-runtime.test.ts
@@ -4,6 +4,7 @@ import type { EcoPagesAppConfig } from '../types/internal-types.ts';
 import { createAppBuildManifest } from './build-manifest.ts';
 import { RolldownBuildAdapter } from './rolldown-build-adapter.ts';
 import { installBuildRuntime, requireBuildRuntime } from './build-runtime.ts';
+import { DedupingBuildExecutor } from './deduping-build-executor.ts';
 import { ParallelBuildExecutor } from './parallel-build-executor.ts';
 import { SerializedBuildExecutor } from './serialized-build-executor.ts';
 import { setAppBuildAdapter, setAppBuildManifest } from './build-adapter.ts';
@@ -30,8 +31,11 @@ test('installBuildRuntime uses parallel executors for route-module and browser-h
 
 	const buildRuntime = installBuildRuntime(appConfig);
 
-	assert.ok(buildRuntime.getProfile('route-module') instanceof ParallelBuildExecutor);
-	assert.ok(buildRuntime.getProfile('browser-hmr') instanceof ParallelBuildExecutor);
+	assert.ok(buildRuntime.getProfile('route-module') instanceof DedupingBuildExecutor);
+	assert.ok(buildRuntime.getProfile('browser-hmr') instanceof DedupingBuildExecutor);
+	assert.ok(
+		(buildRuntime.getProfile('route-module') as DedupingBuildExecutor).unwrap() instanceof ParallelBuildExecutor,
+	);
 	assert.ok(buildRuntime.getProfile('server-entry') instanceof SerializedBuildExecutor);
 	assert.notEqual(
 		buildRuntime.getProfile('route-module'),
@@ -46,5 +50,5 @@ test('requireBuildRuntime installs the runtime when missing', () => {
 	const buildRuntime = requireBuildRuntime(appConfig);
 
 	assert.equal(appConfig.runtime?.buildRuntime, buildRuntime);
-	assert.ok(buildRuntime.getProfile('route-module') instanceof ParallelBuildExecutor);
+	assert.ok(buildRuntime.getProfile('route-module') instanceof DedupingBuildExecutor);
 });

--- a/packages/core/src/build/build-runtime.ts
+++ b/packages/core/src/build/build-runtime.ts
@@ -8,6 +8,7 @@ import {
 	type BuildExecutor,
 } from './build-adapter.ts';
 import { ParallelBuildExecutor } from './parallel-build-executor.ts';
+import { DedupingBuildExecutor } from './deduping-build-executor.ts';
 import { SerializedBuildExecutor } from './serialized-build-executor.ts';
 
 export type BuildProfile = 'server-entry' | 'route-module' | 'browser-hmr';
@@ -43,8 +44,8 @@ class AppBuildRuntime implements BuildRuntime {
 		const limit = resolveParallelismLimit();
 
 		this.serverEntryExecutor = new SerializedBuildExecutor(serverPlugins);
-		this.routeModuleExecutor = new ParallelBuildExecutor(serverPlugins, limit);
-		this.hmrExecutor = new ParallelBuildExecutor(browserPlugins, Math.min(3, limit));
+		this.routeModuleExecutor = new DedupingBuildExecutor(new ParallelBuildExecutor(serverPlugins, limit));
+		this.hmrExecutor = new DedupingBuildExecutor(new ParallelBuildExecutor(browserPlugins, Math.min(3, limit)));
 	}
 
 	getProfile(profile: BuildProfile): BuildExecutor {

--- a/packages/core/src/build/deduping-build-executor.test.ts
+++ b/packages/core/src/build/deduping-build-executor.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import type { BuildExecutor, BuildOptions, BuildResult } from './build-adapter.ts';
+import { createBuildOptionsDedupeKey, DedupingBuildExecutor } from './deduping-build-executor.ts';
+
+const buildOptions: BuildOptions = {
+	entrypoints: ['/in/a.ts'],
+	root: '/in',
+	outdir: '/out',
+	target: 'browser',
+	format: 'esm',
+	sourcemap: 'none',
+};
+
+test('createBuildOptionsDedupeKey treats entrypoint order as equivalent', () => {
+	const keyA = createBuildOptionsDedupeKey({
+		...buildOptions,
+		entrypoints: ['/in/a.ts', '/in/b.ts'],
+	});
+	const keyB = createBuildOptionsDedupeKey({
+		...buildOptions,
+		entrypoints: ['/in/b.ts', '/in/a.ts'],
+	});
+
+	assert.equal(keyA, keyB);
+});
+
+test('DedupingBuildExecutor coalesces concurrent identical builds', async () => {
+	let innerBuildCount = 0;
+	const inner: BuildExecutor = {
+		async build(): Promise<BuildResult> {
+			innerBuildCount += 1;
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			return { success: true, logs: [], outputs: [] };
+		},
+	};
+	const deduping = new DedupingBuildExecutor(inner);
+
+	await Promise.all([deduping.build(buildOptions), deduping.build(buildOptions), deduping.build(buildOptions)]);
+
+	assert.equal(innerBuildCount, 1);
+	assert.equal(deduping.getInFlightCountForTests(), 0);
+});
+
+test('DedupingBuildExecutor does not coalesce different build options', async () => {
+	let innerBuildCount = 0;
+	const inner: BuildExecutor = {
+		async build(): Promise<BuildResult> {
+			innerBuildCount += 1;
+			return { success: true, logs: [], outputs: [] };
+		},
+	};
+	const deduping = new DedupingBuildExecutor(inner);
+
+	await Promise.all([
+		deduping.build(buildOptions),
+		deduping.build({ ...buildOptions, outdir: '/other-out' }),
+	]);
+
+	assert.equal(innerBuildCount, 2);
+});
+
+test('DedupingBuildExecutor releases in-flight entry after failure', async () => {
+	let innerBuildCount = 0;
+	const inner: BuildExecutor = {
+		async build(): Promise<BuildResult> {
+			innerBuildCount += 1;
+			if (innerBuildCount === 1) {
+				throw new Error('synthetic build failure');
+			}
+
+			return { success: true, logs: [], outputs: [] };
+		},
+	};
+	const deduping = new DedupingBuildExecutor(inner);
+
+	await assert.rejects(() => deduping.build(buildOptions), /synthetic build failure/);
+	const followUp = await deduping.build(buildOptions);
+	assert.equal(followUp.success, true);
+	assert.equal(innerBuildCount, 2);
+});
+
+test('DedupingBuildExecutor returns the inner executor via unwrap', () => {
+	const inner: BuildExecutor = {
+		async build(): Promise<BuildResult> {
+			return { success: true, logs: [], outputs: [] };
+		},
+	};
+
+	assert.equal(new DedupingBuildExecutor(inner).unwrap(), inner);
+});

--- a/packages/core/src/build/deduping-build-executor.ts
+++ b/packages/core/src/build/deduping-build-executor.ts
@@ -5,7 +5,13 @@ import {
 	createPluginCacheKey,
 } from '../services/module-loading/route-module-build-manifest.ts';
 
-/** Stable cache key for coalescing concurrent identical build requests. */
+/**
+ * Stable cache key for coalescing concurrent identical build requests.
+ *
+ * @remarks
+ * Reuses the same material as route-module disk cache keys: normalized entrypoints,
+ * outdir, splitting, JSX, and plugin setup fingerprints.
+ */
 export function createBuildOptionsDedupeKey(options: BuildOptions): string {
 	return [
 		normalizeEntrypoints(options.entrypoints),
@@ -36,7 +42,15 @@ function normalizeEntrypoints(entrypoints: BuildOptions['entrypoints']): string 
 }
 
 /**
- * Coalesces concurrent builds with identical options into one in-flight promise.
+ * In-flight build coalescing wrapper.
+ *
+ * @remarks
+ * `ParallelBuildExecutor` allows concurrent builds but does not dedupe identical
+ * options. Multiple callers (route import, browser bundles, HMR) can hit the
+ * same Rolldown request before disk or import caches warm. This wrapper shares
+ * one inner `build()` promise per dedupe key until it settles.
+ *
+ * Wrap route-module and browser-hmr profiles only; server-entry stays serialized.
  */
 export class DedupingBuildExecutor implements BuildExecutor {
 	private readonly inner: BuildExecutor;

--- a/packages/core/src/build/deduping-build-executor.ts
+++ b/packages/core/src/build/deduping-build-executor.ts
@@ -1,0 +1,73 @@
+import path from 'node:path';
+import type { BuildExecutor, BuildOptions, BuildResult } from './build-adapter.ts';
+import {
+	createJsxCacheKey,
+	createPluginCacheKey,
+} from '../services/module-loading/route-module-build-manifest.ts';
+
+/** Stable cache key for coalescing concurrent identical build requests. */
+export function createBuildOptionsDedupeKey(options: BuildOptions): string {
+	return [
+		normalizeEntrypoints(options.entrypoints),
+		options.root ? path.resolve(options.root) : 'root:default',
+		options.outdir ? path.resolve(options.outdir) : 'outdir:default',
+		options.splitting ?? 'splitting:default',
+		options.externalPackages ?? 'externalPackages:default',
+		options.target ?? 'target:default',
+		options.format ?? 'format:default',
+		options.sourcemap ?? 'sourcemap:default',
+		options.minify ?? 'minify:default',
+		options.treeshaking ?? 'treeshaking:default',
+		options.naming ?? 'naming:default',
+		createJsxCacheKey(options.jsx),
+		createPluginCacheKey(options.plugins),
+	].join('::');
+}
+
+function normalizeEntrypoints(entrypoints: BuildOptions['entrypoints']): string {
+	if (Array.isArray(entrypoints)) {
+		return entrypoints.map((entrypoint) => path.resolve(entrypoint)).sort().join('|');
+	}
+
+	return Object.entries(entrypoints)
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([key, value]) => `${key}:${path.resolve(value)}`)
+		.join('|');
+}
+
+/**
+ * Coalesces concurrent builds with identical options into one in-flight promise.
+ */
+export class DedupingBuildExecutor implements BuildExecutor {
+	private readonly inner: BuildExecutor;
+	private readonly inFlight = new Map<string, Promise<BuildResult>>();
+
+	constructor(inner: BuildExecutor) {
+		this.inner = inner;
+	}
+
+	build(options: BuildOptions): Promise<BuildResult> {
+		const key = createBuildOptionsDedupeKey(options);
+		const existing = this.inFlight.get(key);
+		if (existing) {
+			return existing;
+		}
+
+		const buildPromise = this.inner.build(options).finally(() => {
+			if (this.inFlight.get(key) === buildPromise) {
+				this.inFlight.delete(key);
+			}
+		});
+
+		this.inFlight.set(key, buildPromise);
+		return buildPromise;
+	}
+
+	unwrap(): BuildExecutor {
+		return this.inner;
+	}
+
+	getInFlightCountForTests(): number {
+		return this.inFlight.size;
+	}
+}

--- a/packages/core/src/build/runtime-build-executor.test.ts
+++ b/packages/core/src/build/runtime-build-executor.test.ts
@@ -7,6 +7,7 @@ import {
 	ViteHostBuildAdapter,
 } from './build-adapter.ts';
 import { getBuildRuntime, requireBuildRuntime } from './build-runtime.ts';
+import { DedupingBuildExecutor } from './deduping-build-executor.ts';
 import { ParallelBuildExecutor } from './parallel-build-executor.ts';
 import { RolldownBuildAdapter } from './rolldown-build-adapter.ts';
 import { SerializedBuildExecutor } from './serialized-build-executor.ts';
@@ -35,7 +36,8 @@ test('installAppRuntimeBuildExecutor wraps the active adapter in a ParallelBuild
 	const executor = installAppRuntimeBuildExecutor(appConfig);
 
 	assert.notEqual(executor, staleExecutor);
-	assert.ok(executor instanceof ParallelBuildExecutor, 'wraps the executor in a parallel route-module layer');
+	assert.ok(executor instanceof DedupingBuildExecutor, 'wraps the executor in a deduping route-module layer');
+	assert.ok(executor.unwrap() instanceof ParallelBuildExecutor, 'deduping layer wraps a parallel executor');
 });
 
 test('installAppRuntimeBuildExecutor rejects when the app-owned adapter is a Vite-host boundary', async () => {
@@ -134,8 +136,10 @@ test('installAppRuntimeBuildExecutor installs separate executors for route modul
 	const routeExecutor = buildRuntime.getProfile('route-module');
 	const hmrExecutor = buildRuntime.getProfile('browser-hmr');
 
-	assert.ok(routeExecutor instanceof ParallelBuildExecutor);
-	assert.ok(hmrExecutor instanceof ParallelBuildExecutor);
+	assert.ok(routeExecutor instanceof DedupingBuildExecutor);
+	assert.ok(hmrExecutor instanceof DedupingBuildExecutor);
+	assert.ok(routeExecutor.unwrap() instanceof ParallelBuildExecutor);
+	assert.ok(hmrExecutor.unwrap() instanceof ParallelBuildExecutor);
 	assert.notEqual(routeExecutor, hmrExecutor);
 });
 


### PR DESCRIPTION
## Summary
- Add `DedupingBuildExecutor` to coalesce concurrent builds with identical options
- Wrap route-module and browser-hmr profiles in deduping layer over existing parallel executors

## Test plan
- [x] `vitest run packages/core/src/build/deduping-build-executor.test.ts`
- [x] `vitest run packages/core/src/build/build-runtime.test.ts`
- [x] `vitest run packages/core/src/build/runtime-build-executor.test.ts`

## Dependencies
None.