### PR TITLE
refactor(hmr): share adapter lifecycle and unify React HMR bundling

### DIFF
--- a/packages/core/src/adapters/bun/server-adapter.ts
+++ b/packages/core/src/adapters/bun/server-adapter.ts
@@ -1,8 +1,6 @@
 import type { Server as NodeHttpServer } from 'node:http';
 import type { Server, ServerWebSocket, WebSocketHandler } from 'bun';
-import path from 'node:path';
 import { DEFAULT_ECOPAGES_HOSTNAME, DEFAULT_ECOPAGES_PORT } from '../../config/constants.ts';
-import { RESOLVED_ASSETS_DIR } from '../../config/constants.ts';
 import { appLogger } from '../../global/app-logger.ts';
 import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 import type {
@@ -18,9 +16,8 @@ import { createRequire } from '../../utils/locals-utils.ts';
 import { findWebSocketRoute } from '../abstract/ws-pattern-matcher.ts';
 
 import { fileSystem } from '@ecopages/file-system';
-import { getAppBrowserBuildPlugins, setupAppRuntimePlugins } from '../../build/build-adapter.ts';
+import { setupAppRuntimePlugins } from '../../build/build-adapter.ts';
 import { installAppRuntimeBuildExecutor } from '../../build/runtime-build-executor.ts';
-import { disposeAppBuildRuntime } from '../../build/build-runtime.ts';
 import { StaticSiteGenerator } from '../../static-site-generator/static-site-generator.ts';
 import { ProjectWatcher } from '../../watchers/project-watcher.ts';
 import { SharedServerAdapter } from '../shared/server-adapter.ts';
@@ -29,16 +26,16 @@ import { ApiResponseBuilder } from '../shared/api-response.ts';
 import type { StaticPreviewHost } from '../shared/static-preview-host.ts';
 
 import { ServerStaticBuilder } from '../shared/server-static-builder.ts';
-import {
-	injectHmrRuntimeIntoHtmlResponse,
-	isHtmlResponse,
-	shouldInjectHmrHtmlResponse,
-} from '../shared/hmr-html-response.ts';
 import { attachNodeHttpWebSocketUpgrades } from '../shared/node-http-websocket-upgrades.ts';
 import { createBunUserWebSocketLifecycle, type BunUserWebSocketData } from '../shared/bun-user-websocket-lifecycle.ts';
 import { createEcopagesSocket } from '../shared/websocket-lifecycle.ts';
 import { resolveServeRuntimeOrigin } from '../shared/runtime-app-bootstrap.ts';
-import { copyRuntimePublicDirIfChanged } from '../shared/copy-runtime-public-dir.ts';
+import {
+	disposeDevResources,
+	maybeInjectAdapterHmrHtmlResponse,
+	prepareRuntimePublicDir,
+	wireIntegrationHmrManagers,
+} from '../shared/runtime-server-lifecycle.ts';
 import { ClientBridge } from './client-bridge.ts';
 import { setAppDevClientBridge } from '../../dev/client-bridge-registry.ts';
 import { HmrManager } from './hmr-manager.ts';
@@ -245,13 +242,11 @@ export class BunServerAdapter extends SharedServerAdapter<BunServerAdapterParams
 	 * would otherwise bypass the route wrapper entirely.
 	 */
 	private async maybeInjectHmrScript(response: Response): Promise<Response> {
-		if (
-			shouldInjectHmrHtmlResponse(this.options?.watch === true, this.hmrManager, this.hostOwnsDevClient) &&
-			isHtmlResponse(response)
-		) {
-			return injectHmrRuntimeIntoHtmlResponse(response);
-		}
-		return response;
+		return maybeInjectAdapterHmrHtmlResponse(response, {
+			watch: this.options?.watch === true,
+			hmrManager: this.hmrManager,
+			hostOwnsDevClient: this.hostOwnsDevClient,
+		});
 	}
 
 	/**
@@ -264,7 +259,7 @@ export class BunServerAdapter extends SharedServerAdapter<BunServerAdapterParams
 		if (this.options?.watch) {
 			await this.hmrManager.buildRuntime();
 		}
-		this.prepareRuntimePublicDir();
+		prepareRuntimePublicDir(this.appConfig);
 
 		const staticBuilderOptions = {
 			appConfig: this.appConfig,
@@ -276,20 +271,6 @@ export class BunServerAdapter extends SharedServerAdapter<BunServerAdapterParams
 		this.staticBuilder = new ServerStaticBuilder(staticBuilderOptions);
 
 		await this.initializeRuntimePlugins({ watch: this.options?.watch });
-	}
-
-	/**
-	 * Copies the source `public` directory into the runtime output and ensures the
-	 * HMR assets directory exists before any runtime bundles are emitted.
-	 */
-	private prepareRuntimePublicDir(): void {
-		const srcPublicDir = path.join(this.appConfig.rootDir, this.appConfig.srcDir, this.appConfig.publicDir);
-
-		if (fileSystem.exists(srcPublicDir)) {
-			copyRuntimePublicDirIfChanged(srcPublicDir, path.join(this.appConfig.rootDir, this.appConfig.distDir));
-		}
-
-		fileSystem.ensureDir(path.join(this.appConfig.absolutePaths.distDir, RESOLVED_ASSETS_DIR));
 	}
 
 	/**
@@ -314,12 +295,7 @@ export class BunServerAdapter extends SharedServerAdapter<BunServerAdapterParams
 				},
 			});
 
-			const browserBuildPlugins = getAppBrowserBuildPlugins(this.appConfig);
-			this.hmrManager.setPlugins(browserBuildPlugins);
-
-			for (const integration of this.appConfig.integrations) {
-				integration.setHmrManager(this.hmrManager);
-			}
+			wireIntegrationHmrManagers(this.appConfig, this.hmrManager);
 		} catch (error) {
 			appLogger.error(`Failed to initialize plugins: ${error instanceof Error ? error.message : String(error)}`);
 			throw error;
@@ -692,16 +668,15 @@ export class BunServerAdapter extends SharedServerAdapter<BunServerAdapterParams
 
 		this.adapterDisposed = true;
 
-		await this.projectWatcher?.close();
+		await disposeDevResources({
+			projectWatcher: this.projectWatcher,
+			appConfig: this.appConfig,
+			hmrManager: this.hmrManager,
+			bridge: this.bridge,
+			previewHost: this.previewHost,
+		});
+
 		this.projectWatcher = null;
-
-		await disposeAppBuildRuntime(this.appConfig);
-
-		this.hmrManager?.stop();
-
-		this.bridge?.destroy();
-
-		await this.previewHost.stop();
 	}
 
 	/**

--- a/packages/core/src/adapters/node/server-adapter.ts
+++ b/packages/core/src/adapters/node/server-adapter.ts
@@ -1,10 +1,6 @@
 import { type Server as NodeHttpServer, type IncomingMessage } from 'node:http';
-import path from 'node:path';
-import { fileSystem } from '@ecopages/file-system';
-import { getAppBrowserBuildPlugins, setupAppRuntimePlugins } from '../../build/build-adapter.ts';
+import { setupAppRuntimePlugins } from '../../build/build-adapter.ts';
 import { installAppRuntimeBuildExecutor } from '../../build/runtime-build-executor.ts';
-import { disposeAppBuildRuntime } from '../../build/build-runtime.ts';
-import { RESOLVED_ASSETS_DIR } from '../../config/constants.ts';
 import { appLogger } from '../../global/app-logger.ts';
 import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 import { NodeClientBridge } from './node-client-bridge.ts';
@@ -22,11 +18,11 @@ import type { ServerAdapterResult } from '../abstract/server-adapter.ts';
 import { ServerStaticBuilder } from '../shared/server-static-builder.ts';
 import { DEFAULT_ECOPAGES_HOSTNAME, DEFAULT_ECOPAGES_PORT } from '../../config/constants.ts';
 import {
-	injectHmrRuntimeIntoHtmlResponse,
-	isHtmlResponse,
-	shouldInjectHmrHtmlResponse,
-} from '../shared/hmr-html-response.ts';
-import { copyRuntimePublicDirIfChanged } from '../shared/copy-runtime-public-dir.ts';
+	maybeInjectAdapterHmrHtmlResponse,
+	prepareRuntimePublicDir,
+	wireIntegrationHmrManagers,
+	disposeDevResources,
+} from '../shared/runtime-server-lifecycle.ts';
 import { resolveServeRuntimeOrigin } from '../shared/runtime-app-bootstrap.ts';
 import { NodeClientAbortError, NodeHttpRequestBridge } from './http-request-bridge.ts';
 import { NodeStaticPreviewHost } from './static-preview-host.ts';
@@ -131,23 +127,12 @@ export class NodeServerAdapter extends SharedServerAdapter<NodeServerAdapterPara
 		});
 	}
 
-	private isHtmlResponse(response: Response): boolean {
-		return isHtmlResponse(response);
-	}
-
 	private async maybeInjectHmrScript(response: Response): Promise<Response> {
-		if (
-			shouldInjectHmrHtmlResponse(
-				this.options?.watch === true,
-				this.hmrManager ?? undefined,
-				this.hostOwnsDevClient,
-			) &&
-			this.isHtmlResponse(response)
-		) {
-			return injectHmrRuntimeIntoHtmlResponse(response);
-		}
-
-		return response;
+		return maybeInjectAdapterHmrHtmlResponse(response, {
+			watch: this.options?.watch === true,
+			hmrManager: this.hmrManager ?? undefined,
+			hostOwnsDevClient: this.hostOwnsDevClient,
+		});
 	}
 
 	/**
@@ -195,7 +180,7 @@ export class NodeServerAdapter extends SharedServerAdapter<NodeServerAdapterPara
 	public async initialize(): Promise<void> {
 		installAppRuntimeBuildExecutor(this.appConfig);
 
-		this.prepareRuntimePublicDir();
+		prepareRuntimePublicDir(this.appConfig);
 		await setupAppRuntimePlugins({
 			appConfig: this.appConfig,
 			runtimeOrigin: this.runtimeOrigin,
@@ -213,16 +198,6 @@ export class NodeServerAdapter extends SharedServerAdapter<NodeServerAdapterPara
 			apiHandlers: this.apiHandlers,
 		});
 		this.initialized = true;
-	}
-
-	private prepareRuntimePublicDir(): void {
-		const srcPublicDir = path.join(this.appConfig.rootDir, this.appConfig.srcDir, this.appConfig.publicDir);
-
-		if (fileSystem.exists(srcPublicDir)) {
-			copyRuntimePublicDirIfChanged(srcPublicDir, path.join(this.appConfig.rootDir, this.appConfig.distDir));
-		}
-
-		fileSystem.ensureDir(path.join(this.appConfig.absolutePaths.distDir, RESOLVED_ASSETS_DIR));
 	}
 
 	public getServerOptions(): NodeServeAdapterServerOptions {
@@ -288,18 +263,17 @@ export class NodeServerAdapter extends SharedServerAdapter<NodeServerAdapterPara
 
 		this.adapterDisposed = true;
 
-		await this.projectWatcher?.close();
+		await disposeDevResources({
+			projectWatcher: this.projectWatcher,
+			appConfig: this.appConfig,
+			hmrManager: this.hmrManager,
+			bridge: this.bridge,
+			previewHost: this.previewHost,
+		});
+
 		this.projectWatcher = null;
-
-		await disposeAppBuildRuntime(this.appConfig);
-
-		this.hmrManager?.stop();
 		this.hmrManager = null;
-
-		this.bridge?.destroy();
 		this.bridge = null;
-
-		await this.previewHost.stop();
 	}
 
 	/**
@@ -394,12 +368,7 @@ export class NodeServerAdapter extends SharedServerAdapter<NodeServerAdapterPara
 				});
 			}
 
-			const browserBuildPlugins = getAppBrowserBuildPlugins(this.appConfig);
-			this.hmrManager.setPlugins(browserBuildPlugins);
-
-			for (const integration of this.appConfig.integrations) {
-				integration.setHmrManager(this.hmrManager);
-			}
+			wireIntegrationHmrManagers(this.appConfig, this.hmrManager);
 
 			this.configureSharedResponseHandlers(this.staticRoutes, this.hmrManager);
 

--- a/packages/core/src/adapters/shared/runtime-server-lifecycle.ts
+++ b/packages/core/src/adapters/shared/runtime-server-lifecycle.ts
@@ -1,0 +1,81 @@
+import path from 'node:path';
+import { fileSystem } from '@ecopages/file-system';
+import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
+import type { IHmrManager } from '../../types/public-types.ts';
+import { RESOLVED_ASSETS_DIR } from '../../config/constants.ts';
+import { disposeAppBuildRuntime } from '../../build/build-runtime.ts';
+import { getAppBrowserBuildPlugins } from '../../build/build-adapter.ts';
+import type { ProjectWatcher } from '../../watchers/project-watcher.ts';
+import { copyRuntimePublicDirIfChanged } from './copy-runtime-public-dir.ts';
+import {
+	injectHmrRuntimeIntoHtmlResponse,
+	isHtmlResponse,
+	shouldInjectHmrHtmlResponse,
+} from './hmr-html-response.ts';
+
+/**
+ * Copies source `public/` into dist and ensures the resolved assets directory exists.
+ */
+export function prepareRuntimePublicDir(appConfig: EcoPagesAppConfig): void {
+	const srcPublicDir = path.join(appConfig.rootDir, appConfig.srcDir, appConfig.publicDir);
+
+	if (fileSystem.exists(srcPublicDir)) {
+		copyRuntimePublicDirIfChanged(srcPublicDir, path.join(appConfig.rootDir, appConfig.distDir));
+	}
+
+	fileSystem.ensureDir(path.join(appConfig.absolutePaths.distDir, RESOLVED_ASSETS_DIR));
+}
+
+/**
+ * Propagates browser build plugins and the shared HMR manager into integrations.
+ */
+export function wireIntegrationHmrManagers(appConfig: EcoPagesAppConfig, hmrManager: IHmrManager): void {
+	hmrManager.setPlugins(getAppBrowserBuildPlugins(appConfig));
+
+	for (const integration of appConfig.integrations) {
+		integration.setHmrManager(hmrManager);
+	}
+}
+
+/**
+ * Injects the dev HMR runtime into adapter-level HTML responses when watch mode is active.
+ */
+export async function maybeInjectAdapterHmrHtmlResponse(
+	response: Response,
+	options: {
+		watch: boolean;
+		hmrManager?: Pick<IHmrManager, 'isEnabled'>;
+		hostOwnsDevClient: boolean;
+	},
+): Promise<Response> {
+	if (
+		shouldInjectHmrHtmlResponse(options.watch, options.hmrManager, options.hostOwnsDevClient) &&
+		isHtmlResponse(response)
+	) {
+		return injectHmrRuntimeIntoHtmlResponse(response);
+	}
+
+	return response;
+}
+
+/**
+ * Releases shared dev resources in a consistent order across server adapters.
+ *
+ * @remarks
+ * Bun calls `buildRuntime()` during `initialize()` when watch is enabled; Node defers
+ * runtime creation to `completeInitialization()`. Transport-specific setup stays in
+ * each adapter — only shared teardown lives here.
+ */
+export async function disposeDevResources(options: {
+	projectWatcher: ProjectWatcher | null | undefined;
+	appConfig: EcoPagesAppConfig;
+	hmrManager: IHmrManager | null | undefined;
+	bridge: { destroy(): void } | null | undefined;
+	previewHost: { stop(): Promise<void> };
+}): Promise<void> {
+	await options.projectWatcher?.close();
+	await disposeAppBuildRuntime(options.appConfig);
+	options.hmrManager?.stop();
+	options.bridge?.destroy();
+	await options.previewHost.stop();
+}

--- a/packages/integrations/react/src/react-hmr-strategy.ts
+++ b/packages/integrations/react/src/react-hmr-strategy.ts
@@ -506,6 +506,8 @@ export class ReactHmrStrategy extends HmrStrategy {
 		}
 		const requiresLayoutRefresh = isLayout || hasOwnedLayoutDependencyHit || hasLayoutOwnedRequestedTarget;
 
+		await this.clearOutdirsForTargets(pageTargets, nonPageTargets);
+
 		const updates: string[] = [];
 		const requestedOutputUrls = new Set(requestedTargets.map((target) => target.outputUrl));
 		if (pageTargets.length > 1) {
@@ -567,6 +569,92 @@ export class ReactHmrStrategy extends HmrStrategy {
 	}
 
 	/**
+	 * Clears stale HMR output once per outdir before any rebuild pass in `process()`.
+	 *
+	 * @remarks
+	 * Grouped page builds share `getDistDir()`; single page and non-page targets use
+	 * per-entrypoint temp directories. Clearing here avoids redundant work when both
+	 * page and non-page targets land in the same outdir.
+	 */
+	private async clearOutdirsForTargets(
+		pageTargets: ReactHmrBuildTarget[],
+		nonPageTargets: ReactHmrBuildTarget[],
+	): Promise<void> {
+		const outdirs = new Set<string>();
+
+		if (pageTargets.length > 1) {
+			outdirs.add(this.context.getDistDir());
+		} else {
+			for (const { entrypointPath } of pageTargets) {
+				outdirs.add(path.dirname(this.getEntrypointOutput(entrypointPath).outputPath));
+			}
+		}
+
+		for (const { entrypointPath } of nonPageTargets) {
+			outdirs.add(path.dirname(this.getEntrypointOutput(entrypointPath).outputPath));
+		}
+
+		await Promise.all([...outdirs].map((outdir) => this.clearHmrOutdir(outdir)));
+	}
+
+	private async resolveDeclaredModulesForEntrypoint(entrypointPath: string): Promise<readonly string[]> {
+		const cached = this.pageMetadataCache.getDeclaredModules(entrypointPath);
+		if (cached) {
+			return cached;
+		}
+
+		const declaredModules = entrypointPath.endsWith('.mdx')
+			? await collectPageDeclaredModules(entrypointPath)
+			: collectPageDeclaredModulesFromModule(await this.importNodePageModule(entrypointPath));
+		this.pageMetadataCache.setDeclaredModules(entrypointPath, declaredModules);
+		return declaredModules;
+	}
+
+	private async collectDeclaredModulesForTargets(
+		targets: ReactHmrBuildTarget[],
+	): Promise<{ declaredModules: string[]; shouldEnableMdx: boolean }> {
+		const declaredModules = new Set<string>();
+		let shouldEnableMdx = false;
+
+		for (const { entrypointPath } of targets) {
+			const entrypointDeclaredModules = await this.resolveDeclaredModulesForEntrypoint(entrypointPath);
+			for (const declaredModule of entrypointDeclaredModules) {
+				declaredModules.add(declaredModule);
+			}
+
+			if (entrypointPath.endsWith('.mdx')) {
+				shouldEnableMdx = true;
+			}
+		}
+
+		return { declaredModules: [...declaredModules], shouldEnableMdx };
+	}
+
+	private buildPluginsForDeclaredModules(
+		declaredModules: readonly string[],
+		shouldEnableMdx: boolean,
+	): ReturnType<ReactHmrStrategy['getBuildPlugins']> {
+		const plugins = this.getBuildPlugins(declaredModules);
+
+		if (shouldEnableMdx && this.mdxCompilerOptions) {
+			plugins.unshift(createReactMdxLoaderPlugin(this.mdxCompilerOptions));
+		}
+
+		return plugins;
+	}
+
+	private recordBuildDependencyGraph(result: { dependencyGraph?: { entrypoints?: Record<string, string[]> } }): void {
+		if (!result.dependencyGraph?.entrypoints) {
+			return;
+		}
+
+		const dependencyGraph = this.context.getEntrypointDependencyGraph();
+		for (const [entrypoint, deps] of Object.entries(result.dependencyGraph.entrypoints)) {
+			dependencyGraph.setEntrypointDependencies(entrypoint, deps);
+		}
+	}
+
+	/**
 	 * Bundles a single React/MDX entrypoint with HMR support.
 	 *
 	 * After successful bundling, populates the entrypoint dependency graph with
@@ -579,73 +667,8 @@ export class ReactHmrStrategy extends HmrStrategy {
 	 * @returns True if bundling was successful
 	 */
 	private async bundleReactEntrypoint(entrypointPath: string, outputUrl: string): Promise<boolean> {
-		try {
-			const isMdx = entrypointPath.endsWith('.mdx');
-			const { outputPath } = this.getEntrypointOutput(entrypointPath);
-			const tempDir = path.dirname(outputPath);
-
-			const cachedDeclared = this.pageMetadataCache.getDeclaredModules(entrypointPath);
-			let entrypointDeclaredModules: readonly string[];
-			let declaredModules: readonly string[];
-			if (cachedDeclared) {
-				entrypointDeclaredModules = cachedDeclared;
-				declaredModules = cachedDeclared;
-			} else {
-				entrypointDeclaredModules = isMdx
-					? await collectPageDeclaredModules(entrypointPath)
-					: collectPageDeclaredModulesFromModule(await this.importNodePageModule(entrypointPath));
-				// Populate the cache so subsequent rebuilds (single or grouped)
-				// don't re-import the page module on the Node side.
-				this.pageMetadataCache.setDeclaredModules(entrypointPath, entrypointDeclaredModules);
-				declaredModules = entrypointDeclaredModules;
-			}
-			const plugins = this.getBuildPlugins(declaredModules);
-
-			if (isMdx && this.mdxCompilerOptions) {
-				const mdxPlugin = createReactMdxLoaderPlugin(this.mdxCompilerOptions);
-				plugins.unshift(mdxPlugin);
-			}
-
-			await this.clearHmrOutdir(tempDir);
-			const result = await this.context.getBrowserBundleService().bundle({
-				profile: 'hmr-entrypoint',
-				entrypoints: [entrypointPath],
-				outdir: tempDir,
-				naming: `[name].[hash].tmp`,
-				plugins,
-				minify: false,
-			});
-
-			if (!result.success) {
-				appLogger.error(`Failed to build ${entrypointPath}:`, result.logs);
-				return false;
-			}
-
-			if (result.dependencyGraph?.entrypoints) {
-				const dependencyGraph = this.context.getEntrypointDependencyGraph();
-				for (const [entrypoint, deps] of Object.entries(result.dependencyGraph.entrypoints)) {
-					dependencyGraph.setEntrypointDependencies(entrypoint, deps);
-				}
-			}
-
-			const tempFile = result.outputs[0]?.path;
-			if (!tempFile) {
-				appLogger.error(`No output file generated for ${entrypointPath}`);
-				return false;
-			}
-
-			const resolvedTempFile = await this.resolveTempOutputPath(tempFile);
-			if (!resolvedTempFile) {
-				appLogger.debug(`Skipping stale temp output for ${outputUrl}: ${tempFile}`);
-				return false;
-			}
-
-			const processed = await this.processOutput(resolvedTempFile, outputPath, outputUrl);
-			return processed;
-		} catch (error) {
-			appLogger.error(`Error bundling ${entrypointPath}:`, error as Error);
-			return false;
-		}
+		const rebuiltOutputs = await this.bundleReactBuildTargets([{ entrypointPath, outputUrl }], { grouped: false });
+		return rebuiltOutputs.length > 0;
 	}
 
 	/**
@@ -659,95 +682,117 @@ export class ReactHmrStrategy extends HmrStrategy {
 	 * @returns Array of output URLs that were successfully built
 	 */
 	private async bundleReactEntrypoints(entrypoints: ReactHmrBuildTarget[]): Promise<string[]> {
+		return this.bundleReactBuildTargets(entrypoints, { grouped: true });
+	}
+
+	private async bundleReactBuildTargets(
+		targets: ReactHmrBuildTarget[],
+		options: { grouped: boolean },
+	): Promise<string[]> {
+		if (targets.length === 0) {
+			return [];
+		}
+
 		try {
-			const declaredModules = new Set<string>();
-			let shouldEnableMdx = false;
+			const { declaredModules, shouldEnableMdx } = await this.collectDeclaredModulesForTargets(targets);
+			const plugins = this.buildPluginsForDeclaredModules(declaredModules, shouldEnableMdx);
 
-			for (const { entrypointPath } of entrypoints) {
-				const entrypointDeclaredModules = this.pageMetadataCache.getDeclaredModules(entrypointPath)
-					? this.pageMetadataCache.getDeclaredModules(entrypointPath)!
-					: entrypointPath.endsWith('.mdx')
-						? await collectPageDeclaredModules(entrypointPath)
-						: collectPageDeclaredModulesFromModule(await this.importNodePageModule(entrypointPath));
-
-				this.pageMetadataCache.setDeclaredModules(entrypointPath, entrypointDeclaredModules);
-				for (const declaredModule of entrypointDeclaredModules) {
-					declaredModules.add(declaredModule);
+			if (options.grouped) {
+				const entryNameByPath = new Map<string, { key: string; basename: string }>();
+				for (const { entrypointPath } of targets) {
+					entryNameByPath.set(entrypointPath, {
+						key: this.getRolldownEntryKey(entrypointPath),
+						basename: this.getTempFileBasename(entrypointPath),
+					});
 				}
 
-				if (entrypointPath.endsWith('.mdx')) {
-					shouldEnableMdx = true;
-				}
-			}
-
-			const plugins = this.getBuildPlugins([...declaredModules]);
-			if (shouldEnableMdx && this.mdxCompilerOptions) {
-				plugins.unshift(createReactMdxLoaderPlugin(this.mdxCompilerOptions));
-			}
-
-			await this.clearHmrOutdir(this.context.getDistDir());
-			const entryNameByPath = new Map<string, { key: string; basename: string }>();
-			for (const { entrypointPath } of entrypoints) {
-				entryNameByPath.set(entrypointPath, {
-					key: this.getRolldownEntryKey(entrypointPath),
-					basename: this.getTempFileBasename(entrypointPath),
+				const result = await this.context.getBrowserBundleService().bundle({
+					profile: 'hmr-entrypoint',
+					entrypoints: Object.fromEntries(
+						targets.map(({ entrypointPath }) => [entryNameByPath.get(entrypointPath)!.key, entrypointPath]),
+					),
+					outdir: this.context.getDistDir(),
+					naming: '[name].[hash].tmp',
+					splitting: true,
+					plugins,
+					minify: false,
 				});
+
+				if (!result.success) {
+					appLogger.error(`Failed to build grouped React entrypoints:`, result.logs);
+					return [];
+				}
+
+				this.recordBuildDependencyGraph(result);
+
+				const updatedOutputs: string[] = [];
+				for (const { entrypointPath, outputUrl } of targets) {
+					const { outputPath } = this.getEntrypointOutput(entrypointPath);
+					const { basename: tempBasename, key: entryKey } = entryNameByPath.get(entrypointPath)!;
+					const expectedSubdir = path.join(this.context.getDistDir(), path.dirname(entryKey));
+					const tempOutput = result.outputs.find((output) => {
+						return (
+							path.dirname(output.path) === expectedSubdir &&
+							path.basename(output.path).startsWith(`${tempBasename}.`) &&
+							path.basename(output.path).includes('.tmp')
+						);
+					})?.path;
+
+					const resolvedTempOutput = tempOutput
+						? await this.resolveTempOutputPath(tempOutput)
+						: await this.resolveTempOutputPath(path.join(expectedSubdir, `${tempBasename}.[hash].tmp.js`));
+
+					if (!resolvedTempOutput) {
+						appLogger.debug(`Missing grouped temp output for ${outputUrl}`);
+						continue;
+					}
+
+					const processed = await this.processOutput(resolvedTempOutput, outputPath, outputUrl);
+					if (processed) {
+						updatedOutputs.push(outputUrl);
+					}
+				}
+
+				return updatedOutputs;
 			}
+
+			const { entrypointPath, outputUrl } = targets[0]!;
+			const { outputPath } = this.getEntrypointOutput(entrypointPath);
+			const tempDir = path.dirname(outputPath);
+
 			const result = await this.context.getBrowserBundleService().bundle({
 				profile: 'hmr-entrypoint',
-				entrypoints: Object.fromEntries(
-					entrypoints.map(({ entrypointPath }) => [entryNameByPath.get(entrypointPath)!.key, entrypointPath]),
-				),
-				outdir: this.context.getDistDir(),
-				naming: '[name].[hash].tmp',
-				splitting: true,
+				entrypoints: [entrypointPath],
+				outdir: tempDir,
+				naming: `[name].[hash].tmp`,
 				plugins,
 				minify: false,
 			});
 
 			if (!result.success) {
-				appLogger.error(`Failed to build grouped React entrypoints:`, result.logs);
+				appLogger.error(`Failed to build ${entrypointPath}:`, result.logs);
 				return [];
 			}
 
-			if (result.dependencyGraph?.entrypoints) {
-				const dependencyGraph = this.context.getEntrypointDependencyGraph();
-				for (const [entrypoint, deps] of Object.entries(result.dependencyGraph.entrypoints)) {
-					dependencyGraph.setEntrypointDependencies(entrypoint, deps);
-				}
+			this.recordBuildDependencyGraph(result);
+
+			const tempFile = result.outputs[0]?.path;
+			if (!tempFile) {
+				appLogger.error(`No output file generated for ${entrypointPath}`);
+				return [];
 			}
 
-			const updatedOutputs: string[] = [];
-			for (const { entrypointPath, outputUrl } of entrypoints) {
-				const { outputPath } = this.getEntrypointOutput(entrypointPath);
-				const { basename: tempBasename, key: entryKey } = entryNameByPath.get(entrypointPath)!;
-				const expectedSubdir = path.join(this.context.getDistDir(), path.dirname(entryKey));
-				const tempOutput = result.outputs.find((output) => {
-					return (
-						path.dirname(output.path) === expectedSubdir &&
-						path.basename(output.path).startsWith(`${tempBasename}.`) &&
-						path.basename(output.path).includes('.tmp')
-					);
-				})?.path;
-
-				const resolvedTempOutput = tempOutput
-					? await this.resolveTempOutputPath(tempOutput)
-					: await this.resolveTempOutputPath(path.join(expectedSubdir, `${tempBasename}.[hash].tmp.js`));
-
-				if (!resolvedTempOutput) {
-					appLogger.debug(`Missing grouped temp output for ${outputUrl}`);
-					continue;
-				}
-
-				const processed = await this.processOutput(resolvedTempOutput, outputPath, outputUrl);
-				if (processed) {
-					updatedOutputs.push(outputUrl);
-				}
+			const resolvedTempFile = await this.resolveTempOutputPath(tempFile);
+			if (!resolvedTempFile) {
+				appLogger.debug(`Skipping stale temp output for ${outputUrl}: ${tempFile}`);
+				return [];
 			}
 
-			return updatedOutputs;
+			const processed = await this.processOutput(resolvedTempFile, outputPath, outputUrl);
+			return processed ? [outputUrl] : [];
 		} catch (error) {
-			appLogger.error(`Error bundling grouped React entrypoints:`, error as Error);
+			const label = options.grouped ? 'grouped React entrypoints' : targets[0]?.entrypointPath ?? 'React entrypoint';
+			appLogger.error(`Error bundling ${label}:`, error as Error);
 			return [];
 		}
 	}


### PR DESCRIPTION
## Summary
- Extract shared runtime-server lifecycle helpers used by Bun and Node adapters (public dir prep, integration HMR wiring, HTML injection, dev teardown).
- Hoist React HMR outdir clearing to once per `process()` pass instead of per bundle call.
- Merge single and grouped React HMR bundle paths behind shared declared-module, plugin, and dependency-graph helpers.

## Test plan
- [x] `pnpm exec vitest run packages/integrations/react/src/react-hmr-strategy.test.ts`
- [x] `pnpm exec vitest run packages/core/src/adapters/node/server-adapter.test.ts`
- [x] `pnpm exec vitest run packages/core/src/adapters/shared/hmr-manager.dispatch.test.ts`