### PR TITLE
refactor(core): trim dead processor/integration plugin API

### DIFF
--- a/packages/core/src/plugins/integration-plugin.ts
+++ b/packages/core/src/plugins/integration-plugin.ts
@@ -291,7 +291,6 @@ export abstract class IntegrationPlugin<C = EcoPagesElement> {
 	 * Renderers are cheap runtime objects. They receive the finalized app config,
 	 * a fresh asset-processing service, integration-global processed assets, and
 	 * any renderer module context supplied by the active runtime.
-			renderer.name ||= this.name;
 	 */
 	initializeRenderer(options?: { rendererModules?: unknown }): IntegrationRenderer<C> {
 		const renderer = new this.renderer(this.createRendererOptions(options));
@@ -343,8 +342,6 @@ export abstract class IntegrationPlugin<C = EcoPagesElement> {
 			this.integrationDependencies,
 			this.name,
 		);
-
-		this.initializeRenderer();
 	}
 
 	/**

--- a/packages/core/src/plugins/processor.test.ts
+++ b/packages/core/src/plugins/processor.test.ts
@@ -14,8 +14,6 @@ class TestProcessor extends Processor {
 	override async process(input: unknown, _filePath?: string): Promise<unknown> {
 		return input;
 	}
-
-	override async teardown(): Promise<void> {}
 }
 
 describe('Processor', () => {

--- a/packages/core/src/plugins/processor.ts
+++ b/packages/core/src/plugins/processor.ts
@@ -2,7 +2,6 @@ import path from 'node:path';
 import { fileSystem } from '@ecopages/file-system';
 import type { EcoBuildPlugin } from '../build/build-types.ts';
 import type { EcoPagesAppConfig, IClientBridge } from '../types/internal-types.ts';
-import type { AssetDefinition } from '../services/assets/asset-processing-service/assets.types.ts';
 import { DEFAULT_ECOPAGES_WORK_DIR } from '../config/constants.ts';
 import { GENERATED_BASE_PATHS } from '../config/constants.ts';
 import { deepMerge } from '../utils/deep-merge.ts';
@@ -95,7 +94,6 @@ export interface ProcessorContext {
  */
 export abstract class Processor<TOptions = Record<string, unknown>> {
 	readonly name: string;
-	protected dependencies: AssetDefinition[] = [];
 	protected context?: ProcessorContext;
 	protected options?: TOptions;
 	protected watchConfig?: ProcessorWatchConfig;
@@ -149,14 +147,28 @@ export abstract class Processor<TOptions = Record<string, unknown>> {
 	/**
 	 * Reports whether this processor's build inputs changed since the last
 	 * incremental static build.
+	 *
+	 * @remarks
+	 * No shipped processor overrides this today. Integrations and processors can
+	 * opt in when they own build inputs that should invalidate incremental static
+	 * exports without a full rebuild.
 	 */
 	didChange(): boolean {
 		return false;
 	}
 
 	abstract setup(): Promise<void>;
-	abstract teardown(): Promise<void>;
 	abstract process(input: unknown, filePath?: string): Promise<unknown>;
+
+	/**
+	 * Releases runtime resources owned by the processor.
+	 *
+	 * @remarks
+	 * Core does not call this hook today. Override only when a processor owns
+	 * watchers, compiler handles, or other resources that outlive individual
+	 * requests.
+	 */
+	async teardown(): Promise<void> {}
 
 	protected getCachePath(key: string): string {
 		return `${this.context?.cache}/${key}`;
@@ -183,10 +195,6 @@ export abstract class Processor<TOptions = Record<string, unknown>> {
 
 	getWatchConfig(): ProcessorWatchConfig | undefined {
 		return this.watchConfig;
-	}
-
-	getDependencies(): AssetDefinition[] {
-		return this.dependencies;
 	}
 
 	getName(): string {

--- a/packages/core/src/types/internal-types.ts
+++ b/packages/core/src/types/internal-types.ts
@@ -241,13 +241,5 @@ export interface EcoPagesFileSystemServerAdapter<ServerInstanceOptions = unknown
 		| Promise<{ router: RouteRegistry; server: unknown }>;
 }
 
-export interface ProcessorPlugin {
-	name: string;
-	description?: string;
-	setup(): Promise<void>;
-	process<T = unknown>(input: T): Promise<T>;
-	teardown?(): Promise<void>;
-}
-
 // Re-export HMR types from public-types for internal use
 export type { ClientBridgeEvent, DefaultHmrContext, IHmrManager, IClientBridge } from './public-types.ts';

--- a/packages/processors/image-processor/src/plugin.ts
+++ b/packages/processors/image-processor/src/plugin.ts
@@ -13,7 +13,6 @@ import {
 	type ProcessorConfig,
 	type ProcessorWatchConfig,
 } from '@ecopages/core/plugins/processor';
-import type { AssetDefinition } from '@ecopages/core/services/asset-processing-service';
 import { Logger } from '@ecopages/logger';
 import { createImagePlugin, createImagePluginBundler } from './image-plugins.ts';
 import { ImageProcessor } from './image-processor.ts';
@@ -217,7 +216,6 @@ export class ImageProcessorPlugin extends Processor<ImageProcessorConfig> {
 			this.watchConfig.paths = [config.sourceDir];
 		}
 
-		this.dependencies = this.generateDependencies();
 		this.generateTypes();
 		this.buildContributionsPrepared = true;
 	}
@@ -280,34 +278,7 @@ export class ImageProcessorPlugin extends Processor<ImageProcessorConfig> {
 		}
 
 		this.replaceProcessedImages(await this.processor.processDirectory());
-		this.dependencies = this.generateDependencies();
 		this.generateTypes();
-	}
-
-	/**
-	 * Generate dependencies for processor.
-	 * It is ossible to define which one should be included in the final bundle based on the environment.
-	 * @returns
-	 */
-	private generateDependencies(): AssetDefinition[] {
-		const deps: AssetDefinition[] = [];
-
-		if (process.env.NODE_ENV === 'development') {
-			/**
-			 * Here we can define the dependencies for the development environment
-			 * @example
-			 * deps.push(
-			 *   AssetFactory.createInlineScriptAsset({
-			 *     content: `document.addEventListener("DOMContentLoaded",() => console.log("[@ecopages/image-processor] Processor is loaded"));`,
-			 *     attributes: {
-			 *       type: 'module',
-			 *     },
-			 *   }),
-			 * );
-			 */
-		}
-
-		return deps;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Remove unused `Processor` dependency tracking and orphaned `ProcessorPlugin` interface
- Make processor `teardown()` optional with a documented default no-op
- Fix corrupted `initializeRenderer()` JSDoc and stop warming renderers in `setup()`

## Test plan
- [x] `vitest run packages/core/src/plugins/processor.test.ts packages/core/src/plugins/integration-plugin.test.ts packages/core/src/build/build-input-fingerprint.test.ts packages/core/src/static-site-generator/static-build-invalidation.test.ts packages/processors/image-processor/src/test/plugin.test.ts`

## Dependencies
None