### PR TITLE
test(route-renderer): fix graph collector test typecheck

### DIFF
--- a/packages/core/src/route-renderer/orchestration/component-graph-collectors.test.ts
+++ b/packages/core/src/route-renderer/orchestration/component-graph-collectors.test.ts
@@ -35,7 +35,10 @@ test('collectIntegrationNamesFromGraph walks nested dependency components', () =
 });
 
 test('collectResolvedLazyTriggersFromGraph collects triggers from nested components', () => {
-	const trigger = { id: 'lazy-a' } as ResolvedLazyTrigger;
+	const trigger: ResolvedLazyTrigger = {
+		triggerId: 'lazy-a',
+		rules: [{ 'on:idle': { scripts: ['/lazy-a.js'] } }],
+	};
 	const root = createComponent({
 		children: [createComponent({ triggers: [trigger] })],
 	});


### PR DESCRIPTION
## Summary
- Replace invalid `{ id }` lazy-trigger stub with a `ResolvedLazyTrigger` shape (`triggerId` + `rules`) so `packages/core` typecheck passes.

## Test plan
- [x] `cd packages/core && bunx tsc --noEmit`