### PR TITLE
refactor(route-renderer): unify component graph and parallelize route prep

### DIFF
--- a/packages/core/src/route-renderer/orchestration/component-graph-collectors.test.ts
+++ b/packages/core/src/route-renderer/orchestration/component-graph-collectors.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import type { EcoComponent, ResolvedLazyTrigger } from '../../types/public-types.ts';
+import { mapComponentGraph } from './component-graph.ts';
+import {
+	collectIntegrationNamesFromGraph,
+	collectResolvedLazyTriggersFromGraph,
+	hasForeignChildDescendantsInGraph,
+} from './component-graph-collectors.ts';
+
+function createComponent(input: {
+	integration?: string;
+	triggers?: ResolvedLazyTrigger[];
+	children?: EcoComponent[];
+}): EcoComponent {
+	return {
+		config: {
+			integration: input.integration,
+			_resolvedLazyTriggers: input.triggers,
+			dependencies: {
+				components: input.children ?? [],
+			},
+		},
+	} as EcoComponent;
+}
+
+test('collectIntegrationNamesFromGraph walks nested dependency components', () => {
+	const root = createComponent({
+		integration: 'react',
+		children: [createComponent({ integration: 'lit' })],
+	});
+
+	const names = collectIntegrationNamesFromGraph([root], 'react');
+	assert.deepEqual([...names].sort(), ['lit', 'react']);
+});
+
+test('collectResolvedLazyTriggersFromGraph collects triggers from nested components', () => {
+	const trigger = { id: 'lazy-a' } as ResolvedLazyTrigger;
+	const root = createComponent({
+		children: [createComponent({ triggers: [trigger] })],
+	});
+
+	const triggers = collectResolvedLazyTriggersFromGraph([root], 'react');
+	assert.equal(triggers.length, 1);
+	assert.equal(triggers[0], trigger);
+});
+
+test('hasForeignChildDescendantsInGraph detects foreign integration descendants', () => {
+	const sameIntegration = createComponent({
+		integration: 'react',
+		children: [createComponent({ integration: 'react' })],
+	});
+	const foreignChild = createComponent({
+		integration: 'react',
+		children: [createComponent({ integration: 'lit' })],
+	});
+
+	assert.equal(hasForeignChildDescendantsInGraph(sameIntegration, 'react'), false);
+	assert.equal(hasForeignChildDescendantsInGraph(foreignChild, 'react'), true);
+});
+
+test('mapComponentGraph preserves declared ownership mapping semantics', () => {
+	const root = createComponent({
+		integration: 'react',
+		children: [createComponent({ integration: 'lit' })],
+	});
+
+	const nodes = mapComponentGraph({
+		currentIntegrationName: 'react',
+		roots: [{ component: root, source: 'page' }],
+		mapNode: (node) => node.integrationName,
+	});
+
+	assert.deepEqual(nodes, ['react']);
+});

--- a/packages/core/src/route-renderer/orchestration/component-graph-collectors.ts
+++ b/packages/core/src/route-renderer/orchestration/component-graph-collectors.ts
@@ -1,0 +1,151 @@
+import path from 'node:path';
+import type {
+	DependencyAttributes,
+	EcoComponent,
+	EcoComponentConfig,
+	ResolvedLazyTrigger,
+} from '../../types/public-types.ts';
+import type { AssetDefinition } from '../../services/assets/asset-processing-service/index.ts';
+import { AssetFactory } from '../../services/assets/asset-processing-service/index.ts';
+import { walkComponentGraph, type ComponentGraphRoot } from './component-graph.ts';
+
+function toGraphRoots(components: (EcoComponent | Partial<EcoComponent>)[]): ComponentGraphRoot[] {
+	return components.filter(Boolean).map((component) => ({ component }));
+}
+
+export function collectIntegrationNamesFromGraph(
+	components: (EcoComponent | Partial<EcoComponent>)[],
+	currentIntegrationName: string,
+): Set<string> {
+	const integrationNames = new Set<string>();
+
+	walkComponentGraph({
+		roots: toGraphRoots(components),
+		currentIntegrationName,
+		onComponent: ({ component }) => {
+			const integrationName = component.config?.integration ?? component.config?.__eco?.integration;
+			if (integrationName) {
+				integrationNames.add(integrationName);
+			}
+		},
+	});
+
+	return integrationNames;
+}
+
+export function collectResolvedLazyTriggersFromGraph(
+	components: (EcoComponent | Partial<EcoComponent>)[],
+	currentIntegrationName: string,
+): ResolvedLazyTrigger[] {
+	const triggers: ResolvedLazyTrigger[] = [];
+
+	walkComponentGraph({
+		roots: toGraphRoots(components),
+		currentIntegrationName,
+		onComponent: ({ component }) => {
+			const ownTriggers = component.config?._resolvedLazyTriggers;
+			if (ownTriggers?.length) {
+				triggers.push(...ownTriggers);
+			}
+		},
+	});
+
+	return triggers;
+}
+
+export function hasForeignChildDescendantsInGraph(component: EcoComponent, currentIntegrationName: string): boolean {
+	let foundForeign = false;
+
+	walkComponentGraph({
+		roots: [{ component }],
+		currentIntegrationName,
+		onComponent: ({ component: currentComponent }) => {
+			if (foundForeign) {
+				return false;
+			}
+
+			const integrationName =
+				currentComponent.config?.integration ?? currentComponent.config?.__eco?.integration;
+			if (integrationName && integrationName !== currentIntegrationName) {
+				foundForeign = true;
+				return false;
+			}
+		},
+	});
+
+	return foundForeign;
+}
+
+export function collectEagerSsrLazyScriptDefinitions(
+	components: (EcoComponent | Partial<EcoComponent>)[],
+): AssetDefinition[] {
+	const dependencies: AssetDefinition[] = [];
+	const seenKeys = new Set<string>();
+
+	const normalizeAttributes = (attributes?: DependencyAttributes) => ({
+		type: 'module',
+		defer: '',
+		...(attributes ?? {}),
+	});
+
+	walkComponentGraph({
+		roots: toGraphRoots(components),
+		currentIntegrationName: '',
+		visitLayout: true,
+		onConfig: (config) => {
+			const componentFile = config?.__eco?.file;
+			if (!componentFile) {
+				return;
+			}
+
+			const componentDir = path.dirname(componentFile);
+			for (const script of config.dependencies?.scripts ?? []) {
+				if (typeof script === 'string' || !script.lazy || script.ssr !== true) {
+					continue;
+				}
+
+				const attributes = normalizeAttributes(script.attributes);
+
+				if (script.content) {
+					const key = `content:${script.content}:${JSON.stringify(attributes)}`;
+					if (seenKeys.has(key)) {
+						continue;
+					}
+
+					seenKeys.add(key);
+					dependencies.push(
+						AssetFactory.createContentScript({
+							position: 'head',
+							content: script.content,
+							attributes,
+							packageRole: 'dynamic-chunk',
+						}),
+					);
+					continue;
+				}
+
+				if (!script.src) {
+					continue;
+				}
+
+				const resolvedPath = path.resolve(componentDir, script.src);
+				const key = `file:${resolvedPath}:${JSON.stringify(attributes)}`;
+				if (seenKeys.has(key)) {
+					continue;
+				}
+
+				seenKeys.add(key);
+				dependencies.push(
+					AssetFactory.createFileScript({
+						filepath: resolvedPath,
+						position: 'head',
+						attributes,
+						packageRole: 'dynamic-chunk',
+					}),
+				);
+			}
+		},
+	});
+
+	return dependencies;
+}

--- a/packages/core/src/route-renderer/orchestration/component-graph.ts
+++ b/packages/core/src/route-renderer/orchestration/component-graph.ts
@@ -1,0 +1,154 @@
+import type { EcoComponent, OwnershipPlanNodeSource } from '../../types/public-types.ts';
+
+export type DeclaredOwnershipRoot = {
+	component: EcoComponent;
+	source: Extract<OwnershipPlanNodeSource, 'page' | 'layout' | 'html-template'>;
+};
+
+export type DeclaredOwnershipNodeInput = {
+	component: EcoComponent;
+	source: Exclude<OwnershipPlanNodeSource, 'route'>;
+	parentIntegrationName: string;
+	integrationName: string;
+	componentId: string;
+	isForeignToParent: boolean;
+};
+
+export type ComponentGraphRoot = {
+	component: EcoComponent | Partial<EcoComponent>;
+	source?: Exclude<OwnershipPlanNodeSource, 'route'>;
+};
+
+export type ComponentGraphWalkInput = {
+	component: EcoComponent;
+	parentIntegrationName: string;
+	source?: Exclude<OwnershipPlanNodeSource, 'route'>;
+};
+
+export function walkComponentGraph(input: {
+	roots: ComponentGraphRoot[];
+	currentIntegrationName: string;
+	visitLayout?: boolean;
+	onComponent?: (node: ComponentGraphWalkInput) => void | boolean;
+	onConfig?: (config: EcoComponent['config']) => void;
+}): void {
+	const seenComponents = new Set<object>();
+	const seenConfigs = new Set<object>();
+
+	const visitComponent = (
+		component: EcoComponent | Partial<EcoComponent>,
+		parentIntegrationName: string,
+		source?: Exclude<OwnershipPlanNodeSource, 'route'>,
+	): void => {
+		if (!component) {
+			return;
+		}
+
+		const ecoComponent = component as EcoComponent;
+		if (seenComponents.has(ecoComponent)) {
+			return;
+		}
+
+		seenComponents.add(ecoComponent);
+		const integrationName =
+			ecoComponent.config?.integration ?? ecoComponent.config?.__eco?.integration ?? parentIntegrationName;
+
+		if (input.onConfig && ecoComponent.config && !seenConfigs.has(ecoComponent.config)) {
+			seenConfigs.add(ecoComponent.config);
+			input.onConfig(ecoComponent.config);
+		}
+
+		if (input.onComponent) {
+			const shouldContinue = input.onComponent({
+				component: ecoComponent,
+				parentIntegrationName,
+				source,
+			});
+			if (shouldContinue === false) {
+				return;
+			}
+		}
+
+		if (input.visitLayout && ecoComponent.config?.layout?.config) {
+			visitConfig(ecoComponent.config.layout.config, integrationName);
+		}
+
+		for (const child of ecoComponent.config?.dependencies?.components ?? []) {
+			visitComponent(child, integrationName, 'dependency');
+		}
+	};
+
+	const visitConfig = (config: EcoComponent['config'], parentIntegrationName: string): void => {
+		if (!config || seenConfigs.has(config)) {
+			return;
+		}
+
+		seenConfigs.add(config);
+
+		if (input.onConfig) {
+			input.onConfig(config);
+		}
+
+		if (input.visitLayout && config.layout?.config) {
+			visitConfig(config.layout.config, parentIntegrationName);
+		}
+
+		for (const child of config.dependencies?.components ?? []) {
+			visitComponent(child, parentIntegrationName, 'dependency');
+		}
+	};
+
+	for (const root of input.roots) {
+		visitComponent(root.component, input.currentIntegrationName, root.source);
+	}
+}
+
+export function mapComponentGraph<T>(input: {
+	roots: DeclaredOwnershipRoot[];
+	currentIntegrationName: string;
+	mapNode: (node: DeclaredOwnershipNodeInput, children: T[]) => T;
+}): T[] {
+	let nextSyntheticId = 0;
+
+	const mapComponent = (
+		component: EcoComponent,
+		source: Exclude<OwnershipPlanNodeSource, 'route'>,
+		parentIntegrationName: string,
+		lineage: Set<object>,
+	): T => {
+		const integrationName =
+			component.config?.integration ?? component.config?.__eco?.integration ?? parentIntegrationName;
+		const componentMeta = component.config?.__eco;
+		const isForeignToParent = integrationName !== parentIntegrationName;
+		const componentId = componentMeta?.id ?? componentMeta?.file ?? `${source}:${(nextSyntheticId += 1)}`;
+
+		const nextLineage = new Set(lineage);
+		nextLineage.add(component);
+		const children = (component.config?.dependencies?.components ?? []).flatMap((child) => {
+			if (!child || nextLineage.has(child)) {
+				return [];
+			}
+
+			return [mapComponent(child, 'dependency', integrationName, nextLineage)];
+		});
+
+		return input.mapNode(
+			{
+				component,
+				source,
+				parentIntegrationName,
+				integrationName,
+				componentId,
+				isForeignToParent,
+			},
+			children,
+		);
+	};
+
+	return input.roots.map(({ component, source }) =>
+		mapComponent(component, source, input.currentIntegrationName, new Set()),
+	);
+}
+
+/** @deprecated Use `mapComponentGraph` from `component-graph.ts`. */
+export const mapDeclaredOwnershipGraph = mapComponentGraph;

--- a/packages/core/src/route-renderer/orchestration/declared-ownership-graph.ts
+++ b/packages/core/src/route-renderer/orchestration/declared-ownership-graph.ts
@@ -1,62 +1,8 @@
-import type { EcoComponent, OwnershipPlanNodeSource } from '../../types/public-types.ts';
-
-export type DeclaredOwnershipRoot = {
-	component: EcoComponent;
-	source: Extract<OwnershipPlanNodeSource, 'page' | 'layout' | 'html-template'>;
-};
-
-export type DeclaredOwnershipNodeInput = {
-	component: EcoComponent;
-	source: Exclude<OwnershipPlanNodeSource, 'route'>;
-	parentIntegrationName: string;
-	integrationName: string;
-	componentId: string;
-	isForeignToParent: boolean;
-};
-
-export function mapDeclaredOwnershipGraph<T>(input: {
-	roots: DeclaredOwnershipRoot[];
-	currentIntegrationName: string;
-	mapNode: (node: DeclaredOwnershipNodeInput, children: T[]) => T;
-}): T[] {
-	let nextSyntheticId = 0;
-
-	const mapComponent = (
-		component: EcoComponent,
-		source: Exclude<OwnershipPlanNodeSource, 'route'>,
-		parentIntegrationName: string,
-		lineage: Set<object>,
-	): T => {
-		const integrationName =
-			component.config?.integration ?? component.config?.__eco?.integration ?? parentIntegrationName;
-		const componentMeta = component.config?.__eco;
-		const isForeignToParent = integrationName !== parentIntegrationName;
-		const componentId = componentMeta?.id ?? componentMeta?.file ?? `${source}:${(nextSyntheticId += 1)}`;
-
-		const nextLineage = new Set(lineage);
-		nextLineage.add(component);
-		const children = (component.config?.dependencies?.components ?? []).flatMap((child) => {
-			if (!child || nextLineage.has(child)) {
-				return [];
-			}
-
-			return [mapComponent(child, 'dependency', integrationName, nextLineage)];
-		});
-
-		return input.mapNode(
-			{
-				component,
-				source,
-				parentIntegrationName,
-				integrationName,
-				componentId,
-				isForeignToParent,
-			},
-			children,
-		);
-	};
-
-	return input.roots.map(({ component, source }) =>
-		mapComponent(component, source, input.currentIntegrationName, new Set()),
-	);
-}
+export {
+	mapComponentGraph,
+	mapDeclaredOwnershipGraph,
+	type ComponentGraphRoot,
+	type ComponentGraphWalkInput,
+	type DeclaredOwnershipNodeInput,
+	type DeclaredOwnershipRoot,
+} from './component-graph.ts';

--- a/packages/core/src/route-renderer/orchestration/integration-renderer.ts
+++ b/packages/core/src/route-renderer/orchestration/integration-renderer.ts
@@ -37,6 +37,7 @@ import { HttpError } from '../../errors/http-error.ts';
 import { DependencyResolverService } from '../page-loading/dependency-resolver.ts';
 import { PageModuleLoaderService } from '../page-loading/page-module-loader.ts';
 import { OwnershipValidationService } from './ownership-validation.service.ts';
+import { hasForeignChildDescendantsInGraph } from './component-graph-collectors.ts';
 import {
 	type RouteHtmlFinalization,
 	RouteRenderOrchestrator,
@@ -1167,25 +1168,7 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 	 * directly without paying the queue orchestration cost.
 	 */
 	protected hasForeignChildDescendants(component: EcoComponent): boolean {
-		const stack = [component];
-		const seen = new Set<EcoComponent>();
-
-		while (stack.length > 0) {
-			const current = stack.pop();
-			if (!current || seen.has(current)) {
-				continue;
-			}
-
-			seen.add(current);
-			const integrationName = current.config?.integration ?? current.config?.__eco?.integration;
-			if (integrationName && integrationName !== this.name) {
-				return true;
-			}
-
-			stack.push(...(current.config?.dependencies?.components ?? []));
-		}
-
-		return false;
+		return hasForeignChildDescendantsInGraph(component, this.name);
 	}
 
 	/**

--- a/packages/core/src/route-renderer/orchestration/route-render-orchestrator.ts
+++ b/packages/core/src/route-renderer/orchestration/route-render-orchestrator.ts
@@ -4,9 +4,7 @@ import { fileSystem } from '@ecopages/file-system';
 import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 import type {
 	ComponentRenderResult,
-	DependencyAttributes,
 	EcoComponent,
-	EcoComponentConfig,
 	EcoPageComponent,
 	EcoPageFile,
 	HtmlTemplateProps,
@@ -35,6 +33,11 @@ import { appLogger } from '../../global/app-logger.ts';
 import { inspectUnresolvedMarkerArtifactHtml } from './render-output.utils.ts';
 import { OwnershipValidationService, throwIfOwnershipInvalid } from './ownership-validation.service.ts';
 import { dedupeProcessedAssets } from './processed-asset-dedupe.ts';
+import {
+	collectEagerSsrLazyScriptDefinitions,
+	collectIntegrationNamesFromGraph,
+	collectResolvedLazyTriggersFromGraph,
+} from './component-graph-collectors.ts';
 
 export type RouteRenderOrchestratorResolvedInputs = {
 	Page: EcoPageFile['default'] | EcoPageComponent<any>;
@@ -223,35 +226,37 @@ export class RouteRenderOrchestrator {
 		throwIfOwnershipInvalid(validationErrors);
 
 		const componentsToResolve = Layout ? [HtmlTemplate, Layout, Page] : [HtmlTemplate, Page];
-		const { resolvedDependencies } = await adapter.resolveRouteDependencies({
-			components: componentsToResolve,
-		});
-		const pageBrowserGraph = await this.resolvePageBrowserGraph({
-			routeFile: routeOptions.file,
-			integrationName: adapter.name,
-			collectContribution: async (routeFile) => await adapter.collectPageBrowserGraphContribution(routeFile),
-		});
+		const [{ resolvedDependencies }, pageBrowserGraph, componentRender] = await Promise.all([
+			adapter.resolveRouteDependencies({
+				components: componentsToResolve,
+			}),
+			this.resolvePageBrowserGraph({
+				routeFile: routeOptions.file,
+				integrationName: adapter.name,
+				collectContribution: async (routeFile) => await adapter.collectPageBrowserGraphContribution(routeFile),
+			}),
+			adapter.resolveRoutePageComponentRender({
+				Page: Page as EcoComponent,
+				Layout,
+				props,
+				routeOptions,
+			}),
+		]);
 		const usedIntegrationDependencies = this.collectUsedIntegrationDependencies(componentsToResolve, adapter.name);
 		const allDependencies = [...resolvedDependencies, ...usedIntegrationDependencies];
-
-		const componentRender = await adapter.resolveRoutePageComponentRender({
-			Page: Page as EcoComponent,
-			Layout,
-			props,
-			routeOptions,
-		});
 
 		if (componentRender?.assets?.length) {
 			allDependencies.push(...componentRender.assets);
 		}
 
-		const triggers = this.collectResolvedTriggers(componentsToResolve);
-		if (triggers.length > 0) {
-			const globalAssets = await this.buildGlobalInjectorAssets(triggers, adapter.name);
+		const triggers = collectResolvedLazyTriggersFromGraph(componentsToResolve, adapter.name);
+		const [globalAssets, eagerSsrLazyAssets] = await Promise.all([
+			triggers.length > 0 ? this.buildGlobalInjectorAssets(triggers, adapter.name) : Promise.resolve([]),
+			this.buildEagerSsrLazyAssets(componentsToResolve, adapter.name),
+		]);
+		if (globalAssets.length > 0) {
 			allDependencies.push(...globalAssets);
 		}
-
-		const eagerSsrLazyAssets = await this.buildEagerSsrLazyAssets(componentsToResolve, adapter.name);
 		if (eagerSsrLazyAssets.length > 0) {
 			allDependencies.push(...eagerSsrLazyAssets);
 		}
@@ -647,38 +652,11 @@ export class RouteRenderOrchestrator {
 		};
 	}
 
-	private collectResolvedTriggers(
-		components: (EcoComponent | Partial<EcoComponent>)[],
-		seen = new Set<object>(),
-	): ResolvedLazyTrigger[] {
-		const triggers: ResolvedLazyTrigger[] = [];
-		for (const comp of components) {
-			if (!comp) {
-				continue;
-			}
-
-			const ecoComp = comp as EcoComponent;
-			if (seen.has(ecoComp)) {
-				continue;
-			}
-			seen.add(ecoComp);
-			const ownTriggers = ecoComp.config?._resolvedLazyTriggers;
-			if (ownTriggers?.length) {
-				triggers.push(...ownTriggers);
-			}
-			const nested = ecoComp.config?.dependencies?.components;
-			if (nested?.length) {
-				triggers.push(...this.collectResolvedTriggers(nested, seen));
-			}
-		}
-		return triggers;
-	}
-
 	private collectUsedIntegrationDependencies(
 		components: (EcoComponent | Partial<EcoComponent>)[],
 		currentIntegrationName: string,
 	): ProcessedAsset[] {
-		const integrationNames = this.collectIntegrationNames(components);
+		const integrationNames = collectIntegrationNamesFromGraph(components, currentIntegrationName);
 		const dependencies: ProcessedAsset[] = [];
 
 		for (const integrationName of integrationNames) {
@@ -697,40 +675,6 @@ export class RouteRenderOrchestrator {
 		}
 
 		return dependencies;
-	}
-
-	private collectIntegrationNames(
-		components: (EcoComponent | Partial<EcoComponent>)[],
-		seen = new Set<object>(),
-	): Set<string> {
-		const integrationNames = new Set<string>();
-
-		for (const comp of components) {
-			if (!comp) {
-				continue;
-			}
-
-			const ecoComp = comp as EcoComponent;
-			if (seen.has(ecoComp)) {
-				continue;
-			}
-			seen.add(ecoComp);
-
-			const integrationName = ecoComp.config?.integration ?? ecoComp.config?.__eco?.integration;
-			if (integrationName) {
-				integrationNames.add(integrationName);
-			}
-
-			const nested = ecoComp.config?.dependencies?.components;
-			if (nested?.length) {
-				const nestedNames = this.collectIntegrationNames(nested, seen);
-				for (const nestedName of nestedNames) {
-					integrationNames.add(nestedName);
-				}
-			}
-		}
-
-		return integrationNames;
 	}
 
 	private async buildGlobalInjectorAssets(
@@ -771,99 +715,11 @@ export class RouteRenderOrchestrator {
 		components: (EcoComponent | Partial<EcoComponent>)[],
 		currentIntegrationName: string,
 	): Promise<ProcessedAsset[]> {
-		const dependencies = this.collectEagerSsrLazyDependencies(components);
+		const dependencies = collectEagerSsrLazyScriptDefinitions(components);
 		if (dependencies.length === 0) {
 			return [];
 		}
 
 		return this.assetProcessingService.processDependencies(dependencies, `${currentIntegrationName}:ssr-lazy`);
-	}
-
-	private collectEagerSsrLazyDependencies(
-		components: (EcoComponent | Partial<EcoComponent>)[],
-	): ReturnType<AssetProcessingService['processDependencies']> extends Promise<infer _>
-		? Parameters<AssetProcessingService['processDependencies']>[0]
-		: never {
-		const dependencies = [] as Parameters<AssetProcessingService['processDependencies']>[0];
-		const visitedConfigs = new Set<EcoComponentConfig>();
-		const seenKeys = new Set<string>();
-
-		const normalizeAttributes = (attributes?: DependencyAttributes) => ({
-			type: 'module',
-			defer: '',
-			...(attributes ?? {}),
-		});
-
-		const collect = (config?: EcoComponentConfig) => {
-			if (!config || visitedConfigs.has(config)) {
-				return;
-			}
-
-			visitedConfigs.add(config);
-
-			const componentFile = config.__eco?.file;
-			if (componentFile) {
-				const componentDir = path.dirname(componentFile);
-				for (const script of config.dependencies?.scripts ?? []) {
-					if (typeof script === 'string' || !script.lazy || script.ssr !== true) {
-						continue;
-					}
-
-					const attributes = normalizeAttributes(script.attributes);
-
-					if (script.content) {
-						const key = `content:${script.content}:${JSON.stringify(attributes)}`;
-						if (seenKeys.has(key)) {
-							continue;
-						}
-
-						seenKeys.add(key);
-						dependencies.push(
-							AssetFactory.createContentScript({
-								position: 'head',
-								content: script.content,
-								attributes,
-								packageRole: 'dynamic-chunk',
-							}),
-						);
-						continue;
-					}
-
-					if (!script.src) {
-						continue;
-					}
-
-					const resolvedPath = path.resolve(componentDir, script.src);
-					const key = `file:${resolvedPath}:${JSON.stringify(attributes)}`;
-					if (seenKeys.has(key)) {
-						continue;
-					}
-
-					seenKeys.add(key);
-					dependencies.push(
-						AssetFactory.createFileScript({
-							filepath: resolvedPath,
-							position: 'head',
-							attributes,
-							packageRole: 'dynamic-chunk',
-						}),
-					);
-				}
-			}
-
-			if (config.layout?.config) {
-				collect(config.layout.config);
-			}
-
-			for (const nestedComponent of config.dependencies?.components ?? []) {
-				collect(nestedComponent?.config);
-			}
-		};
-
-		for (const component of components) {
-			collect(component.config);
-		}
-
-		return dependencies;
 	}
 }


### PR DESCRIPTION
## Summary
- Add `component-graph.ts` with `walkComponentGraph` / `mapComponentGraph`
- Add `component-graph-collectors.ts` for integration names, lazy triggers, eager SSR scripts, and foreign-child detection
- Parallelize `prepareRenderOptions` Phase A (deps + page browser graph + component render) and Phase B (global injector + eager SSR lazy assets)
- Thin `declared-ownership-graph.ts` re-export shim; migrate `hasForeignChildDescendants` to shared collector

## Test plan
- [x] `vitest run packages/core/src/route-renderer/orchestration/component-graph-collectors.test.ts`
- [x] `vitest run packages/core/src/route-renderer/orchestration/route-render-orchestrator.prepare-render-options.test.ts`
- [x] `vitest run packages/core/src/route-renderer/orchestration/integration-renderer.test.ts`

## Dependencies
None. PR4 (orchestrator extract) builds on this branch.