### PR TITLE
refactor(core): extract shared stylesheet processor pipeline

### DIFF
--- a/packages/core/src/services/assets/asset-processing-service/processors/stylesheet/content-stylesheet.processor.ts
+++ b/packages/core/src/services/assets/asset-processing-service/processors/stylesheet/content-stylesheet.processor.ts
@@ -2,52 +2,12 @@ import path from 'node:path';
 import { fileSystem } from '@ecopages/file-system';
 import type { ContentStylesheetAsset, ProcessedAsset } from '../../assets.types.ts';
 import { BaseProcessor } from '../base/base-processor.ts';
+import { applyStylesheetProcessors } from './stylesheet-processor-pipeline.ts';
 
 export class ContentStylesheetProcessor extends BaseProcessor<ContentStylesheetAsset> {
-	private static readonly PROCESSABLE_STYLESHEET_EXTENSIONS = new Set(['.css', '.scss', '.sass', '.less']);
-
-	private isProcessableStylesheet(filepath: string): boolean {
-		return ContentStylesheetProcessor.PROCESSABLE_STYLESHEET_EXTENSIONS.has(path.extname(filepath));
-	}
-
-	private async applyStylesheetProcessors(content: string, filepath: string): Promise<string> {
-		if (!this.isProcessableStylesheet(filepath)) {
-			return content;
-		}
-
-		let transformedContent = content;
-		const processors = this.appConfig.processors ? Array.from(this.appConfig.processors.values()) : [];
-
-		for (const processor of processors) {
-			const hasCapabilities = processor.getAssetCapabilities().length > 0;
-			const canProcessStylesheet = processor.canProcessAsset('stylesheet', filepath);
-
-			if (!canProcessStylesheet && (hasCapabilities || !processor.getName().includes('postcss'))) {
-				continue;
-			}
-
-			if (!processor.matchesFileFilter(filepath)) {
-				continue;
-			}
-
-			const result = await processor.process(transformedContent, filepath);
-
-			if (typeof result === 'string') {
-				transformedContent = result;
-				continue;
-			}
-
-			if (result instanceof Buffer) {
-				transformedContent = result.toString();
-			}
-		}
-
-		return transformedContent;
-	}
-
 	async process(dep: ContentStylesheetAsset): Promise<ProcessedAsset> {
 		const virtualFilepath = path.join(this.appConfig.absolutePaths.distDir, 'styles', 'page-bundle.css');
-		const processedContent = await this.applyStylesheetProcessors(dep.content, virtualFilepath);
+		const processedContent = await applyStylesheetProcessors(this.appConfig, dep.content, virtualFilepath);
 		const hash = this.generateHash(processedContent);
 		const filename = `style-${hash}.css`;
 		const cachekey = this.buildCacheKey(filename, hash, dep);

--- a/packages/core/src/services/assets/asset-processing-service/processors/stylesheet/file-stylesheet.processor.ts
+++ b/packages/core/src/services/assets/asset-processing-service/processors/stylesheet/file-stylesheet.processor.ts
@@ -2,56 +2,17 @@ import path from 'node:path';
 import { fileSystem } from '@ecopages/file-system';
 import type { FileStylesheetAsset, ProcessedAsset } from '../../assets.types.ts';
 import { BaseProcessor } from '../base/base-processor.ts';
+import { applyStylesheetProcessors } from './stylesheet-processor-pipeline.ts';
 
 export class FileStylesheetProcessor extends BaseProcessor<FileStylesheetAsset> {
-	private static readonly PROCESSABLE_STYLESHEET_EXTENSIONS = new Set(['.css', '.scss', '.sass', '.less']);
-
 	getStyleContent = (srcUrl: string): Buffer => {
 		return fileSystem.readFileAsBuffer(srcUrl);
 	};
 
-	private isProcessableStylesheet(filepath: string): boolean {
-		return FileStylesheetProcessor.PROCESSABLE_STYLESHEET_EXTENSIONS.has(path.extname(filepath));
-	}
-
-	private async applyStylesheetProcessors(content: string, filepath: string): Promise<string> {
-		if (!this.isProcessableStylesheet(filepath)) {
-			return content;
-		}
-
-		let transformedContent = content;
-
-		for (const processor of this.appConfig.processors.values()) {
-			const hasCapabilities = processor.getAssetCapabilities().length > 0;
-			const canProcessStylesheet = processor.canProcessAsset('stylesheet', filepath);
-
-			if (!canProcessStylesheet && (hasCapabilities || !processor.getName().includes('postcss'))) {
-				continue;
-			}
-
-			if (!processor.matchesFileFilter(filepath)) {
-				continue;
-			}
-
-			const result = await processor.process(transformedContent, filepath);
-
-			if (typeof result === 'string') {
-				transformedContent = result;
-				continue;
-			}
-
-			if (result instanceof Buffer) {
-				transformedContent = result.toString();
-			}
-		}
-
-		return transformedContent;
-	}
-
 	async process(dep: FileStylesheetAsset): Promise<ProcessedAsset> {
 		const buffer = this.getStyleContent(dep.filepath);
 		const rawContent = buffer.toString();
-		const processedContent = await this.applyStylesheetProcessors(rawContent, dep.filepath);
+		const processedContent = await applyStylesheetProcessors(this.appConfig, rawContent, dep.filepath);
 		const hash = this.generateHash(processedContent);
 		const cachekey = this.buildCacheKey(dep.filepath, hash, dep);
 

--- a/packages/core/src/services/assets/asset-processing-service/processors/stylesheet/stylesheet-processor-pipeline.ts
+++ b/packages/core/src/services/assets/asset-processing-service/processors/stylesheet/stylesheet-processor-pipeline.ts
@@ -1,0 +1,67 @@
+import path from 'node:path';
+import type { EcoPagesAppConfig } from '../../../../../types/internal-types.ts';
+import type { Processor } from '../../../../../plugins/processor.ts';
+
+const PROCESSABLE_STYLESHEET_EXTENSIONS = new Set(['.css', '.scss', '.sass', '.less']);
+
+function isProcessableStylesheet(filepath: string): boolean {
+	return PROCESSABLE_STYLESHEET_EXTENSIONS.has(path.extname(filepath));
+}
+
+/**
+ * Legacy fallback for processors that transform stylesheets without declaring
+ * capabilities (notably PostCSS before capability metadata was required).
+ */
+function shouldRunStylesheetProcessor(
+	processor: Processor,
+	filepath: string,
+): boolean {
+	const hasCapabilities = processor.getAssetCapabilities().length > 0;
+	const canProcessStylesheet = processor.canProcessAsset('stylesheet', filepath);
+
+	if (canProcessStylesheet) {
+		return true;
+	}
+
+	if (hasCapabilities) {
+		return false;
+	}
+
+	return processor.getName().includes('postcss');
+}
+
+export async function applyStylesheetProcessors(
+	appConfig: EcoPagesAppConfig,
+	content: string,
+	filepath: string,
+): Promise<string> {
+	if (!isProcessableStylesheet(filepath)) {
+		return content;
+	}
+
+	let transformedContent = content;
+	const processors = appConfig.processors ? Array.from(appConfig.processors.values()) : [];
+
+	for (const processor of processors) {
+		if (!shouldRunStylesheetProcessor(processor, filepath)) {
+			continue;
+		}
+
+		if (!processor.matchesFileFilter(filepath)) {
+			continue;
+		}
+
+		const result = await processor.process(transformedContent, filepath);
+
+		if (typeof result === 'string') {
+			transformedContent = result;
+			continue;
+		}
+
+		if (result instanceof Buffer) {
+			transformedContent = result.toString();
+		}
+	}
+
+	return transformedContent;
+}


### PR DESCRIPTION
## Summary
- Extract duplicated `applyStylesheetProcessors` logic into `stylesheet-processor-pipeline.ts`
- Isolate the legacy PostCSS name fallback in one documented predicate

## Test plan
- [x] `vitest run packages/core/src/services/assets/asset-processing-service/processors/stylesheet/`

## Dependencies
None