### PR TITLE
refactor(renderer): extract route-render adapter seam

### DIFF
--- a/packages/core/src/route-renderer/orchestration/integration-renderer.ts
+++ b/packages/core/src/route-renderer/orchestration/integration-renderer.ts
@@ -39,11 +39,12 @@ import { PageModuleLoaderService } from '../page-loading/page-module-loader.ts';
 import { OwnershipValidationService } from './ownership-validation.service.ts';
 import { hasForeignChildDescendantsInGraph } from './component-graph-collectors.ts';
 import {
-	type RouteHtmlFinalization,
 	RouteRenderOrchestrator,
 	type RouteRenderOrchestratorAdapter,
 	type RouteRenderOrchestratorResolvedInputs,
 } from './route-render-orchestrator.ts';
+import { createIntegrationRouteRenderAdapter } from './integration-route-render-adapter.ts';
+import { loadPageBrowserGraphContribution } from './page-browser-graph-contribution.loader.ts';
 import type { ForeignChildRuntime } from './component-render-context.ts';
 import { normalizeUnresolvedMarkerArtifactHtml, isMarkupNodeLike } from './render-output.utils.ts';
 import {
@@ -244,10 +245,12 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 		return await this.routeRenderOrchestrator.resolveDeclaredPageBrowserGraph({
 			routeFile: filePath,
 			integrationName: this.name,
-			collectContribution: async (routeFile) => {
-				const pageModule = await this.importPageFile(routeFile);
-				return await this.collectPageBrowserGraphContribution({ file: routeFile, pageModule });
-			},
+			collectContribution: (routeFile) =>
+				loadPageBrowserGraphContribution(
+					routeFile,
+					(targetFile) => this.importPageFile(targetFile),
+					(context) => this.collectPageBrowserGraphContribution(context),
+				),
 		});
 	}
 
@@ -809,20 +812,22 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 	 * subclasses continue to override protected renderer behavior directly.
 	 */
 	protected createRouteRenderOrchestratorAdapter(): RouteRenderOrchestratorAdapter<C> {
-		return {
+		return createIntegrationRouteRenderAdapter({
 			name: this.name,
 			resolveRouteRenderInputs: (routeOptions) => this.resolveRouteRenderInputs(routeOptions),
 			resolveRouteDependencies: (input) => this.resolveRouteDependencies(input),
-			collectPageBrowserGraphContribution: async (routeFile) => {
-				const pageModule = await this.importPageFile(routeFile);
-				return await this.collectPageBrowserGraphContribution({ file: routeFile, pageModule });
-			},
+			importPageFile: (file) => this.importPageFile(file),
+			collectPageBrowserGraphContribution: (context) => this.collectPageBrowserGraphContribution(context),
 			resolveRoutePageComponentRender: (input) => this.resolveRoutePageComponentRender(input),
 			renderRouteBody: (renderOptions) => this.renderRouteBody(renderOptions),
-			getRouteHtmlFinalization: (renderOptions) => this.getRouteHtmlFinalization(renderOptions),
+			getDocumentAttributes: (renderOptions) => this.getDocumentAttributes(renderOptions),
+			getHtmlDocumentContributions: (options) => this.getHtmlDocumentContributions(options),
+			applyAttributesToFirstBodyElement: (html, attributes) =>
+				this.applyAttributesToFirstBodyElement(html, attributes),
+			applyAttributesToHtmlElement: (html, attributes) => this.applyAttributesToHtmlElement(html, attributes),
 			transformRouteResponse: (response, htmlContributions, pagePackage) =>
 				this.transformRouteResponse(response, htmlContributions, pagePackage),
-		};
+		});
 	}
 
 	protected async resolveRouteRenderInputs(
@@ -883,44 +888,6 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 
 	protected async renderRouteBody(renderOptions: IntegrationRendererRenderOptions<C>): Promise<RouteRendererBody> {
 		return this.render(renderOptions);
-	}
-
-	protected getRouteHtmlFinalization(renderOptions: IntegrationRendererRenderOptions<C>): RouteHtmlFinalization {
-		const componentRootAttributes =
-			renderOptions.componentRender?.canAttachAttributes &&
-			renderOptions.componentRender.rootAttributes &&
-			Object.keys(renderOptions.componentRender.rootAttributes).length > 0
-				? (renderOptions.componentRender.rootAttributes as Record<string, string>)
-				: undefined;
-		const documentAttributes = this.getDocumentAttributes(renderOptions);
-		const htmlContributions = this.getHtmlDocumentContributions({ renderOptions, partial: false });
-		const hasStructuralFinalization =
-			(componentRootAttributes && Object.keys(componentRootAttributes).length > 0) ||
-			(documentAttributes && Object.keys(documentAttributes).length > 0);
-
-		if (!hasStructuralFinalization && (!htmlContributions || htmlContributions.length === 0)) {
-			return {};
-		}
-
-		return {
-			htmlContributions,
-			finalizeHtml: (html) => {
-				let renderedHtml = html;
-
-				if (componentRootAttributes) {
-					renderedHtml = this.htmlTransformer.applyAttributesToFirstBodyElement(
-						renderedHtml,
-						componentRootAttributes,
-					);
-				}
-
-				if (documentAttributes) {
-					renderedHtml = this.htmlTransformer.applyAttributesToHtmlElement(renderedHtml, documentAttributes);
-				}
-
-				return renderedHtml;
-			},
-		};
 	}
 
 	protected async transformRouteResponse(
@@ -1060,6 +1027,14 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 		_renderOptions: IntegrationRendererRenderOptions<C>,
 	): Record<string, string> | undefined {
 		return undefined;
+	}
+
+	protected applyAttributesToFirstBodyElement(html: string, attributes: Record<string, string>): string {
+		return this.htmlTransformer.applyAttributesToFirstBodyElement(html, attributes);
+	}
+
+	protected applyAttributesToHtmlElement(html: string, attributes: Record<string, string>): string {
+		return this.htmlTransformer.applyAttributesToHtmlElement(html, attributes);
 	}
 
 	/**

--- a/packages/core/src/route-renderer/orchestration/integration-route-render-adapter.ts
+++ b/packages/core/src/route-renderer/orchestration/integration-route-render-adapter.ts
@@ -1,0 +1,88 @@
+import type { ProcessedAsset } from '../../services/assets/asset-processing-service/index.ts';
+import type { HtmlDocumentContribution } from '../../services/html/html-transformer.service.ts';
+import type {
+	ComponentRenderResult,
+	EcoComponent,
+	EcoPageFile,
+	IntegrationRendererRenderOptions,
+	PageBrowserGraphContribution,
+	PageBrowserGraphContributionContext,
+	PagePackageResult,
+	RouteRendererBody,
+	RouteRendererOptions,
+} from '../../types/public-types.ts';
+import { loadPageBrowserGraphContribution } from './page-browser-graph-contribution.loader.ts';
+import { buildRouteHtmlFinalization } from './route-html-finalization.service.ts';
+import type {
+	RouteHtmlFinalization,
+	RouteRenderOrchestratorAdapter,
+	RouteRenderOrchestratorResolvedInputs,
+} from './route-render-orchestrator.ts';
+
+/**
+ * Host surface required to build the orchestrator adapter for one integration renderer.
+ */
+export type IntegrationRouteRenderAdapterHost<C> = {
+	readonly name: string;
+	resolveRouteRenderInputs(routeOptions: RouteRendererOptions): Promise<RouteRenderOrchestratorResolvedInputs>;
+	resolveRouteDependencies(input: {
+		components: (EcoComponent | Partial<EcoComponent>)[];
+	}): Promise<{ resolvedDependencies: ProcessedAsset[] }>;
+	importPageFile(file: string): Promise<EcoPageFile>;
+	collectPageBrowserGraphContribution(
+		context: PageBrowserGraphContributionContext,
+	): Promise<PageBrowserGraphContribution | undefined>;
+	resolveRoutePageComponentRender(input: {
+		Page: EcoComponent;
+		Layout?: EcoComponent;
+		props: Record<string, unknown>;
+		routeOptions: RouteRendererOptions;
+	}): Promise<ComponentRenderResult | undefined>;
+	renderRouteBody(renderOptions: IntegrationRendererRenderOptions<C>): Promise<RouteRendererBody>;
+	getDocumentAttributes(renderOptions: IntegrationRendererRenderOptions<C>): Record<string, string> | undefined;
+	getHtmlDocumentContributions(options: {
+		renderOptions: IntegrationRendererRenderOptions<C>;
+		partial: boolean;
+	}): HtmlDocumentContribution[] | undefined;
+	applyAttributesToFirstBodyElement(html: string, attributes: Record<string, string>): string;
+	applyAttributesToHtmlElement(html: string, attributes: Record<string, string>): string;
+	transformRouteResponse(
+		response: Response,
+		htmlContributions?: HtmlDocumentContribution[],
+		pagePackage?: PagePackageResult,
+	): Promise<RouteRendererBody>;
+};
+
+/**
+ * Builds the internal route-render adapter consumed by `RouteRenderOrchestrator`.
+ */
+export function createIntegrationRouteRenderAdapter<C>(
+	host: IntegrationRouteRenderAdapterHost<C>,
+): RouteRenderOrchestratorAdapter<C> {
+	return {
+		name: host.name,
+		resolveRouteRenderInputs: (routeOptions) => host.resolveRouteRenderInputs(routeOptions),
+		resolveRouteDependencies: (input) => host.resolveRouteDependencies(input),
+		collectPageBrowserGraphContribution: (routeFile) =>
+			loadPageBrowserGraphContribution(
+				routeFile,
+				(file) => host.importPageFile(file),
+				(context) => host.collectPageBrowserGraphContribution(context),
+			),
+		resolveRoutePageComponentRender: (input) => host.resolveRoutePageComponentRender(input),
+		renderRouteBody: (renderOptions) => host.renderRouteBody(renderOptions),
+		getRouteHtmlFinalization: (renderOptions) =>
+			buildRouteHtmlFinalization({
+				renderOptions,
+				getDocumentAttributes: (options) => host.getDocumentAttributes(options),
+				getHtmlDocumentContributions: (options) => host.getHtmlDocumentContributions(options),
+				applyAttributesToFirstBodyElement: (html, attributes) =>
+					host.applyAttributesToFirstBodyElement(html, attributes),
+				applyAttributesToHtmlElement: (html, attributes) => host.applyAttributesToHtmlElement(html, attributes),
+			}),
+		transformRouteResponse: (response, htmlContributions, pagePackage) =>
+			host.transformRouteResponse(response, htmlContributions, pagePackage),
+	};
+}
+
+export type { RouteHtmlFinalization };

--- a/packages/core/src/route-renderer/orchestration/page-browser-graph-contribution.loader.ts
+++ b/packages/core/src/route-renderer/orchestration/page-browser-graph-contribution.loader.ts
@@ -1,0 +1,23 @@
+import type {
+	EcoPageFile,
+	PageBrowserGraphContribution,
+	PageBrowserGraphContributionContext,
+} from '../../types/public-types.ts';
+
+/**
+ * Loads a page module once and collects declarative browser-graph requirements.
+ *
+ * @remarks
+ * Shared by route orchestration prep and the integration route-render adapter so
+ * page imports are not duplicated when both paths need the same contribution.
+ */
+export async function loadPageBrowserGraphContribution(
+	routeFile: string,
+	importPageFile: (file: string) => Promise<EcoPageFile>,
+	collectContribution: (
+		context: PageBrowserGraphContributionContext,
+	) => Promise<PageBrowserGraphContribution | undefined>,
+): Promise<PageBrowserGraphContribution | undefined> {
+	const pageModule = await importPageFile(routeFile);
+	return collectContribution({ file: routeFile, pageModule });
+}

--- a/packages/core/src/route-renderer/orchestration/route-html-finalization.service.ts
+++ b/packages/core/src/route-renderer/orchestration/route-html-finalization.service.ts
@@ -1,0 +1,53 @@
+import type { HtmlDocumentContribution } from '../../services/html/html-transformer.service.ts';
+import type { IntegrationRendererRenderOptions } from '../../types/public-types.ts';
+import type { RouteHtmlFinalization } from './route-render-orchestrator.ts';
+
+export type RouteHtmlFinalizationContext<C> = {
+	renderOptions: IntegrationRendererRenderOptions<C>;
+	getDocumentAttributes: (renderOptions: IntegrationRendererRenderOptions<C>) => Record<string, string> | undefined;
+	getHtmlDocumentContributions: (options: {
+		renderOptions: IntegrationRendererRenderOptions<C>;
+		partial: boolean;
+	}) => HtmlDocumentContribution[] | undefined;
+	applyAttributesToFirstBodyElement: (html: string, attributes: Record<string, string>) => string;
+	applyAttributesToHtmlElement: (html: string, attributes: Record<string, string>) => string;
+};
+
+/**
+ * Builds the structural HTML finalization plan for one prepared route render.
+ */
+export function buildRouteHtmlFinalization<C>(context: RouteHtmlFinalizationContext<C>): RouteHtmlFinalization {
+	const { renderOptions } = context;
+	const componentRootAttributes =
+		renderOptions.componentRender?.canAttachAttributes &&
+		renderOptions.componentRender.rootAttributes &&
+		Object.keys(renderOptions.componentRender.rootAttributes).length > 0
+			? (renderOptions.componentRender.rootAttributes as Record<string, string>)
+			: undefined;
+	const documentAttributes = context.getDocumentAttributes(renderOptions);
+	const htmlContributions = context.getHtmlDocumentContributions({ renderOptions, partial: false });
+	const hasStructuralFinalization =
+		(componentRootAttributes && Object.keys(componentRootAttributes).length > 0) ||
+		(documentAttributes && Object.keys(documentAttributes).length > 0);
+
+	if (!hasStructuralFinalization && (!htmlContributions || htmlContributions.length === 0)) {
+		return {};
+	}
+
+	return {
+		htmlContributions,
+		finalizeHtml: (html) => {
+			let renderedHtml = html;
+
+			if (componentRootAttributes) {
+				renderedHtml = context.applyAttributesToFirstBodyElement(renderedHtml, componentRootAttributes);
+			}
+
+			if (documentAttributes) {
+				renderedHtml = context.applyAttributesToHtmlElement(renderedHtml, documentAttributes);
+			}
+
+			return renderedHtml;
+		},
+	};
+}


### PR DESCRIPTION
## Summary
- Extract `createIntegrationRouteRenderAdapter` and shared page-browser-graph contribution loading into dedicated orchestration modules.
- Move route HTML finalization planning into `buildRouteHtmlFinalization` so the orchestrator adapter owns that seam explicitly.
- Keep `mergePageBrowserGraphIntoPagePackage` on `IntegrationRenderer` and reuse one adapter instance across `prepareRenderOptions` and `executePrepared`.

## Test plan
- [x] `pnpm exec vitest run packages/core/src/route-renderer/orchestration/integration-renderer.test.ts`
- [x] `pnpm exec vitest run packages/core/src/route-renderer/orchestration/route-render-orchestrator.test.ts`
- [x] `pnpm exec vitest run packages/core/src/route-renderer/orchestration/route-render-orchestrator.prepare-render-options.test.ts`
- [x] `pnpm exec vitest run packages/integrations/react/src/react-renderer.locals.test.ts`