### PR TITLE
refactor(integrations): consolidate MDX loaders into mdx-core

### DIFF
--- a/packages/integrations/ecopages-jsx/package.json
+++ b/packages/integrations/ecopages-jsx/package.json
@@ -42,6 +42,7 @@
 		"remark-gfm": "^4.0.1"
 	},
 	"dependencies": {
+		"@ecopages/mdx-core": "workspace:*",
 		"@mdx-js/mdx": "^3.1.1",
 		"vfile": "^6.0.3"
 	},

--- a/packages/integrations/ecopages-jsx/src/ecopages-jsx-mdx.ts
+++ b/packages/integrations/ecopages-jsx/src/ecopages-jsx-mdx.ts
@@ -1,15 +1,18 @@
 import { readFile } from 'node:fs/promises';
-import path from 'node:path';
 import type { CompileOptions } from '@mdx-js/mdx';
 import type { EcoComponent, EcoComponentConfig, EcoFunctionComponent, EcoPageFile, GetMetadata } from '@ecopages/core';
 import { rapidhash } from '@ecopages/core/hash';
 import type { EcoBuildPlugin } from '@ecopages/core/plugins/integration-plugin';
+import {
+	appendMdxExtensions,
+	createMdxExtensionFilter,
+	createMdxLoaderPlugin as createMdxLoaderPluginCore,
+	resolveMdxCompilerOptions as resolveMdxCompilerOptionsCore,
+} from '@ecopages/mdx-core';
 import type { JsxRenderable } from '@ecopages/jsx';
 import { VFile } from 'vfile';
 import { ECOPAGES_JSX_PLUGIN_NAME } from './ecopages-jsx.constants.ts';
 import type { EcopagesJsxMdxCompileOptions, EcopagesJsxMdxOptions } from './ecopages-jsx.types.ts';
-
-type MdxPluginList = NonNullable<CompileOptions['remarkPlugins']>;
 
 export type ResolvedMdxCompileOptions = EcopagesJsxMdxCompileOptions &
 	Pick<CompileOptions, 'jsxImportSource' | 'jsxRuntime'>;
@@ -22,73 +25,28 @@ export type EcopagesJsxMdxPageModule = EcoPageFile<{
 	getMetadata?: GetMetadata;
 }>;
 
-const escapeRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+export { appendMdxExtensions, createMdxExtensionFilter };
 
-const mergePluginLists = <T>(...lists: Array<readonly T[] | null | undefined>): T[] | undefined => {
-	const merged = lists.flatMap((list) => (list ? [...list] : []));
-	return merged.length > 0 ? merged : undefined;
-};
-
-export const createMdxExtensionFilter = (extensions: string[], options?: { allowQueryString?: boolean }): RegExp => {
-	const escaped = extensions.map(escapeRegex);
-	const suffix = options?.allowQueryString ? '(\\?.*)?$' : '$';
-	return new RegExp(`(${escaped.join('|')})${suffix}`);
-};
-
-export const appendMdxExtensions = (target: string[], mdxExtensions: string[]): void => {
-	for (const ext of mdxExtensions) {
-		if (!target.includes(ext)) {
-			target.push(ext);
-		}
-	}
-};
-
-export const resolveMdxCompilerOptions = (mdxOptions: EcopagesJsxMdxOptions): ResolvedMdxCompileOptions => {
-	const { compilerOptions, remarkPlugins, rehypePlugins, recmaPlugins } = mdxOptions;
-	const resolved: ResolvedMdxCompileOptions = {
-		format: 'detect',
-		outputFormat: 'program',
-		...compilerOptions,
+export const resolveMdxCompilerOptions = (mdxOptions: EcopagesJsxMdxOptions): ResolvedMdxCompileOptions =>
+	resolveMdxCompilerOptionsCore(mdxOptions, {
 		jsxImportSource: '@ecopages/jsx',
-		jsxRuntime: 'automatic',
-		development: process.env.NODE_ENV === 'development',
-	};
-
-	const mergedRemark = mergePluginLists<MdxPluginList[number]>(compilerOptions?.remarkPlugins, remarkPlugins);
-	const mergedRehype = mergePluginLists<MdxPluginList[number]>(compilerOptions?.rehypePlugins, rehypePlugins);
-	const mergedRecma = mergePluginLists<MdxPluginList[number]>(compilerOptions?.recmaPlugins, recmaPlugins);
-
-	if (mergedRemark) resolved.remarkPlugins = mergedRemark;
-	if (mergedRehype) resolved.rehypePlugins = mergedRehype;
-	if (mergedRecma) resolved.recmaPlugins = mergedRecma;
-
-	return resolved;
-};
+		defaults: {
+			format: 'detect',
+			outputFormat: 'program',
+		},
+	}) as ResolvedMdxCompileOptions;
 
 export const createMdxLoaderPlugin = (
 	compilerOptions: ResolvedMdxCompileOptions,
 	extensions: string[],
-): EcoBuildPlugin => {
-	const filter = createMdxExtensionFilter(extensions, { allowQueryString: true });
-
-	return {
+): EcoBuildPlugin =>
+	createMdxLoaderPluginCore({
 		name: 'ecopages-jsx-mdx-loader',
-		setup(build) {
-			build.onLoad({ filter }, async (args) => {
-				const { compile } = await import('@mdx-js/mdx');
-				const filePath = args.path.includes('?') ? args.path.split('?')[0] : args.path;
-				const source = await readFile(filePath, 'utf-8');
-				const compiled = await compile(new VFile({ value: source, path: filePath }), compilerOptions);
-
-				return {
-					contents: String(compiled.value),
-					loader: 'js',
-					resolveDir: path.dirname(filePath),
-				};
-			});
-		},
-	};
-};
+		compilerOptions,
+		extensions,
+		includeSourceMap: false,
+		loader: 'js',
+	});
 
 export const registerBunMdxPlugin = async (
 	compilerOptions: ResolvedMdxCompileOptions,

--- a/packages/integrations/mdx-core/package.json
+++ b/packages/integrations/mdx-core/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "@ecopages/mdx-core",
+	"version": "0.2.0-beta.9",
+	"description": "Shared MDX loader utilities for Ecopages integrations",
+	"license": "MIT",
+	"type": "module",
+	"private": true,
+	"exports": {
+		".": {
+			"default": "./src/index.ts",
+			"types": "./src/index.ts"
+		}
+	},
+	"files": [
+		"src"
+	],
+	"scripts": {
+		"typecheck": "tsc --noEmit"
+	},
+	"peerDependencies": {
+		"@ecopages/core": "workspace:*",
+		"@mdx-js/mdx": "^3.1.0"
+	},
+	"dependencies": {
+		"source-map": "^0.7.6",
+		"vfile": "^6.0.3"
+	},
+	"devDependencies": {
+		"@ecopages/core": "workspace:*"
+	}
+}

--- a/packages/integrations/mdx-core/src/index.ts
+++ b/packages/integrations/mdx-core/src/index.ts
@@ -1,0 +1,10 @@
+export { createMdxLoaderPlugin, type CreateMdxLoaderPluginOptions } from './mdx-loader-plugin.ts';
+export {
+	appendMdxExtensions,
+	createMdxExtensionFilter,
+	mergePluginLists,
+	resolveCompileFormat,
+	resolveLoaderExtensions,
+	resolveMdxCompilerOptions,
+	type MdxCompilerOptionsInput,
+} from './mdx-utils.ts';

--- a/packages/integrations/mdx-core/src/mdx-loader-plugin.ts
+++ b/packages/integrations/mdx-core/src/mdx-loader-plugin.ts
@@ -1,0 +1,58 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { EcoBuildPlugin } from '@ecopages/core/plugins/integration-plugin';
+import { type CompileOptions, compile } from '@mdx-js/mdx';
+import sourceMap from 'source-map';
+import { VFile } from 'vfile';
+import { createMdxExtensionFilter, resolveCompileFormat, resolveLoaderExtensions } from './mdx-utils.ts';
+
+export interface CreateMdxLoaderPluginOptions {
+	name: string;
+	compilerOptions?: CompileOptions;
+	extensions?: string[];
+	defaultMdExtensions?: string[];
+	includeSourceMap?: boolean;
+	loader?: 'js' | 'jsx';
+}
+
+export function createMdxLoaderPlugin(options: CreateMdxLoaderPluginOptions): EcoBuildPlugin {
+	const {
+		name,
+		compilerOptions,
+		extensions = resolveLoaderExtensions(compilerOptions, {
+			defaultMdExtensions: options.defaultMdExtensions,
+		}),
+		includeSourceMap = true,
+		loader = compilerOptions?.jsx ? 'jsx' : 'js',
+	} = options;
+
+	const filter = createMdxExtensionFilter(extensions, { allowQueryString: true });
+
+	return {
+		name,
+		setup(build) {
+			build.onLoad({ filter }, async (args) => {
+				const filePath = args.path.includes('?') ? args.path.split('?')[0] : args.path;
+				const source = await readFile(filePath, 'utf-8');
+				const file = new VFile({ path: filePath, value: source });
+
+				const compiled = await compile(file, {
+					...compilerOptions,
+					format: resolveCompileFormat(filePath, compilerOptions),
+					SourceMapGenerator: sourceMap.SourceMapGenerator,
+				});
+
+				const inlineSourceMap =
+					includeSourceMap && compiled.map
+						? `\n//# sourceMappingURL=data:application/json;base64,${Buffer.from(JSON.stringify(compiled.map)).toString('base64')}\n`
+						: '';
+
+				return {
+					contents: `${String(compiled.value)}${inlineSourceMap}`,
+					loader,
+					resolveDir: path.dirname(args.path),
+				};
+			});
+		},
+	};
+}

--- a/packages/integrations/mdx-core/src/mdx-utils.ts
+++ b/packages/integrations/mdx-core/src/mdx-utils.ts
@@ -1,0 +1,88 @@
+import path from 'node:path';
+import type { CompileOptions } from '@mdx-js/mdx';
+
+export interface MdxCompilerOptionsInput {
+	compilerOptions?: CompileOptions;
+	remarkPlugins?: CompileOptions['remarkPlugins'];
+	rehypePlugins?: CompileOptions['rehypePlugins'];
+	recmaPlugins?: CompileOptions['recmaPlugins'];
+}
+
+export const mergePluginLists = <T>(...lists: Array<readonly T[] | null | undefined>): T[] | undefined => {
+	const merged = lists.flatMap((list) => (list ? [...list] : []));
+	return merged.length > 0 ? merged : undefined;
+};
+
+export const appendMdxExtensions = (target: string[], mdxExtensions: string[]): void => {
+	for (const extension of mdxExtensions) {
+		if (!target.includes(extension)) {
+			target.push(extension);
+		}
+	}
+};
+
+const escapeRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const createMdxExtensionFilter = (extensions: string[], options?: { allowQueryString?: boolean }): RegExp => {
+	const escaped = extensions.map(escapeRegex);
+	const suffix = options?.allowQueryString ? '(\\?.*)?$' : '$';
+	return new RegExp(`(${escaped.join('|')})${suffix}`);
+};
+
+export function resolveLoaderExtensions(
+	compilerOptions?: CompileOptions,
+	options?: { defaultMdExtensions?: string[] },
+): string[] {
+	const mdxExtensions = compilerOptions?.mdxExtensions ?? ['.mdx'];
+	const mdExtensions = compilerOptions?.mdExtensions ?? options?.defaultMdExtensions ?? [];
+	return [...mdxExtensions, ...mdExtensions];
+}
+
+/**
+ * Resolves the MDX parser mode for a source file.
+ *
+ * Files with a `.md` extension must be forced into `mdx` mode when the caller
+ * explicitly opts them into the MDX pipeline. Leaving the compiler in `detect`
+ * mode would treat `.md` files as plain markdown, causing top-level ESM such as
+ * `import` and `export` to render as text instead of being compiled.
+ */
+export function resolveCompileFormat(
+	filePath: string,
+	compilerOptions?: CompileOptions,
+): CompileOptions['format'] {
+	const configuredFormat = compilerOptions?.format;
+
+	if (configuredFormat && configuredFormat !== 'detect') {
+		return configuredFormat;
+	}
+
+	return path.extname(filePath).toLowerCase() === '.md' ? 'mdx' : configuredFormat;
+}
+
+export function resolveMdxCompilerOptions(
+	mdxOptions: MdxCompilerOptionsInput,
+	options: {
+		jsxImportSource: string;
+		jsxRuntime?: CompileOptions['jsxRuntime'];
+		defaults?: CompileOptions;
+	},
+): CompileOptions {
+	const { compilerOptions, remarkPlugins, rehypePlugins, recmaPlugins } = mdxOptions;
+	const resolved: CompileOptions = {
+		...options.defaults,
+		...compilerOptions,
+		jsxImportSource: options.jsxImportSource,
+		jsxRuntime: options.jsxRuntime ?? 'automatic',
+		development: process.env.NODE_ENV === 'development',
+	};
+
+	const mergedRemark = mergePluginLists(compilerOptions?.remarkPlugins, remarkPlugins);
+	const mergedRehype = mergePluginLists(compilerOptions?.rehypePlugins, rehypePlugins);
+	const mergedRecma = mergePluginLists(compilerOptions?.recmaPlugins, recmaPlugins);
+
+	if (mergedRemark) resolved.remarkPlugins = mergedRemark;
+	if (mergedRehype) resolved.rehypePlugins = mergedRehype;
+	if (mergedRecma) resolved.recmaPlugins = mergedRecma;
+
+	return resolved;
+}

--- a/packages/integrations/mdx-core/tsconfig.json
+++ b/packages/integrations/mdx-core/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"allowImportingTsExtensions": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"target": "ES2021",
+		"verbatimModuleSyntax": true
+	}
+}

--- a/packages/integrations/mdx/package.json
+++ b/packages/integrations/mdx/package.json
@@ -43,6 +43,7 @@
 	},
 	"dependencies": {
 		"@ecopages/logger": "^0.2.3",
+		"@ecopages/mdx-core": "workspace:*",
 		"source-map": "^0.7.6",
 		"vfile": "^6.0.3"
 	},

--- a/packages/integrations/mdx/src/mdx-loader-plugin.ts
+++ b/packages/integrations/mdx/src/mdx-loader-plugin.ts
@@ -1,63 +1,10 @@
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
-import type { EcoBuildPlugin } from '@ecopages/core/plugins/integration-plugin';
-import { type CompileOptions, compile } from '@mdx-js/mdx';
-import sourceMap from 'source-map';
-import { VFile } from 'vfile';
+import type { CompileOptions } from '@mdx-js/mdx';
+import { createMdxLoaderPlugin as createMdxLoaderPluginCore } from '@ecopages/mdx-core';
 
-/**
- * Resolves the MDX parser mode for a source file.
- *
- * Files with a `.md` extension must be forced into `mdx` mode when the caller
- * explicitly opts them into the MDX pipeline. Leaving the compiler in `detect`
- * mode would treat `.md` files as plain markdown, causing top-level ESM such as
- * `import` and `export` to render as text instead of being compiled.
- *
- * @param filePath Absolute or relative source file path.
- * @param compilerOptions User-provided MDX compiler options.
- * @returns The compile format that should be passed to `@mdx-js/mdx`.
- */
-function resolveCompileFormat(filePath: string, compilerOptions?: CompileOptions): CompileOptions['format'] {
-	const configuredFormat = compilerOptions?.format;
-
-	if (configuredFormat && configuredFormat !== 'detect') {
-		return configuredFormat;
-	}
-
-	return path.extname(filePath).toLowerCase() === '.md' ? 'mdx' : configuredFormat;
-}
-
-export function createMdxLoaderPlugin(compilerOptions?: CompileOptions): EcoBuildPlugin {
-	const mdxExtensions = compilerOptions?.mdxExtensions ?? ['.mdx'];
-	const mdExtensions = compilerOptions?.mdExtensions ?? ['.md'];
-	const allExtensions = [...mdxExtensions, ...mdExtensions];
-	const escapedExts = allExtensions.map((ext) => ext.replace('.', '\\.'));
-	const filter = new RegExp(`(${escapedExts.join('|')})(\\?.*)?$`);
-
-	return {
+export function createMdxLoaderPlugin(compilerOptions?: CompileOptions) {
+	return createMdxLoaderPluginCore({
 		name: 'mdx-loader',
-		setup(build) {
-			build.onLoad({ filter }, async (args) => {
-				const filePath = args.path.includes('?') ? args.path.split('?')[0] : args.path;
-				const source = readFileSync(filePath, 'utf-8');
-				const file = new VFile({ path: filePath, value: source });
-
-				const compiled = await compile(file, {
-					...compilerOptions,
-					format: resolveCompileFormat(filePath, compilerOptions),
-					SourceMapGenerator: sourceMap.SourceMapGenerator,
-				});
-
-				const inlineSourceMap = compiled.map
-					? `\n//# sourceMappingURL=data:application/json;base64,${Buffer.from(JSON.stringify(compiled.map)).toString('base64')}\n`
-					: '';
-
-				return {
-					contents: `${String(compiled.value)}${inlineSourceMap}`,
-					loader: compilerOptions?.jsx ? 'jsx' : 'js',
-					resolveDir: path.dirname(args.path),
-				};
-			});
-		},
-	};
+		compilerOptions,
+		defaultMdExtensions: ['.md'],
+	});
 }

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -50,6 +50,7 @@
 	"dependencies": {
 		"@ecopages/file-system": "workspace:*",
 		"@ecopages/logger": "^0.2.3",
+		"@ecopages/mdx-core": "workspace:*",
 		"@mdx-js/mdx": "^3.1.1",
 		"oxc-parser": "^0.124.0",
 		"oxc-transform": "^0.124.0",

--- a/packages/integrations/react/src/react.plugin.ts
+++ b/packages/integrations/react/src/react.plugin.ts
@@ -22,6 +22,7 @@ import type { ReactRouterAdapter } from './router-adapter.ts';
 import { ReactRuntimeBundleService } from './services/react-runtime-bundle.service.ts';
 import { ReactHmrPageMetadataCache } from './services/react-hmr-page-metadata-cache.ts';
 import { createReactMdxLoaderPlugin } from './utils/react-mdx-loader-plugin.ts';
+import { appendMdxExtensions, resolveMdxCompilerOptions } from '@ecopages/mdx-core';
 import { ClientGraphBoundaryCache } from './utils/client-graph-boundary-cache.ts';
 
 export type { ReactMdxOptions, ReactPluginOptions, ReactRendererConfig } from './react.types.ts';
@@ -42,44 +43,8 @@ type ResolvedReactPluginConfig = Omit<
  */
 export const PLUGIN_NAME = REACT_PLUGIN_NAME;
 
-const mergePluginLists = <T>(...lists: Array<readonly T[] | null | undefined>): T[] | undefined => {
-	const merged = lists.flatMap((list) => (list ? [...list] : []));
-	return merged.length > 0 ? merged : undefined;
-};
-
-const appendMdxExtensions = (target: string[], mdxExtensions: string[]): void => {
-	for (const extension of mdxExtensions) {
-		if (!target.includes(extension)) {
-			target.push(extension);
-		}
-	}
-};
-
-/**
- * Resolves MDX compiler options for the React integration.
- *
- * React owns the JSX runtime fields for MDX route compilation so mixed route
- * graphs keep the same runtime contract as authored React page modules.
- */
-const resolveReactMdxCompilerOptions = (mdxOptions: ReactMdxOptions): CompileOptions => {
-	const { compilerOptions, remarkPlugins, rehypePlugins, recmaPlugins } = mdxOptions;
-	const resolved: CompileOptions = {
-		...compilerOptions,
-		jsxImportSource: 'react',
-		jsxRuntime: 'automatic',
-		development: process.env.NODE_ENV === 'development',
-	};
-
-	const mergedRemark = mergePluginLists(compilerOptions?.remarkPlugins, remarkPlugins);
-	const mergedRehype = mergePluginLists(compilerOptions?.rehypePlugins, rehypePlugins);
-	const mergedRecma = mergePluginLists(compilerOptions?.recmaPlugins, recmaPlugins);
-
-	if (mergedRemark) resolved.remarkPlugins = mergedRemark;
-	if (mergedRehype) resolved.rehypePlugins = mergedRehype;
-	if (mergedRecma) resolved.recmaPlugins = mergedRecma;
-
-	return resolved;
-};
+const resolveReactMdxCompilerOptions = (mdxOptions: ReactMdxOptions): CompileOptions =>
+	resolveMdxCompilerOptions(mdxOptions, { jsxImportSource: 'react' });
 
 /**
  * Resolves user-facing React plugin options into the internal plugin config.

--- a/packages/integrations/react/src/utils/react-mdx-loader-plugin.ts
+++ b/packages/integrations/react/src/utils/react-mdx-loader-plugin.ts
@@ -1,63 +1,10 @@
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
-import type { EcoBuildPlugin } from '@ecopages/core/plugins/integration-plugin';
-import { type CompileOptions, compile } from '@mdx-js/mdx';
-import sourceMap from 'source-map';
-import { VFile } from 'vfile';
+import type { CompileOptions } from '@mdx-js/mdx';
+import { createMdxLoaderPlugin as createMdxLoaderPluginCore } from '@ecopages/mdx-core';
 
-/**
- * Resolves the MDX parser mode for a React-backed MDX source file.
- *
- * When `.md` files are explicitly opted into the React MDX loader they still
- * need to compile as MDX, not plain markdown. Otherwise top-level ESM exports
- * like `config` are treated as literal text and the route cannot execute as a
- * page module.
- *
- * @param filePath Absolute or relative source file path.
- * @param compilerOptions User-provided MDX compiler options.
- * @returns The compile format that should be passed to `@mdx-js/mdx`.
- */
-function resolveCompileFormat(filePath: string, compilerOptions?: CompileOptions): CompileOptions['format'] {
-	const configuredFormat = compilerOptions?.format;
-
-	if (configuredFormat && configuredFormat !== 'detect') {
-		return configuredFormat;
-	}
-
-	return path.extname(filePath).toLowerCase() === '.md' ? 'mdx' : configuredFormat;
-}
-
-export function createReactMdxLoaderPlugin(compilerOptions?: CompileOptions): EcoBuildPlugin {
-	const mdxExtensions = compilerOptions?.mdxExtensions ?? ['.mdx'];
-	const mdExtensions = compilerOptions?.mdExtensions ?? [];
-	const allExtensions = [...mdxExtensions, ...mdExtensions];
-	const escapedExts = allExtensions.map((ext) => ext.replace('.', '\\.'));
-	const filter = new RegExp(`(${escapedExts.join('|')})(\\?.*)?$`);
-
-	return {
+export function createReactMdxLoaderPlugin(compilerOptions?: CompileOptions) {
+	return createMdxLoaderPluginCore({
 		name: 'react-mdx-loader',
-		setup(build) {
-			build.onLoad({ filter }, async (args) => {
-				const filePath = args.path.includes('?') ? args.path.split('?')[0] : args.path;
-				const source = readFileSync(filePath, 'utf-8');
-				const file = new VFile({ path: filePath, value: source });
-
-				const compiled = await compile(file, {
-					...compilerOptions,
-					format: resolveCompileFormat(filePath, compilerOptions),
-					SourceMapGenerator: sourceMap.SourceMapGenerator,
-				});
-
-				const inlineSourceMap = compiled.map
-					? `\n//# sourceMappingURL=data:application/json;base64,${Buffer.from(JSON.stringify(compiled.map)).toString('base64')}\n`
-					: '';
-
-				return {
-					contents: `${String(compiled.value)}${inlineSourceMap}`,
-					loader: compilerOptions?.jsx ? 'jsx' : 'js',
-					resolveDir: path.dirname(args.path),
-				};
-			});
-		},
-	};
+		compilerOptions,
+		defaultMdExtensions: [],
+	});
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,13155 +1,10362 @@
 lockfileVersion: '9.0'
 
 settings:
-    autoInstallPeers: true
-    excludeLinksFromLockfile: false
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
-    .:
-        devDependencies:
-            '@ecopages/logger':
-                specifier: ^0.2.3
-                version: 0.2.3(typescript@5.9.3)
-            '@playwright/test':
-                specifier: ^1.60.0
-                version: 1.60.0
-            '@testing-library/react':
-                specifier: ^16.3.2
-                version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-            '@testing-library/user-event':
-                specifier: ^14.6.1
-                version: 14.6.1(@testing-library/dom@10.4.1)
-            '@types/node':
-                specifier: ^24.12.4
-                version: 24.13.2
-            '@vitest/browser':
-                specifier: ^4.1.6
-                version: 4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
-            '@vitest/browser-playwright':
-                specifier: ^4.1.6
-                version: 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
-            better-commits:
-                specifier: ^1.23.0
-                version: 1.24.0(typescript@5.9.3)
-            esbuild:
-                specifier: ^0.28.0
-                version: 0.28.1
-            husky:
-                specifier: ^9.1.7
-                version: 9.1.7
-            lint-staged:
-                specifier: ^15.5.2
-                version: 15.5.2
-            oxlint:
-                specifier: ^1.64.0
-                version: 1.69.0
-            playwright:
-                specifier: ^1.60.0
-                version: 1.60.0
-            prettier:
-                specifier: ^3.8.3
-                version: 3.8.4
-            typescript:
-                specifier: ^5.9.3
-                version: 5.9.3
-            vite:
-                specifier: ^8.0.16
-                version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-            vitest:
-                specifier: ^4.1.6
-                version: 4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
-    apps/docs:
-        devDependencies:
-            '@ecopages/browser-router':
-                specifier: workspace:*
-                version: link:../../packages/browser-router
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../packages/core
-            '@ecopages/ecopages-jsx':
-                specifier: workspace:*
-                version: link:../../packages/integrations/ecopages-jsx
-            '@ecopages/image-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/image-processor
-            '@ecopages/jsx':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(typescript@5.9.3)
-            '@ecopages/mdx':
-                specifier: workspace:*
-                version: link:../../packages/integrations/mdx
-            '@ecopages/postcss-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/postcss-processor
-            '@ecopages/radiant':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
-            '@ecopages/signals':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(typescript@5.9.3)
-            '@mdx-js/mdx':
-                specifier: ^3.1.1
-                version: 3.1.1
-            '@rehype-pretty/transformers':
-                specifier: ^0.13.2
-                version: 0.13.2
-            '@tailwindcss/postcss':
-                specifier: ^4.3.0
-                version: 4.3.1
-            '@types/hast':
-                specifier: ^3.0.4
-                version: 3.0.4
-            '@types/mdast':
-                specifier: ^4.0.4
-                version: 4.0.4
-            ecopages:
-                specifier: workspace:*
-                version: link:../../packages/ecopages
-            lit:
-                specifier: ^3.3.3
-                version: 3.3.3
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
-            rehype:
-                specifier: ^13.0.2
-                version: 13.0.2
-            rehype-pretty-code:
-                specifier: ^0.14.3
-                version: 0.14.3(shiki@3.23.0)
-            rehype-raw:
-                specifier: ^7.0.0
-                version: 7.0.0
-            remark-gfm:
-                specifier: ^4.0.1
-                version: 4.0.1
-            shiki:
-                specifier: ^3.23.0
-                version: 3.23.0
-            tailwindcss:
-                specifier: ^4.3.0
-                version: 4.3.1
-            unified:
-                specifier: ^11.0.5
-                version: 11.0.5
-            unist-util-visit:
-                specifier: ^5.1.0
-                version: 5.1.0
+  .:
+    devDependencies:
+      '@ecopages/logger':
+        specifier: ^0.2.3
+        version: 0.2.3(typescript@5.9.3)
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.13.2
+      '@vitest/browser':
+        specifier: ^4.1.6
+        version: 4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.6
+        version: 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      better-commits:
+        specifier: ^1.23.0
+        version: 1.24.0(typescript@5.9.3)
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.1
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
+      lint-staged:
+        specifier: ^15.5.2
+        version: 15.5.2
+      oxlint:
+        specifier: ^1.64.0
+        version: 1.69.0
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.4
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
-    e2e/fixtures/browser-router-app:
-        dependencies:
-            '@mdx-js/mdx':
-                specifier: ^3.1.1
-                version: 3.1.1
-        devDependencies:
-            '@ecopages/browser-router':
-                specifier: workspace:*
-                version: link:../../../packages/browser-router
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../../packages/core
-            '@ecopages/kitajs':
-                specifier: workspace:*
-                version: link:../../../packages/integrations/kitajs
-            '@ecopages/mdx':
-                specifier: workspace:*
-                version: link:../../../packages/integrations/mdx
-            '@kitajs/html':
-                specifier: ^4.2.13
-                version: 4.2.13
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
+  apps/docs:
+    devDependencies:
+      '@ecopages/browser-router':
+        specifier: workspace:*
+        version: link:../../packages/browser-router
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@ecopages/ecopages-jsx':
+        specifier: workspace:*
+        version: link:../../packages/integrations/ecopages-jsx
+      '@ecopages/image-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/image-processor
+      '@ecopages/jsx':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(typescript@5.9.3)
+      '@ecopages/mdx':
+        specifier: workspace:*
+        version: link:../../packages/integrations/mdx
+      '@ecopages/postcss-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/postcss-processor
+      '@ecopages/radiant':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
+      '@ecopages/signals':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(typescript@5.9.3)
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
+      '@rehype-pretty/transformers':
+        specifier: ^0.13.2
+        version: 0.13.2
+      '@tailwindcss/postcss':
+        specifier: ^4.3.0
+        version: 4.3.1
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
+      ecopages:
+        specifier: workspace:*
+        version: link:../../packages/ecopages
+      lit:
+        specifier: ^3.3.3
+        version: 3.3.3
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
+      rehype:
+        specifier: ^13.0.2
+        version: 13.0.2
+      rehype-pretty-code:
+        specifier: ^0.14.3
+        version: 0.14.3(shiki@3.23.0)
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      shiki:
+        specifier: ^3.23.0
+        version: 3.23.0
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.1
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
 
-    e2e/fixtures/cache-app:
-        dependencies:
-            '@mdx-js/mdx':
-                specifier: ^3.1.1
-                version: 3.1.1
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../../packages/core
-            '@ecopages/mdx':
-                specifier: workspace:*
-                version: link:../../../packages/integrations/mdx
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
+  e2e/fixtures/browser-router-app:
+    dependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
+    devDependencies:
+      '@ecopages/browser-router':
+        specifier: workspace:*
+        version: link:../../../packages/browser-router
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      '@ecopages/kitajs':
+        specifier: workspace:*
+        version: link:../../../packages/integrations/kitajs
+      '@ecopages/mdx':
+        specifier: workspace:*
+        version: link:../../../packages/integrations/mdx
+      '@kitajs/html':
+        specifier: ^4.2.13
+        version: 4.2.13
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
 
-    e2e/fixtures/kitchen-sink-app:
-        dependencies:
-            '@mdx-js/mdx':
-                specifier: ^3.1.1
-                version: 3.1.1
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../../packages/core
-            '@ecopages/kitajs':
-                specifier: workspace:*
-                version: link:../../../packages/integrations/kitajs
-            '@ecopages/lit':
-                specifier: workspace:*
-                version: link:../../../packages/integrations/lit
-            '@ecopages/react':
-                specifier: workspace:*
-                version: link:../../../packages/integrations/react
-            '@ecopages/testing':
-                specifier: workspace:*
-                version: link:../../../packages/__internals/testing
-            '@kitajs/html':
-                specifier: ^4.2.13
-                version: 4.2.13
-            lit:
-                specifier: ^3.3.3
-                version: 3.3.3
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
+  e2e/fixtures/cache-app:
+    dependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      '@ecopages/mdx':
+        specifier: workspace:*
+        version: link:../../../packages/integrations/mdx
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
 
-    e2e/fixtures/react-router-app:
-        dependencies:
-            '@mdx-js/mdx':
-                specifier: ^3.1.1
-                version: 3.1.1
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../../packages/core
-            '@ecopages/mdx':
-                specifier: workspace:*
-                version: link:../../../packages/integrations/mdx
-            '@ecopages/react':
-                specifier: workspace:*
-                version: link:../../../packages/integrations/react
-            '@ecopages/react-router':
-                specifier: workspace:*
-                version: link:../../../packages/react-router
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
+  e2e/fixtures/kitchen-sink-app:
+    dependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      '@ecopages/kitajs':
+        specifier: workspace:*
+        version: link:../../../packages/integrations/kitajs
+      '@ecopages/lit':
+        specifier: workspace:*
+        version: link:../../../packages/integrations/lit
+      '@ecopages/react':
+        specifier: workspace:*
+        version: link:../../../packages/integrations/react
+      '@ecopages/testing':
+        specifier: workspace:*
+        version: link:../../../packages/__internals/testing
+      '@kitajs/html':
+        specifier: ^4.2.13
+        version: 4.2.13
+      lit:
+        specifier: ^3.3.3
+        version: 3.3.3
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
 
-    packages/__internals/testing:
-        dependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../core
-            '@ecopages/jsx':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(typescript@5.9.3)
-            '@kitajs/html':
-                specifier: ^4.2.13
-                version: 4.2.13
-            lit:
-                specifier: ^3.3.3
-                version: 3.3.3
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-        devDependencies:
-            '@types/react':
-                specifier: ^19.2.14
-                version: 19.2.17
+  e2e/fixtures/react-router-app:
+    dependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      '@ecopages/mdx':
+        specifier: workspace:*
+        version: link:../../../packages/integrations/mdx
+      '@ecopages/react':
+        specifier: workspace:*
+        version: link:../../../packages/integrations/react
+      '@ecopages/react-router':
+        specifier: workspace:*
+        version: link:../../../packages/react-router
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
 
-    packages/browser-router:
-        dependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../core
-            morphdom:
-                specifier: ^2.7.8
-                version: 2.7.8
+  packages/__internals/testing:
+    dependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@ecopages/jsx':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(typescript@5.9.3)
+      '@kitajs/html':
+        specifier: ^4.2.13
+        version: 4.2.13
+      lit:
+        specifier: ^3.3.3
+        version: 3.3.3
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.17
 
-    packages/codemod:
-        dependencies:
-            typescript:
-                specifier: ^5.0.0
-                version: 5.9.3
-        devDependencies:
-            '@types/jscodeshift':
-                specifier: ^17.3.0
-                version: 17.3.0
-            jscodeshift:
-                specifier: ^17.3.0
-                version: 17.3.0
-            vitest:
-                specifier: ^4.1.6
-                version: 4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+  packages/browser-router:
+    dependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../core
+      morphdom:
+        specifier: ^2.7.8
+        version: 2.7.8
 
-    packages/core:
-        dependencies:
-            '@ecopages/file-system':
-                specifier: workspace:*
-                version: link:../file-system
-            '@ecopages/logger':
-                specifier: ^0.2.3
-                version: 0.2.3(typescript@5.9.3)
-            '@ecopages/scripts-injector':
-                specifier: ^0.1.5
-                version: 0.1.5(typescript@5.9.3)
-            '@oxc-project/runtime':
-                specifier: 0.134.0
-                version: 0.134.0
-            '@worker-tools/html-rewriter':
-                specifier: 0.1.0-pre.19
-                version: 0.1.0-pre.19
-            chokidar:
-                specifier: ^5.0.0
-                version: 5.0.0
-            esbuild:
-                specifier: ^0.28.0
-                version: 0.28.1
-            ghtml:
-                specifier: ^4.0.2
-                version: 4.0.2
-            oxc-parser:
-                specifier: ^0.124.0
-                version: 0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
-            rolldown:
-                specifier: ^1.1.0
-                version: 1.1.1
-            ws:
-                specifier: ^8.20.1
-                version: 8.21.0
-        devDependencies:
-            '@types/bun':
-                specifier: latest
-                version: 1.3.14
-            '@types/ws':
-                specifier: ^8.18.1
-                version: 8.18.1
-            arktype:
-                specifier: ^2.2.0
-                version: 2.2.0
-            tailwindcss:
-                specifier: ^3.4.19
-                version: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
-            valibot:
-                specifier: ^1.4.0
-                version: 1.4.1(typescript@5.9.3)
-            zod:
-                specifier: ^4.4.3
-                version: 4.4.3
+  packages/codemod:
+    dependencies:
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+    devDependencies:
+      '@types/jscodeshift':
+        specifier: ^17.3.0
+        version: 17.3.0
+      jscodeshift:
+        specifier: ^17.3.0
+        version: 17.3.0
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
-    packages/core/__fixtures__/app:
-        dependencies:
-            '@mdx-js/mdx':
-                specifier: ^3.1.1
-                version: 3.1.1
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../..
-            '@ecopages/mdx':
-                specifier: workspace:*
-                version: link:../../../integrations/mdx
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
+  packages/core:
+    dependencies:
+      '@ecopages/file-system':
+        specifier: workspace:*
+        version: link:../file-system
+      '@ecopages/logger':
+        specifier: ^0.2.3
+        version: 0.2.3(typescript@5.9.3)
+      '@ecopages/scripts-injector':
+        specifier: ^0.1.5
+        version: 0.1.5(typescript@5.9.3)
+      '@oxc-project/runtime':
+        specifier: 0.134.0
+        version: 0.134.0
+      '@worker-tools/html-rewriter':
+        specifier: 0.1.0-pre.19
+        version: 0.1.0-pre.19
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.1
+      ghtml:
+        specifier: ^4.0.2
+        version: 4.0.2
+      oxc-parser:
+        specifier: ^0.124.0
+        version: 0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
+      rolldown:
+        specifier: ^1.1.0
+        version: 1.1.1
+      ws:
+        specifier: ^8.20.1
+        version: 8.21.0
+    devDependencies:
+      '@types/bun':
+        specifier: latest
+        version: 1.3.14
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      arktype:
+        specifier: ^2.2.0
+        version: 2.2.0
+      tailwindcss:
+        specifier: ^3.4.19
+        version: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
+      valibot:
+        specifier: ^1.4.0
+        version: 1.4.1(typescript@5.9.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
-    packages/ecopages:
-        dependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../core
-            '@ecopages/logger':
-                specifier: ^0.2.3
-                version: 0.2.3(typescript@5.9.3)
-            bun-types:
-                specifier: '*'
-                version: 1.3.14
-            giget:
-                specifier: ^2.0.0
-                version: 2.0.0
-            tsx:
-                specifier: ^4.22.3
-                version: 4.22.4
-            typescript:
-                specifier: ^5
-                version: 5.9.3
+  packages/core/__fixtures__/app:
+    dependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../..
+      '@ecopages/mdx':
+        specifier: workspace:*
+        version: link:../../../integrations/mdx
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
 
-    packages/file-system:
-        dependencies:
-            bun:
-                specifier: '>=1.0.0'
-                version: 1.3.14
-        devDependencies:
-            '@types/bun':
-                specifier: ^1.3.14
-                version: 1.3.14
-            '@types/node':
-                specifier: ^24.12.4
-                version: 24.13.2
-            mitata:
-                specifier: ^1.0.34
-                version: 1.0.34
+  packages/ecopages:
+    dependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../core
+      '@ecopages/logger':
+        specifier: ^0.2.3
+        version: 0.2.3(typescript@5.9.3)
+      bun-types:
+        specifier: '*'
+        version: 1.3.14
+      giget:
+        specifier: ^2.0.0
+        version: 2.0.0
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.4
+      typescript:
+        specifier: ^5
+        version: 5.9.3
 
-    packages/integrations/ecopages-jsx:
-        dependencies:
-            '@ecopages/jsx':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(typescript@5.9.3)
-            '@ecopages/radiant':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
-            '@mdx-js/mdx':
-                specifier: ^3.1.1
-                version: 3.1.1
-            vfile:
-                specifier: ^6.0.3
-                version: 6.0.3
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../core
-            '@ecopages/testing':
-                specifier: workspace:*
-                version: link:../../__internals/testing
-            '@kitajs/html':
-                specifier: ^4.2.13
-                version: 4.2.13
-            lit:
-                specifier: ^3.3.3
-                version: 3.3.3
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            remark-gfm:
-                specifier: ^4.0.1
-                version: 4.0.1
+  packages/file-system:
+    dependencies:
+      bun:
+        specifier: '>=1.0.0'
+        version: 1.3.14
+    devDependencies:
+      '@types/bun':
+        specifier: ^1.3.14
+        version: 1.3.14
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.13.2
+      mitata:
+        specifier: ^1.0.34
+        version: 1.0.34
 
-    packages/integrations/kitajs:
-        dependencies:
-            '@kitajs/html':
-                specifier: ^4.1.0
-                version: 4.2.13
-            '@kitajs/ts-html-plugin':
-                specifier: ^4.0.1
-                version: 4.1.4(@kitajs/html@4.2.13)(typescript@5.9.3)
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../core
-            '@ecopages/testing':
-                specifier: workspace:*
-                version: link:../../__internals/testing
+  packages/integrations/ecopages-jsx:
+    dependencies:
+      '@ecopages/jsx':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(typescript@5.9.3)
+      '@ecopages/mdx-core':
+        specifier: workspace:*
+        version: link:../mdx-core
+      '@ecopages/radiant':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@ecopages/testing':
+        specifier: workspace:*
+        version: link:../../__internals/testing
+      '@kitajs/html':
+        specifier: ^4.2.13
+        version: 4.2.13
+      lit:
+        specifier: ^3.3.3
+        version: 3.3.3
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
 
-    packages/integrations/lit:
-        dependencies:
-            '@lit-labs/ssr':
-                specifier: ^3.3.0
-                version: 3.3.1
-            '@lit-labs/ssr-client':
-                specifier: ^1.1.7
-                version: 1.1.8
-            lit:
-                specifier: ^3.2.1
-                version: 3.3.3
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../core
-            '@ecopages/testing':
-                specifier: workspace:*
-                version: link:../../__internals/testing
+  packages/integrations/kitajs:
+    dependencies:
+      '@kitajs/html':
+        specifier: ^4.1.0
+        version: 4.2.13
+      '@kitajs/ts-html-plugin':
+        specifier: ^4.0.1
+        version: 4.1.4(@kitajs/html@4.2.13)(typescript@5.9.3)
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@ecopages/testing':
+        specifier: workspace:*
+        version: link:../../__internals/testing
 
-    packages/integrations/mdx:
-        dependencies:
-            '@ecopages/logger':
-                specifier: ^0.2.3
-                version: 0.2.3(typescript@5.9.3)
-            '@kitajs/html':
-                specifier: ^4.1.0
-                version: 4.2.13
-            '@mdx-js/mdx':
-                specifier: ^3.1.0
-                version: 3.1.1
-            source-map:
-                specifier: ^0.7.6
-                version: 0.7.6
-            vfile:
-                specifier: ^6.0.3
-                version: 6.0.3
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../core
-            '@ecopages/testing':
-                specifier: workspace:*
-                version: link:../../__internals/testing
+  packages/integrations/lit:
+    dependencies:
+      '@lit-labs/ssr':
+        specifier: ^3.3.0
+        version: 3.3.1
+      '@lit-labs/ssr-client':
+        specifier: ^1.1.7
+        version: 1.1.8
+      lit:
+        specifier: ^3.2.1
+        version: 3.3.3
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@ecopages/testing':
+        specifier: workspace:*
+        version: link:../../__internals/testing
 
-    packages/integrations/react:
-        dependencies:
-            '@ecopages/file-system':
-                specifier: workspace:*
-                version: link:../../file-system
-            '@ecopages/logger':
-                specifier: ^0.2.3
-                version: 0.2.3(typescript@5.9.3)
-            '@mdx-js/mdx':
-                specifier: ^3.1.1
-                version: 3.1.1
-            '@types/react':
-                specifier: ^19
-                version: 19.2.17
-            '@types/react-dom':
-                specifier: ^19
-                version: 19.2.3(@types/react@19.2.17)
-            oxc-parser:
-                specifier: ^0.124.0
-                version: 0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
-            oxc-transform:
-                specifier: ^0.124.0
-                version: 0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
-            react:
-                specifier: ^19
-                version: 19.2.7
-            react-dom:
-                specifier: ^19
-                version: 19.2.7(react@19.2.7)
-            source-map:
-                specifier: ^0.7.6
-                version: 0.7.6
-            vfile:
-                specifier: ^6.0.3
-                version: 6.0.3
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../core
-            '@ecopages/testing':
-                specifier: workspace:*
-                version: link:../../__internals/testing
+  packages/integrations/mdx:
+    dependencies:
+      '@ecopages/logger':
+        specifier: ^0.2.3
+        version: 0.2.3(typescript@5.9.3)
+      '@ecopages/mdx-core':
+        specifier: workspace:*
+        version: link:../mdx-core
+      '@kitajs/html':
+        specifier: ^4.1.0
+        version: 4.2.13
+      '@mdx-js/mdx':
+        specifier: ^3.1.0
+        version: 3.1.1
+      source-map:
+        specifier: ^0.7.6
+        version: 0.7.6
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@ecopages/testing':
+        specifier: workspace:*
+        version: link:../../__internals/testing
 
-    packages/processors/image-processor:
-        dependencies:
-            '@ecopages/file-system':
-                specifier: workspace:*
-                version: link:../../file-system
-            '@ecopages/logger':
-                specifier: ^0.2.3
-                version: 0.2.3(typescript@5.9.3)
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
-            sharp:
-                specifier: ^0.34.5
-                version: 0.34.5
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../core
-            '@types/react':
-                specifier: ^19.2.14
-                version: 19.2.17
-            '@types/react-dom':
-                specifier: ^19.2.3
-                version: 19.2.3(@types/react@19.2.17)
+  packages/integrations/mdx-core:
+    dependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.0
+        version: 3.1.1
+      source-map:
+        specifier: ^0.7.6
+        version: 0.7.6
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../core
 
-    packages/processors/postcss-processor:
-        dependencies:
-            '@ecopages/file-system':
-                specifier: workspace:*
-                version: link:../../file-system
-            '@ecopages/logger':
-                specifier: ^0.2.3
-                version: 0.2.3(typescript@5.9.3)
-            autoprefixer:
-                specifier: ^10.5.0
-                version: 10.5.0(postcss@8.5.15)
-            browserslist:
-                specifier: ^4.28.2
-                version: 4.28.2
-            cssnano:
-                specifier: ^7.1.9
-                version: 7.1.9(postcss@8.5.15)
-            postcss:
-                specifier: ^8.5.14
-                version: 8.5.15
-            postcss-import:
-                specifier: ^16.1.1
-                version: 16.1.1(postcss@8.5.15)
-            postcss-nested:
-                specifier: ^7.0.2
-                version: 7.0.2(postcss@8.5.15)
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../core
-            '@tailwindcss/postcss':
-                specifier: ^4.3.0
-                version: 4.3.1
-            '@types/bun':
-                specifier: latest
-                version: 1.3.14
-            '@types/postcss-import':
-                specifier: ^14.0.3
-                version: 14.0.3
-            postcss-simple-vars:
-                specifier: ^7.0.1
-                version: 7.0.1(postcss@8.5.15)
-            tailwindcss:
-                specifier: ^3.4.19
-                version: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
+  packages/integrations/react:
+    dependencies:
+      '@ecopages/file-system':
+        specifier: workspace:*
+        version: link:../../file-system
+      '@ecopages/logger':
+        specifier: ^0.2.3
+        version: 0.2.3(typescript@5.9.3)
+      '@ecopages/mdx-core':
+        specifier: workspace:*
+        version: link:../mdx-core
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
+      '@types/react':
+        specifier: ^19
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.17)
+      oxc-parser:
+        specifier: ^0.124.0
+        version: 0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
+      oxc-transform:
+        specifier: ^0.124.0
+        version: 0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
+      react:
+        specifier: ^19
+        version: 19.2.7
+      react-dom:
+        specifier: ^19
+        version: 19.2.7(react@19.2.7)
+      source-map:
+        specifier: ^0.7.6
+        version: 0.7.6
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@ecopages/testing':
+        specifier: workspace:*
+        version: link:../../__internals/testing
 
-    packages/react-router:
-        dependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../core
-            '@ecopages/react':
-                specifier: workspace:*
-                version: link:../integrations/react
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
-        devDependencies:
-            '@types/bun':
-                specifier: ^1.3.14
-                version: 1.3.14
-            '@types/react':
-                specifier: ^19.2.14
-                version: 19.2.17
-            '@types/react-dom':
-                specifier: ^19.2.3
-                version: 19.2.3(@types/react@19.2.17)
+  packages/processors/image-processor:
+    dependencies:
+      '@ecopages/file-system':
+        specifier: workspace:*
+        version: link:../../file-system
+      '@ecopages/logger':
+        specifier: ^0.2.3
+        version: 0.2.3(typescript@5.9.3)
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
 
-    packages/vite-plugin:
-        dependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../core
-            vite:
-                specifier: '>=8.0.0'
-                version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+  packages/processors/postcss-processor:
+    dependencies:
+      '@ecopages/file-system':
+        specifier: workspace:*
+        version: link:../../file-system
+      '@ecopages/logger':
+        specifier: ^0.2.3
+        version: 0.2.3(typescript@5.9.3)
+      autoprefixer:
+        specifier: ^10.5.0
+        version: 10.5.0(postcss@8.5.15)
+      browserslist:
+        specifier: ^4.28.2
+        version: 4.28.2
+      cssnano:
+        specifier: ^7.1.9
+        version: 7.1.9(postcss@8.5.15)
+      postcss:
+        specifier: ^8.5.14
+        version: 8.5.15
+      postcss-import:
+        specifier: ^16.1.1
+        version: 16.1.1(postcss@8.5.15)
+      postcss-nested:
+        specifier: ^7.0.2
+        version: 7.0.2(postcss@8.5.15)
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@tailwindcss/postcss':
+        specifier: ^4.3.0
+        version: 4.3.1
+      '@types/bun':
+        specifier: latest
+        version: 1.3.14
+      '@types/postcss-import':
+        specifier: ^14.0.3
+        version: 14.0.3
+      postcss-simple-vars:
+        specifier: ^7.0.1
+        version: 7.0.1(postcss@8.5.15)
+      tailwindcss:
+        specifier: ^3.4.19
+        version: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
 
-    playground/browser-router:
-        devDependencies:
-            '@ecopages/browser-router':
-                specifier: workspace:*
-                version: link:../../packages/browser-router
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../packages/core
-            '@ecopages/image-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/image-processor
-            '@ecopages/kitajs':
-                specifier: workspace:*
-                version: link:../../packages/integrations/kitajs
-            '@ecopages/mdx':
-                specifier: workspace:*
-                version: link:../../packages/integrations/mdx
-            '@ecopages/postcss-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/postcss-processor
-            '@ecopages/radiant':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
-            '@kitajs/html':
-                specifier: ^4.2.13
-                version: 4.2.13
-            '@tailwindcss/postcss':
-                specifier: ^4.3.0
-                version: 4.3.1
-            ecopages:
-                specifier: workspace:*
-                version: link:../../packages/ecopages
-            tailwindcss:
-                specifier: ^4.3.0
-                version: 4.3.1
+  packages/react-router:
+    dependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../core
+      '@ecopages/react':
+        specifier: workspace:*
+        version: link:../integrations/react
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/bun':
+        specifier: ^1.3.14
+        version: 1.3.14
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
 
-    playground/eco-blog:
-        dependencies:
-            '@mdx-js/mdx':
-                specifier: ^3.1.1
-                version: 3.1.1
-            '@tiptap/core':
-                specifier: latest
-                version: 3.27.1(@tiptap/pm@3.27.1)
-            '@tiptap/extension-image':
-                specifier: ^3.23.4
-                version: 3.26.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-            '@tiptap/pm':
-                specifier: latest
-                version: 3.27.1
-            '@tiptap/starter-kit':
-                specifier: latest
-                version: 3.27.1
-            better-auth:
-                specifier: latest
-                version: 1.6.20(drizzle-kit@1.0.0-rc.4-ca0f029)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8)
-            drizzle-orm:
-                specifier: ^0.45.2
-                version: 0.45.2(bun-types@1.3.14)(kysely@0.29.2)
-            tiptap-markdown:
-                specifier: latest
-                version: 0.9.0(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-            zod:
-                specifier: latest
-                version: 4.4.3
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../packages/core
-            '@ecopages/image-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/image-processor
-            '@ecopages/kitajs':
-                specifier: workspace:*
-                version: link:../../packages/integrations/kitajs
-            '@ecopages/mdx':
-                specifier: workspace:*
-                version: link:../../packages/integrations/mdx
-            '@ecopages/postcss-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/postcss-processor
-            '@ecopages/radiant':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
-            '@faker-js/faker':
-                specifier: ^10.4.0
-                version: 10.4.0
-            '@kitajs/html':
-                specifier: ^4.2.13
-                version: 4.2.13
-            '@tailwindcss/postcss':
-                specifier: latest
-                version: 4.3.1
-            drizzle-kit:
-                specifier: ^1.0.0-rc.2
-                version: 1.0.0-rc.4-ca0f029
-            ecopages:
-                specifier: workspace:*
-                version: link:../../packages/ecopages
-            tailwindcss:
-                specifier: latest
-                version: 4.3.1
+  packages/vite-plugin:
+    dependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../core
+      vite:
+        specifier: '>=8.0.0'
+        version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
-    playground/explicit-routes:
-        dependencies:
-            zod:
-                specifier: ^4.4.3
-                version: 4.4.3
-        devDependencies:
-            '@ecopages/browser-router':
-                specifier: workspace:*
-                version: link:../../packages/browser-router
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../packages/core
-            '@ecopages/kitajs':
-                specifier: workspace:*
-                version: link:../../packages/integrations/kitajs
-            '@ecopages/postcss-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/postcss-processor
-            '@kitajs/html':
-                specifier: ^4.2.13
-                version: 4.2.13
-            '@tailwindcss/postcss':
-                specifier: ^4.3.0
-                version: 4.3.1
-            ecopages:
-                specifier: workspace:*
-                version: link:../../packages/ecopages
-            tailwindcss:
-                specifier: ^4.3.0
-                version: 4.3.1
+  playground/browser-router:
+    devDependencies:
+      '@ecopages/browser-router':
+        specifier: workspace:*
+        version: link:../../packages/browser-router
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@ecopages/image-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/image-processor
+      '@ecopages/kitajs':
+        specifier: workspace:*
+        version: link:../../packages/integrations/kitajs
+      '@ecopages/mdx':
+        specifier: workspace:*
+        version: link:../../packages/integrations/mdx
+      '@ecopages/postcss-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/postcss-processor
+      '@ecopages/radiant':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
+      '@kitajs/html':
+        specifier: ^4.2.13
+        version: 4.2.13
+      '@tailwindcss/postcss':
+        specifier: ^4.3.0
+        version: 4.3.1
+      ecopages:
+        specifier: workspace:*
+        version: link:../../packages/ecopages
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.1
 
-    playground/global:
-        dependencies:
-            '@mdx-js/mdx':
-                specifier: ^3.1.1
-                version: 3.1.1
-        devDependencies:
-            '@ecopages/browser-router':
-                specifier: workspace:*
-                version: link:../../packages/browser-router
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../packages/core
-            '@ecopages/image-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/image-processor
-            '@ecopages/kitajs':
-                specifier: workspace:*
-                version: link:../../packages/integrations/kitajs
-            '@ecopages/lit':
-                specifier: workspace:*
-                version: link:../../packages/integrations/lit
-            '@ecopages/mdx':
-                specifier: workspace:*
-                version: link:../../packages/integrations/mdx
-            '@ecopages/postcss-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/postcss-processor
-            '@ecopages/radiant':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
-            '@ecopages/react':
-                specifier: workspace:*
-                version: link:../../packages/integrations/react
-            '@ecopages/scripts-injector':
-                specifier: ^0.1.5
-                version: 0.1.5(typescript@5.9.3)
-            '@faker-js/faker':
-                specifier: 9.7.0
-                version: 9.7.0
-            '@kitajs/html':
-                specifier: ^4.2.13
-                version: 4.2.13
-            '@types/alpinejs':
-                specifier: ^3.13.11
-                version: 3.13.11
-            '@types/react':
-                specifier: ^19.2.14
-                version: 19.2.17
-            '@types/react-dom':
-                specifier: ^19.2.3
-                version: 19.2.3(@types/react@19.2.17)
-            alpinejs:
-                specifier: ^3.15.12
-                version: 3.15.12
-            ecopages:
-                specifier: workspace:*
-                version: link:../../packages/ecopages
-            lit:
-                specifier: ^3.3.3
-                version: 3.3.3
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
-            shiki:
-                specifier: ^1.29.2
-                version: 1.29.2
-            tailwindcss:
-                specifier: ^3.4.19
-                version: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
+  playground/eco-blog:
+    dependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
+      '@tiptap/core':
+        specifier: latest
+        version: 3.27.1(@tiptap/pm@3.27.1)
+      '@tiptap/extension-image':
+        specifier: ^3.23.4
+        version: 3.26.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      '@tiptap/pm':
+        specifier: latest
+        version: 3.27.1
+      '@tiptap/starter-kit':
+        specifier: latest
+        version: 3.27.1
+      better-auth:
+        specifier: latest
+        version: 1.6.21(drizzle-kit@1.0.0-rc.4-ca0f029)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8)
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(bun-types@1.3.14)(kysely@0.29.2)
+      tiptap-markdown:
+        specifier: latest
+        version: 0.9.0(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      zod:
+        specifier: latest
+        version: 4.4.3
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@ecopages/image-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/image-processor
+      '@ecopages/kitajs':
+        specifier: workspace:*
+        version: link:../../packages/integrations/kitajs
+      '@ecopages/mdx':
+        specifier: workspace:*
+        version: link:../../packages/integrations/mdx
+      '@ecopages/postcss-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/postcss-processor
+      '@ecopages/radiant':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
+      '@faker-js/faker':
+        specifier: ^10.4.0
+        version: 10.4.0
+      '@kitajs/html':
+        specifier: ^4.2.13
+        version: 4.2.13
+      '@tailwindcss/postcss':
+        specifier: latest
+        version: 4.3.1
+      drizzle-kit:
+        specifier: ^1.0.0-rc.2
+        version: 1.0.0-rc.4-ca0f029
+      ecopages:
+        specifier: workspace:*
+        version: link:../../packages/ecopages
+      tailwindcss:
+        specifier: latest
+        version: 4.3.1
 
-    playground/kitchen-sink:
-        dependencies:
-            '@mdx-js/mdx':
-                specifier: ^3.1.1
-                version: 3.1.1
-        devDependencies:
-            '@ecopages/browser-router':
-                specifier: workspace:*
-                version: link:../../packages/browser-router
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../packages/core
-            '@ecopages/ecopages-jsx':
-                specifier: workspace:*
-                version: link:../../packages/integrations/ecopages-jsx
-            '@ecopages/file-system':
-                specifier: workspace:*
-                version: link:../../packages/file-system
-            '@ecopages/image-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/image-processor
-            '@ecopages/jsx':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(typescript@5.9.3)
-            '@ecopages/kitajs':
-                specifier: workspace:*
-                version: link:../../packages/integrations/kitajs
-            '@ecopages/lit':
-                specifier: workspace:*
-                version: link:../../packages/integrations/lit
-            '@ecopages/mdx':
-                specifier: workspace:*
-                version: link:../../packages/integrations/mdx
-            '@ecopages/postcss-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/postcss-processor
-            '@ecopages/radiant':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
-            '@ecopages/react':
-                specifier: workspace:*
-                version: link:../../packages/integrations/react
-            '@ecopages/react-router':
-                specifier: workspace:*
-                version: link:../../packages/react-router
-            '@ecopages/scripts-injector':
-                specifier: ^0.1.5
-                version: 0.1.5(typescript@5.9.3)
-            '@ecopages/testing':
-                specifier: workspace:*
-                version: link:../../packages/__internals/testing
-            '@ecopages/vite-plugin':
-                specifier: workspace:*
-                version: link:../../packages/vite-plugin
-            '@fontsource-variable/jetbrains-mono':
-                specifier: ^5.2.8
-                version: 5.2.8
-            '@kitajs/html':
-                specifier: ^4.2.13
-                version: 4.2.13
-            '@playwright/test':
-                specifier: ^1.60.0
-                version: 1.60.0
-            '@tailwindcss/postcss':
-                specifier: ^4.3.0
-                version: 4.3.1
-            '@types/node':
-                specifier: ^24.12.4
-                version: 24.13.2
-            '@types/react':
-                specifier: ^19.2.14
-                version: 19.2.17
-            '@types/react-dom':
-                specifier: ^19.2.3
-                version: 19.2.3(@types/react@19.2.17)
-            ecopages:
-                specifier: workspace:*
-                version: link:../../packages/ecopages
-            lit:
-                specifier: ^3.3.3
-                version: 3.3.3
-            playwright:
-                specifier: ^1.60.0
-                version: 1.60.0
-            playwright-core:
-                specifier: ^1.60.0
-                version: 1.60.0
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
-            tailwindcss:
-                specifier: ^4.3.0
-                version: 4.3.1
-            vite:
-                specifier: 8.0.4
-                version: 8.0.4(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-            zod:
-                specifier: ^4.4.3
-                version: 4.4.3
+  playground/explicit-routes:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@ecopages/browser-router':
+        specifier: workspace:*
+        version: link:../../packages/browser-router
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@ecopages/kitajs':
+        specifier: workspace:*
+        version: link:../../packages/integrations/kitajs
+      '@ecopages/postcss-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/postcss-processor
+      '@kitajs/html':
+        specifier: ^4.2.13
+        version: 4.2.13
+      '@tailwindcss/postcss':
+        specifier: ^4.3.0
+        version: 4.3.1
+      ecopages:
+        specifier: workspace:*
+        version: link:../../packages/ecopages
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.1
 
-    playground/namespace:
-        devDependencies:
-            '@ecopages/browser-router':
-                specifier: workspace:*
-                version: link:../../packages/browser-router
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../packages/core
-            '@ecopages/kitajs':
-                specifier: workspace:*
-                version: link:../../packages/integrations/kitajs
-            '@ecopages/lit':
-                specifier: workspace:*
-                version: link:../../packages/integrations/lit
-            '@ecopages/postcss-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/postcss-processor
-            '@ecopages/radiant':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
-            '@faker-js/faker':
-                specifier: ^10.4.0
-                version: 10.4.0
-            '@kitajs/html':
-                specifier: ^4.2.13
-                version: 4.2.13
-            '@tailwindcss/postcss':
-                specifier: ^4.3.0
-                version: 4.3.1
-            '@types/alpinejs':
-                specifier: ^3.13.11
-                version: 3.13.11
-            alpinejs:
-                specifier: ^3.15.12
-                version: 3.15.12
-            ecopages:
-                specifier: workspace:*
-                version: link:../../packages/ecopages
-            lit:
-                specifier: ^3.3.3
-                version: 3.3.3
-            tailwindcss:
-                specifier: ^4.3.0
-                version: 4.3.1
+  playground/global:
+    dependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
+    devDependencies:
+      '@ecopages/browser-router':
+        specifier: workspace:*
+        version: link:../../packages/browser-router
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@ecopages/image-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/image-processor
+      '@ecopages/kitajs':
+        specifier: workspace:*
+        version: link:../../packages/integrations/kitajs
+      '@ecopages/lit':
+        specifier: workspace:*
+        version: link:../../packages/integrations/lit
+      '@ecopages/mdx':
+        specifier: workspace:*
+        version: link:../../packages/integrations/mdx
+      '@ecopages/postcss-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/postcss-processor
+      '@ecopages/radiant':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
+      '@ecopages/react':
+        specifier: workspace:*
+        version: link:../../packages/integrations/react
+      '@ecopages/scripts-injector':
+        specifier: ^0.1.5
+        version: 0.1.5(typescript@5.9.3)
+      '@faker-js/faker':
+        specifier: 9.7.0
+        version: 9.7.0
+      '@kitajs/html':
+        specifier: ^4.2.13
+        version: 4.2.13
+      '@types/alpinejs':
+        specifier: ^3.13.11
+        version: 3.13.11
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      alpinejs:
+        specifier: ^3.15.12
+        version: 3.15.12
+      ecopages:
+        specifier: workspace:*
+        version: link:../../packages/ecopages
+      lit:
+        specifier: ^3.3.3
+        version: 3.3.3
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
+      shiki:
+        specifier: ^1.29.2
+        version: 1.29.2
+      tailwindcss:
+        specifier: ^3.4.19
+        version: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
 
-    playground/react:
-        dependencies:
-            '@tanstack/react-table':
-                specifier: ^8.21.3
-                version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-aria-components:
-                specifier: ^1.17.0
-                version: 1.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../packages/core
-            '@ecopages/image-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/image-processor
-            '@ecopages/postcss-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/postcss-processor
-            '@ecopages/radiant':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
-            '@ecopages/react':
-                specifier: workspace:*
-                version: link:../../packages/integrations/react
-            '@ecopages/react-router':
-                specifier: workspace:*
-                version: link:../../packages/react-router
-            '@types/react':
-                specifier: ^19.2.14
-                version: 19.2.17
-            '@types/react-dom':
-                specifier: ^19.2.3
-                version: 19.2.3(@types/react@19.2.17)
-            ecopages:
-                specifier: workspace:*
-                version: link:../../packages/ecopages
-            tailwindcss:
-                specifier: ^3.4.19
-                version: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
+  playground/kitchen-sink:
+    dependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
+    devDependencies:
+      '@ecopages/browser-router':
+        specifier: workspace:*
+        version: link:../../packages/browser-router
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@ecopages/ecopages-jsx':
+        specifier: workspace:*
+        version: link:../../packages/integrations/ecopages-jsx
+      '@ecopages/file-system':
+        specifier: workspace:*
+        version: link:../../packages/file-system
+      '@ecopages/image-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/image-processor
+      '@ecopages/jsx':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(typescript@5.9.3)
+      '@ecopages/kitajs':
+        specifier: workspace:*
+        version: link:../../packages/integrations/kitajs
+      '@ecopages/lit':
+        specifier: workspace:*
+        version: link:../../packages/integrations/lit
+      '@ecopages/mdx':
+        specifier: workspace:*
+        version: link:../../packages/integrations/mdx
+      '@ecopages/postcss-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/postcss-processor
+      '@ecopages/radiant':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
+      '@ecopages/react':
+        specifier: workspace:*
+        version: link:../../packages/integrations/react
+      '@ecopages/react-router':
+        specifier: workspace:*
+        version: link:../../packages/react-router
+      '@ecopages/scripts-injector':
+        specifier: ^0.1.5
+        version: 0.1.5(typescript@5.9.3)
+      '@ecopages/testing':
+        specifier: workspace:*
+        version: link:../../packages/__internals/testing
+      '@ecopages/vite-plugin':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin
+      '@fontsource-variable/jetbrains-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@kitajs/html':
+        specifier: ^4.2.13
+        version: 4.2.13
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
+      '@tailwindcss/postcss':
+        specifier: ^4.3.0
+        version: 4.3.1
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.13.2
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      ecopages:
+        specifier: workspace:*
+        version: link:../../packages/ecopages
+      lit:
+        specifier: ^3.3.3
+        version: 3.3.3
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
+      playwright-core:
+        specifier: ^1.60.0
+        version: 1.60.0
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.1
+      vite:
+        specifier: 8.0.4
+        version: 8.0.4(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
-    playground/react-router:
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../packages/core
-            '@ecopages/image-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/image-processor
-            '@ecopages/postcss-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/postcss-processor
-            '@ecopages/radiant':
-                specifier: 0.3.0-alpha.25
-                version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
-            '@ecopages/react':
-                specifier: workspace:*
-                version: link:../../packages/integrations/react
-            '@ecopages/react-router':
-                specifier: workspace:*
-                version: link:../../packages/react-router
-            '@tailwindcss/postcss':
-                specifier: ^4.3.0
-                version: 4.3.1
-            '@types/react':
-                specifier: ^19.2.14
-                version: 19.2.17
-            '@types/react-dom':
-                specifier: ^19.2.3
-                version: 19.2.3(@types/react@19.2.17)
-            ecopages:
-                specifier: workspace:*
-                version: link:../../packages/ecopages
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
-            tailwindcss:
-                specifier: ^4.3.0
-                version: 4.3.1
+  playground/namespace:
+    devDependencies:
+      '@ecopages/browser-router':
+        specifier: workspace:*
+        version: link:../../packages/browser-router
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@ecopages/kitajs':
+        specifier: workspace:*
+        version: link:../../packages/integrations/kitajs
+      '@ecopages/lit':
+        specifier: workspace:*
+        version: link:../../packages/integrations/lit
+      '@ecopages/postcss-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/postcss-processor
+      '@ecopages/radiant':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
+      '@faker-js/faker':
+        specifier: ^10.4.0
+        version: 10.4.0
+      '@kitajs/html':
+        specifier: ^4.2.13
+        version: 4.2.13
+      '@tailwindcss/postcss':
+        specifier: ^4.3.0
+        version: 4.3.1
+      '@types/alpinejs':
+        specifier: ^3.13.11
+        version: 3.13.11
+      alpinejs:
+        specifier: ^3.15.12
+        version: 3.15.12
+      ecopages:
+        specifier: workspace:*
+        version: link:../../packages/ecopages
+      lit:
+        specifier: ^3.3.3
+        version: 3.3.3
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.1
 
-    playground/tailwind-v4:
-        devDependencies:
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../packages/core
-            '@ecopages/postcss-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/postcss-processor
-            '@ecopages/react':
-                specifier: workspace:*
-                version: link:../../packages/integrations/react
-            '@tailwindcss/postcss':
-                specifier: ^4.3.0
-                version: 4.3.1
-            ecopages:
-                specifier: workspace:*
-                version: link:../../packages/ecopages
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
-            tailwindcss:
-                specifier: ^4.3.0
-                version: 4.3.1
+  playground/react:
+    dependencies:
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-aria-components:
+        specifier: ^1.17.0
+        version: 1.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@ecopages/image-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/image-processor
+      '@ecopages/postcss-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/postcss-processor
+      '@ecopages/radiant':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
+      '@ecopages/react':
+        specifier: workspace:*
+        version: link:../../packages/integrations/react
+      '@ecopages/react-router':
+        specifier: workspace:*
+        version: link:../../packages/react-router
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      ecopages:
+        specifier: workspace:*
+        version: link:../../packages/ecopages
+      tailwindcss:
+        specifier: ^3.4.19
+        version: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
 
-    playground/with-react-better-auth:
-        dependencies:
-            better-auth:
-                specifier: ^1.6.11
-                version: 1.6.18(drizzle-kit@1.0.0-rc.4-ca0f029)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8)
-            drizzle-orm:
-                specifier: ^0.45.2
-                version: 0.45.2(bun-types@1.3.14)(kysely@0.29.2)
-            react:
-                specifier: ^19.2.6
-                version: 19.2.7
-            react-dom:
-                specifier: ^19.2.6
-                version: 19.2.7(react@19.2.7)
-        devDependencies:
-            '@ecopages/browser-router':
-                specifier: workspace:*
-                version: link:../../packages/browser-router
-            '@ecopages/core':
-                specifier: workspace:*
-                version: link:../../packages/core
-            '@ecopages/image-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/image-processor
-            '@ecopages/mdx':
-                specifier: workspace:*
-                version: link:../../packages/integrations/mdx
-            '@ecopages/postcss-processor':
-                specifier: workspace:*
-                version: link:../../packages/processors/postcss-processor
-            '@ecopages/react':
-                specifier: workspace:*
-                version: link:../../packages/integrations/react
-            '@ecopages/react-router':
-                specifier: workspace:*
-                version: link:../../packages/react-router
-            '@tailwindcss/postcss':
-                specifier: ^4.3.0
-                version: 4.3.1
-            '@types/bun':
-                specifier: latest
-                version: 1.3.14
-            '@types/react':
-                specifier: ^19.2.14
-                version: 19.2.17
-            '@types/react-dom':
-                specifier: ^19.2.3
-                version: 19.2.3(@types/react@19.2.17)
-            drizzle-kit:
-                specifier: ^1.0.0-rc.2
-                version: 1.0.0-rc.4-ca0f029
-            ecopages:
-                specifier: workspace:*
-                version: link:../../packages/ecopages
-            rehype-pretty-code:
-                specifier: ^0.14.3
-                version: 0.14.3(shiki@3.23.0)
-            remark-gfm:
-                specifier: ^4.0.1
-                version: 4.0.1
-            tailwindcss:
-                specifier: ^4.3.0
-                version: 4.3.1
-            typescript:
-                specifier: ^5.9.3
-                version: 5.9.3
+  playground/react-router:
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@ecopages/image-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/image-processor
+      '@ecopages/postcss-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/postcss-processor
+      '@ecopages/radiant':
+        specifier: 0.3.0-alpha.25
+        version: 0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))
+      '@ecopages/react':
+        specifier: workspace:*
+        version: link:../../packages/integrations/react
+      '@ecopages/react-router':
+        specifier: workspace:*
+        version: link:../../packages/react-router
+      '@tailwindcss/postcss':
+        specifier: ^4.3.0
+        version: 4.3.1
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      ecopages:
+        specifier: workspace:*
+        version: link:../../packages/ecopages
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.1
+
+  playground/tailwind-v4:
+    devDependencies:
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@ecopages/postcss-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/postcss-processor
+      '@ecopages/react':
+        specifier: workspace:*
+        version: link:../../packages/integrations/react
+      '@tailwindcss/postcss':
+        specifier: ^4.3.0
+        version: 4.3.1
+      ecopages:
+        specifier: workspace:*
+        version: link:../../packages/ecopages
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.1
+
+  playground/with-react-better-auth:
+    dependencies:
+      better-auth:
+        specifier: ^1.6.11
+        version: 1.6.18(drizzle-kit@1.0.0-rc.4-ca0f029)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8)
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(bun-types@1.3.14)(kysely@0.29.2)
+      react:
+        specifier: ^19.2.6
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@ecopages/browser-router':
+        specifier: workspace:*
+        version: link:../../packages/browser-router
+      '@ecopages/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@ecopages/image-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/image-processor
+      '@ecopages/mdx':
+        specifier: workspace:*
+        version: link:../../packages/integrations/mdx
+      '@ecopages/postcss-processor':
+        specifier: workspace:*
+        version: link:../../packages/processors/postcss-processor
+      '@ecopages/react':
+        specifier: workspace:*
+        version: link:../../packages/integrations/react
+      '@ecopages/react-router':
+        specifier: workspace:*
+        version: link:../../packages/react-router
+      '@tailwindcss/postcss':
+        specifier: ^4.3.0
+        version: 4.3.1
+      '@types/bun':
+        specifier: latest
+        version: 1.3.14
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      drizzle-kit:
+        specifier: ^1.0.0-rc.2
+        version: 1.0.0-rc.4-ca0f029
+      ecopages:
+        specifier: workspace:*
+        version: link:../../packages/ecopages
+      rehype-pretty-code:
+        specifier: ^0.14.3
+        version: 0.14.3(shiki@3.23.0)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
 packages:
-    '@alloc/quick-lru@5.2.0':
-        resolution:
-            {
-                integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==,
-            }
-        engines: { node: '>=10' }
-
-    '@ark/schema@0.56.0':
-        resolution:
-            {
-                integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==,
-            }
-
-    '@ark/util@0.56.0':
-        resolution:
-            {
-                integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==,
-            }
-
-    '@babel/code-frame@7.29.7':
-        resolution:
-            {
-                integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/compat-data@7.29.7':
-        resolution:
-            {
-                integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/core@7.29.7':
-        resolution:
-            {
-                integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/generator@7.29.7':
-        resolution:
-            {
-                integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-annotate-as-pure@7.29.7':
-        resolution:
-            {
-                integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-compilation-targets@7.29.7':
-        resolution:
-            {
-                integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-create-class-features-plugin@7.29.7':
-        resolution:
-            {
-                integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0
-
-    '@babel/helper-globals@7.29.7':
-        resolution:
-            {
-                integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-member-expression-to-functions@7.29.7':
-        resolution:
-            {
-                integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-module-imports@7.29.7':
-        resolution:
-            {
-                integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-module-transforms@7.29.7':
-        resolution:
-            {
-                integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0
-
-    '@babel/helper-optimise-call-expression@7.29.7':
-        resolution:
-            {
-                integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-plugin-utils@7.29.7':
-        resolution:
-            {
-                integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-replace-supers@7.29.7':
-        resolution:
-            {
-                integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0
-
-    '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
-        resolution:
-            {
-                integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-string-parser@7.29.7':
-        resolution:
-            {
-                integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-validator-identifier@7.29.7':
-        resolution:
-            {
-                integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-validator-option@7.29.7':
-        resolution:
-            {
-                integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helpers@7.29.7':
-        resolution:
-            {
-                integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/parser@7.29.7':
-        resolution:
-            {
-                integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==,
-            }
-        engines: { node: '>=6.0.0' }
-        hasBin: true
-
-    '@babel/plugin-syntax-flow@7.29.7':
-        resolution:
-            {
-                integrity: sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/plugin-syntax-jsx@7.29.7':
-        resolution:
-            {
-                integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/plugin-syntax-typescript@7.29.7':
-        resolution:
-            {
-                integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/plugin-transform-class-properties@7.29.7':
-        resolution:
-            {
-                integrity: sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/plugin-transform-flow-strip-types@7.29.7':
-        resolution:
-            {
-                integrity: sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/plugin-transform-modules-commonjs@7.29.7':
-        resolution:
-            {
-                integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/plugin-transform-nullish-coalescing-operator@7.29.7':
-        resolution:
-            {
-                integrity: sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/plugin-transform-optional-chaining@7.29.7':
-        resolution:
-            {
-                integrity: sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/plugin-transform-private-methods@7.29.7':
-        resolution:
-            {
-                integrity: sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/plugin-transform-typescript@7.29.7':
-        resolution:
-            {
-                integrity: sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/preset-flow@7.29.7':
-        resolution:
-            {
-                integrity: sha512-KYIRV0BuaN68CDdsqFkAD7MU7yipUqQNuNElwATdxaIdpTjhvtY82QvkBJs7zV3Evxj2jFAAZ1iO8nyy0nhjqA==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/preset-typescript@7.29.7':
-        resolution:
-            {
-                integrity: sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/register@7.29.7':
-        resolution:
-            {
-                integrity: sha512-AMGJoWuES861riy6pcB0fphE1YXybtQnBYQMuIyPv6mKLiosfa79BKTnAOyx215c/3RJPJpdQwoHZ3earVH7AA==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/runtime@7.29.7':
-        resolution:
-            {
-                integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/template@7.29.7':
-        resolution:
-            {
-                integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/traverse@7.29.7':
-        resolution:
-            {
-                integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/types@7.29.7':
-        resolution:
-            {
-                integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@better-auth/core@1.6.18':
-        resolution:
-            {
-                integrity: sha512-mlPZBKHY6gZdJtuY6LiuKjN2r8AWu0LCss7CEnI0xMbE9D7Sw6WofwPPwiMm+0Hi0QBKIaZGYRmR7/WasbOs+Q==,
-            }
-        peerDependencies:
-            '@better-auth/utils': 0.4.1
-            '@better-fetch/fetch': 1.3.0
-            '@cloudflare/workers-types': '>=4'
-            '@opentelemetry/api': ^1.9.0
-            better-call: 1.3.6
-            jose: ^6.1.0
-            kysely: ^0.28.5 || ^0.29.0
-            nanostores: ^1.0.1
-        peerDependenciesMeta:
-            '@cloudflare/workers-types':
-                optional: true
-            '@opentelemetry/api':
-                optional: true
-
-    '@better-auth/core@1.6.20':
-        resolution:
-            {
-                integrity: sha512-y73I1xNXuNYiHBFduWGRcJ2ro2rNuVDEYkgVMJtIaRXtbosdXHs9gfyQrHecgeHMHKx1SYSBT/CExak0vVMTng==,
-            }
-        peerDependencies:
-            '@better-auth/utils': 0.4.2
-            '@better-fetch/fetch': 1.3.1
-            '@cloudflare/workers-types': '>=4'
-            '@opentelemetry/api': ^1.9.0
-            better-call: 1.3.6
-            jose: ^6.1.0
-            kysely: ^0.28.5 || ^0.29.0
-            nanostores: ^1.0.1
-        peerDependenciesMeta:
-            '@cloudflare/workers-types':
-                optional: true
-            '@opentelemetry/api':
-                optional: true
-
-    '@better-auth/drizzle-adapter@1.6.18':
-        resolution:
-            {
-                integrity: sha512-VFcW2YMLZt0YAD0hy6BcMkjPh4Rh9khV71jnV2uL3udqz599Z1P4PiuWO6XZLELTvb/bbAUnxS5ZnyXQwFDAPQ==,
-            }
-        peerDependencies:
-            '@better-auth/core': ^1.6.18
-            '@better-auth/utils': 0.4.1
-            drizzle-orm: ^0.45.2
-        peerDependenciesMeta:
-            drizzle-orm:
-                optional: true
-
-    '@better-auth/drizzle-adapter@1.6.20':
-        resolution:
-            {
-                integrity: sha512-hJHfCdAiZrC7EmZAt3NAiGgcNo9Y5Qz3PLL+a9rODXaAJGCMvzUJniqef9wHuJBwU0SWW+2f4wXe8xQmaC/IKQ==,
-            }
-        peerDependencies:
-            '@better-auth/core': ^1.6.20
-            '@better-auth/utils': 0.4.2
-            drizzle-orm: ^0.45.2
-        peerDependenciesMeta:
-            drizzle-orm:
-                optional: true
-
-    '@better-auth/kysely-adapter@1.6.18':
-        resolution:
-            {
-                integrity: sha512-7Q9+LYWiVD8t3nrxN/fPqZOgUQFcVh+KUo95CDj2+Hfnf4GCb6/ZsQrEnBXBgplwBQbUOYN58Lp/uevb6ugwFQ==,
-            }
-        peerDependencies:
-            '@better-auth/core': ^1.6.18
-            '@better-auth/utils': 0.4.1
-            kysely: ^0.28.17 || ^0.29.0
-        peerDependenciesMeta:
-            kysely:
-                optional: true
-
-    '@better-auth/kysely-adapter@1.6.20':
-        resolution:
-            {
-                integrity: sha512-Uvpmgbx5y8JqXroVanNzDdKzOl3HojoTz+/X6MR6zOUr25IzlYz660mjnu0rxKiIF55kD3CroqFsDzjNUw7ERw==,
-            }
-        peerDependencies:
-            '@better-auth/core': ^1.6.20
-            '@better-auth/utils': 0.4.2
-            kysely: ^0.28.17 || ^0.29.0
-        peerDependenciesMeta:
-            kysely:
-                optional: true
-
-    '@better-auth/memory-adapter@1.6.18':
-        resolution:
-            {
-                integrity: sha512-jHulNRsA0OGKAACmsCNfAbH2z0NEoLQCLdZTU6Pvqn/Cd+xh7aFz0oys69KyKZp2r30QUjuEG9FrrqS8ASWDiw==,
-            }
-        peerDependencies:
-            '@better-auth/core': ^1.6.18
-            '@better-auth/utils': 0.4.1
-
-    '@better-auth/memory-adapter@1.6.20':
-        resolution:
-            {
-                integrity: sha512-J5Ni0LlFijbzXlwu2rFHaD8zEFocmajyzWkRnHsq8LhV/Dk4iWQwwnqzLrPoDQEj8roECAUF03hrIeMzqWRqJQ==,
-            }
-        peerDependencies:
-            '@better-auth/core': ^1.6.20
-            '@better-auth/utils': 0.4.2
-
-    '@better-auth/mongo-adapter@1.6.18':
-        resolution:
-            {
-                integrity: sha512-A6aD3sKsptQl5sBq2wFoLGckEIM5Pa93T//R1DR+erAZOMejZGyaqYaPXWwRk7ZejFOyrftMm98OP0IJsz52gg==,
-            }
-        peerDependencies:
-            '@better-auth/core': ^1.6.18
-            '@better-auth/utils': 0.4.1
-            mongodb: ^6.0.0 || ^7.0.0
-        peerDependenciesMeta:
-            mongodb:
-                optional: true
-
-    '@better-auth/mongo-adapter@1.6.20':
-        resolution:
-            {
-                integrity: sha512-ClDBJf6h4g85WJswxwQwxLaiyRU67Gmz/uaIf19tY1gqlLJDykSGjmqRNSBMG5rWABNzcNqbO4KG31rYUldbIw==,
-            }
-        peerDependencies:
-            '@better-auth/core': ^1.6.20
-            '@better-auth/utils': 0.4.2
-            mongodb: ^6.0.0 || ^7.0.0
-        peerDependenciesMeta:
-            mongodb:
-                optional: true
-
-    '@better-auth/prisma-adapter@1.6.18':
-        resolution:
-            {
-                integrity: sha512-9hJrDYDqGpb53o8BUuB8uunkkeY+nACzYpZr06R8+22zTFS/NL/jLwgUlK3Xf+1VjhBoXAoEBKJ3ghVUGu6jFw==,
-            }
-        peerDependencies:
-            '@better-auth/core': ^1.6.18
-            '@better-auth/utils': 0.4.1
-            '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
-            prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
-        peerDependenciesMeta:
-            '@prisma/client':
-                optional: true
-            prisma:
-                optional: true
-
-    '@better-auth/prisma-adapter@1.6.20':
-        resolution:
-            {
-                integrity: sha512-WhYdhSGuVSfu1peCSf2snmmVzfWjRaEvbSrsNCusiwGE9l94HlES4mjSPM48fed24hL7yg4j1dYK/yjEt87FpQ==,
-            }
-        peerDependencies:
-            '@better-auth/core': ^1.6.20
-            '@better-auth/utils': 0.4.2
-            '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
-            prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
-        peerDependenciesMeta:
-            '@prisma/client':
-                optional: true
-            prisma:
-                optional: true
-
-    '@better-auth/telemetry@1.6.18':
-        resolution:
-            {
-                integrity: sha512-C/sWZzDAFrtb8bFs+yLHLYYfk1Yffw2GnKXerxTGO3rHI7qV2Ktf359nAf3IdZr+cC/404fFk4hkDCnQiGCkZA==,
-            }
-        peerDependencies:
-            '@better-auth/core': ^1.6.18
-            '@better-auth/utils': 0.4.1
-            '@better-fetch/fetch': 1.3.0
-
-    '@better-auth/telemetry@1.6.20':
-        resolution:
-            {
-                integrity: sha512-3BhbY3naQDERvdJvJ7fGszVY6rpsVfc6c9uyBVZlC1coVEF/rkM0rIcjtMVI1GUH7vWy1wjR6qF5vQnMun3XNQ==,
-            }
-        peerDependencies:
-            '@better-auth/core': ^1.6.20
-            '@better-auth/utils': 0.4.2
-            '@better-fetch/fetch': 1.3.1
-
-    '@better-auth/utils@0.4.1':
-        resolution:
-            {
-                integrity: sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==,
-            }
-
-    '@better-auth/utils@0.4.2':
-        resolution:
-            {
-                integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==,
-            }
-
-    '@better-fetch/fetch@1.3.0':
-        resolution:
-            {
-                integrity: sha512-Lgkl18IrUURFqa1nE38GNDWXf7XGzfxXQDCE/alCQV0yZ98YrPGtlmW61ch1T4YRt3lxrSAGA+Ft73FzuWWb3A==,
-            }
-
-    '@better-fetch/fetch@1.3.1':
-        resolution:
-            {
-                integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==,
-            }
-
-    '@blazediff/core@1.9.1':
-        resolution:
-            {
-                integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==,
-            }
-
-    '@bomb.sh/args@0.3.1':
-        resolution:
-            {
-                integrity: sha512-CwxKrfgcorUPP6KfYD59aRdBYWBTsfsxT+GmoLVnKo5Tmyoqbpo0UNcjngRMyU+6tiPbd18RuIYxhgAn44wU/Q==,
-            }
-
-    '@clack/core@1.4.1':
-        resolution:
-            {
-                integrity: sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==,
-            }
-        engines: { node: '>= 20.12.0' }
-
-    '@clack/prompts@1.5.1':
-        resolution:
-            {
-                integrity: sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==,
-            }
-        engines: { node: '>= 20.12.0' }
-
-    '@colordx/core@5.4.3':
-        resolution:
-            {
-                integrity: sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==,
-            }
-
-    '@drizzle-team/brocli@0.11.0':
-        resolution:
-            {
-                integrity: sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg==,
-            }
-
-    '@ecopages/jsx@0.3.0-alpha.25':
-        resolution:
-            {
-                integrity: sha512-sEjCLWEosxIHmsDzkhFix79B8km2jhwE8KPjTcmegw/EmAr7NPjIxerVnHE1sT4+o6VR9p+NrEhu82v05LRuGw==,
-            }
-        peerDependencies:
-            typescript: ^5
-
-    '@ecopages/logger@0.2.3':
-        resolution:
-            {
-                integrity: sha512-Hkt5H9Kzv6y07aiPZPaDkJ6/Bp7+Aen5ZFuI5zQ6ON7PyeuVu1lMiQy9pL+9Wm8yeO3wnMO44Jmph84Cc0X0lQ==,
-            }
-        peerDependencies:
-            typescript: ^5.0.0
-
-    '@ecopages/radiant@0.3.0-alpha.25':
-        resolution:
-            {
-                integrity: sha512-qz6FP2ymTAR1lR1AoM7RjQBmPM4vEQ1dv8YijZpCBDKy4IWDzSK3hZHgK2MGC5KvnPdUC6HZwDh380Qzxxg1Pg==,
-            }
-        peerDependencies:
-            '@ecopages/jsx': '>=0.3.0-alpha.0 <1.0.0'
-            '@ecopages/signals': '>=0.3.0-alpha.0 <1.0.0'
-
-    '@ecopages/scripts-injector@0.1.5':
-        resolution:
-            {
-                integrity: sha512-4julGcmVkf4G8asK0/vAZ9o9bIWudEyGk4D/rRF/IE2J4ePT5FgmR8QdzRxD+DElzEnkJTnS7gyX2Dj7JeNtdg==,
-            }
-        peerDependencies:
-            typescript: ^5.0.0
-
-    '@ecopages/signals@0.3.0-alpha.25':
-        resolution:
-            {
-                integrity: sha512-X4zEa2KONuJI84uGy0iTAMcYhvRPsSzj4swuHZVIhxudexkr/GLK1zcv4nXDa5ggB4kj/pCXbn3jMOVSkNB0xA==,
-            }
-        peerDependencies:
-            typescript: ^5
-
-    '@emnapi/core@1.10.0':
-        resolution:
-            {
-                integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
-            }
-
-    '@emnapi/core@1.11.0':
-        resolution:
-            {
-                integrity: sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==,
-            }
-
-    '@emnapi/runtime@1.10.0':
-        resolution:
-            {
-                integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
-            }
-
-    '@emnapi/runtime@1.11.0':
-        resolution:
-            {
-                integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==,
-            }
-
-    '@emnapi/runtime@1.11.1':
-        resolution:
-            {
-                integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==,
-            }
-
-    '@emnapi/wasi-threads@1.2.1':
-        resolution:
-            {
-                integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
-            }
-
-    '@emnapi/wasi-threads@1.2.2':
-        resolution:
-            {
-                integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==,
-            }
-
-    '@esbuild/aix-ppc64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ppc64]
-        os: [aix]
-
-    '@esbuild/aix-ppc64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ppc64]
-        os: [aix]
-
-    '@esbuild/android-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [android]
-
-    '@esbuild/android-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [android]
-
-    '@esbuild/android-arm@0.25.12':
-        resolution:
-            {
-                integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm]
-        os: [android]
-
-    '@esbuild/android-arm@0.28.1':
-        resolution:
-            {
-                integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm]
-        os: [android]
-
-    '@esbuild/android-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [android]
-
-    '@esbuild/android-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [android]
-
-    '@esbuild/darwin-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@esbuild/darwin-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@esbuild/darwin-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [darwin]
-
-    '@esbuild/darwin-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [darwin]
-
-    '@esbuild/freebsd-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [freebsd]
-
-    '@esbuild/freebsd-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [freebsd]
-
-    '@esbuild/freebsd-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@esbuild/freebsd-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@esbuild/linux-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [linux]
-
-    '@esbuild/linux-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [linux]
-
-    '@esbuild/linux-arm@0.25.12':
-        resolution:
-            {
-                integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm]
-        os: [linux]
-
-    '@esbuild/linux-arm@0.28.1':
-        resolution:
-            {
-                integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm]
-        os: [linux]
-
-    '@esbuild/linux-ia32@0.25.12':
-        resolution:
-            {
-                integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ia32]
-        os: [linux]
-
-    '@esbuild/linux-ia32@0.28.1':
-        resolution:
-            {
-                integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ia32]
-        os: [linux]
-
-    '@esbuild/linux-loong64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
-            }
-        engines: { node: '>=18' }
-        cpu: [loong64]
-        os: [linux]
-
-    '@esbuild/linux-loong64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [loong64]
-        os: [linux]
-
-    '@esbuild/linux-mips64el@0.25.12':
-        resolution:
-            {
-                integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [mips64el]
-        os: [linux]
-
-    '@esbuild/linux-mips64el@0.28.1':
-        resolution:
-            {
-                integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [mips64el]
-        os: [linux]
-
-    '@esbuild/linux-ppc64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ppc64]
-        os: [linux]
-
-    '@esbuild/linux-ppc64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ppc64]
-        os: [linux]
-
-    '@esbuild/linux-riscv64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
-            }
-        engines: { node: '>=18' }
-        cpu: [riscv64]
-        os: [linux]
-
-    '@esbuild/linux-riscv64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [riscv64]
-        os: [linux]
-
-    '@esbuild/linux-s390x@0.25.12':
-        resolution:
-            {
-                integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [s390x]
-        os: [linux]
-
-    '@esbuild/linux-s390x@0.28.1':
-        resolution:
-            {
-                integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==,
-            }
-        engines: { node: '>=18' }
-        cpu: [s390x]
-        os: [linux]
-
-    '@esbuild/linux-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [linux]
-
-    '@esbuild/linux-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [linux]
-
-    '@esbuild/netbsd-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [netbsd]
-
-    '@esbuild/netbsd-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [netbsd]
-
-    '@esbuild/netbsd-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [netbsd]
-
-    '@esbuild/netbsd-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [netbsd]
-
-    '@esbuild/openbsd-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [openbsd]
-
-    '@esbuild/openbsd-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [openbsd]
-
-    '@esbuild/openbsd-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [openbsd]
-
-    '@esbuild/openbsd-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [openbsd]
-
-    '@esbuild/openharmony-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@esbuild/openharmony-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@esbuild/sunos-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [sunos]
-
-    '@esbuild/sunos-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [sunos]
-
-    '@esbuild/win32-arm64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [win32]
-
-    '@esbuild/win32-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [win32]
-
-    '@esbuild/win32-ia32@0.25.12':
-        resolution:
-            {
-                integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ia32]
-        os: [win32]
-
-    '@esbuild/win32-ia32@0.28.1':
-        resolution:
-            {
-                integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ia32]
-        os: [win32]
-
-    '@esbuild/win32-x64@0.25.12':
-        resolution:
-            {
-                integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [win32]
-
-    '@esbuild/win32-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [win32]
-
-    '@faker-js/faker@10.4.0':
-        resolution:
-            {
-                integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==,
-            }
-        engines: { node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10' }
-
-    '@faker-js/faker@9.7.0':
-        resolution:
-            {
-                integrity: sha512-aozo5vqjCmDoXLNUJarFZx2IN/GgGaogY4TMJ6so/WLZOWpSV7fvj2dmrV6sEAnUm1O7aCrhTibjpzeDFgNqbg==,
-            }
-        engines: { node: '>=18.0.0', npm: '>=9.0.0' }
-
-    '@fontsource-variable/jetbrains-mono@5.2.8':
-        resolution:
-            {
-                integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==,
-            }
-
-    '@img/colour@1.1.0':
-        resolution:
-            {
-                integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==,
-            }
-        engines: { node: '>=18' }
-
-    '@img/sharp-darwin-arm64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@img/sharp-darwin-x64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [x64]
-        os: [darwin]
-
-    '@img/sharp-libvips-darwin-arm64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==,
-            }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@img/sharp-libvips-darwin-x64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==,
-            }
-        cpu: [x64]
-        os: [darwin]
-
-    '@img/sharp-libvips-linux-arm64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==,
-            }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@img/sharp-libvips-linux-arm@1.2.4':
-        resolution:
-            {
-                integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==,
-            }
-        cpu: [arm]
-        os: [linux]
-        libc: [glibc]
-
-    '@img/sharp-libvips-linux-ppc64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==,
-            }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@img/sharp-libvips-linux-riscv64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==,
-            }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [glibc]
-
-    '@img/sharp-libvips-linux-s390x@1.2.4':
-        resolution:
-            {
-                integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==,
-            }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@img/sharp-libvips-linux-x64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==,
-            }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==,
-            }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-        resolution:
-            {
-                integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==,
-            }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@img/sharp-linux-arm64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@img/sharp-linux-arm@0.34.5':
-        resolution:
-            {
-                integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [arm]
-        os: [linux]
-        libc: [glibc]
-
-    '@img/sharp-linux-ppc64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@img/sharp-linux-riscv64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [glibc]
-
-    '@img/sharp-linux-s390x@0.34.5':
-        resolution:
-            {
-                integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@img/sharp-linux-x64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@img/sharp-linuxmusl-arm64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@img/sharp-linuxmusl-x64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@img/sharp-wasm32@0.34.5':
-        resolution:
-            {
-                integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [wasm32]
-
-    '@img/sharp-win32-arm64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [arm64]
-        os: [win32]
-
-    '@img/sharp-win32-ia32@0.34.5':
-        resolution:
-            {
-                integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [ia32]
-        os: [win32]
-
-    '@img/sharp-win32-x64@0.34.5':
-        resolution:
-            {
-                integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-        cpu: [x64]
-        os: [win32]
-
-    '@internationalized/date@3.12.2':
-        resolution:
-            {
-                integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==,
-            }
-
-    '@internationalized/number@3.6.7':
-        resolution:
-            {
-                integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==,
-            }
-
-    '@internationalized/string@3.2.9':
-        resolution:
-            {
-                integrity: sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==,
-            }
-
-    '@jridgewell/gen-mapping@0.3.13':
-        resolution:
-            {
-                integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
-            }
-
-    '@jridgewell/remapping@2.3.5':
-        resolution:
-            {
-                integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==,
-            }
-
-    '@jridgewell/resolve-uri@3.1.2':
-        resolution:
-            {
-                integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
-            }
-        engines: { node: '>=6.0.0' }
-
-    '@jridgewell/sourcemap-codec@1.5.5':
-        resolution:
-            {
-                integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
-            }
-
-    '@jridgewell/trace-mapping@0.3.31':
-        resolution:
-            {
-                integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
-            }
-
-    '@js-temporal/polyfill@0.5.1':
-        resolution:
-            {
-                integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==,
-            }
-        engines: { node: '>=12' }
-
-    '@kitajs/html@4.2.13':
-        resolution:
-            {
-                integrity: sha512-o+8e61EsoLDPTP7rsPkYolca1YFybHuxU2Lr5fWDZCUkYT/6uBlVkvnZUdCXMQKentJL9dxwpR8/xK2Q+U4LhA==,
-            }
-        engines: { node: '>=12' }
-
-    '@kitajs/ts-html-plugin@4.1.4':
-        resolution:
-            {
-                integrity: sha512-xK5mNrhnIy73kJFKx5yVGChJyWFRGmIaE0sjlVxVYllk5dyaEYVCrIh1N8AfnseEHka8gAqzPGW95HlkhDvnJA==,
-            }
-        hasBin: true
-        peerDependencies:
-            '@kitajs/html': ^4.2.10
-            typescript: ^5.9.3
-
-    '@lit-labs/ssr-client@1.1.8':
-        resolution:
-            {
-                integrity: sha512-PjGh81oKsoI64m3IDjTqqjhC7dr2uC/o0jrllUb5gRAyp/RlAHxapgJrjq9kWz97faCHLQ8jUlTi6tGm+8fgyA==,
-            }
-
-    '@lit-labs/ssr-dom-shim@1.6.0':
-        resolution:
-            {
-                integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==,
-            }
-
-    '@lit-labs/ssr@3.3.1':
-        resolution:
-            {
-                integrity: sha512-JlF1PempxvzrGEpRFrF+Ki0MHzR3HA51SK8Zv0cFpW9p0bPW4k0FeCwrElCu371UEpXF7RcaE2wgYaE1az0XKg==,
-            }
-        engines: { node: '>=13.9.0' }
-
-    '@lit/reactive-element@2.1.2':
-        resolution:
-            {
-                integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==,
-            }
-
-    '@mdx-js/mdx@3.1.1':
-        resolution:
-            {
-                integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==,
-            }
-
-    '@napi-rs/wasm-runtime@1.1.5':
-        resolution:
-            {
-                integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==,
-            }
-        peerDependencies:
-            '@emnapi/core': ^1.7.1
-            '@emnapi/runtime': ^1.7.1
-
-    '@noble/ciphers@2.2.0':
-        resolution:
-            {
-                integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==,
-            }
-        engines: { node: '>= 20.19.0' }
-
-    '@noble/hashes@2.2.0':
-        resolution:
-            {
-                integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==,
-            }
-        engines: { node: '>= 20.19.0' }
-
-    '@nodelib/fs.scandir@2.1.5':
-        resolution:
-            {
-                integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
-            }
-        engines: { node: '>= 8' }
-
-    '@nodelib/fs.stat@2.0.5':
-        resolution:
-            {
-                integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
-            }
-        engines: { node: '>= 8' }
-
-    '@nodelib/fs.walk@1.2.8':
-        resolution:
-            {
-                integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
-            }
-        engines: { node: '>= 8' }
-
-    '@opentelemetry/semantic-conventions@1.41.1':
-        resolution:
-            {
-                integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==,
-            }
-        engines: { node: '>=14' }
-
-    '@oven/bun-darwin-aarch64@1.3.14':
-        resolution:
-            {
-                integrity: sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A==,
-            }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@oven/bun-darwin-x64-baseline@1.3.14':
-        resolution:
-            {
-                integrity: sha512-OSfsTZstc898HHElhU4NccaBGOSSDn5VfahiVTnidZ9B/+wb7WTyfZJaBeJcfjwJ9H2W9uTh2TGtl3UfcXgV9g==,
-            }
-        cpu: [x64]
-        os: [darwin]
-
-    '@oven/bun-darwin-x64@1.3.14':
-        resolution:
-            {
-                integrity: sha512-FFj3QdU/OhlDyZOJ8CWfN5eWLpRlT4qjZg7lMQi7jA6GuoY5ajlO1zWLP/MuHYRSbXQUvV52RejNi8DVnAp13w==,
-            }
-        cpu: [x64]
-        os: [darwin]
-
-    '@oven/bun-freebsd-aarch64@1.3.14':
-        resolution:
-            {
-                integrity: sha512-LIKrXaFxAHybVO5Pf+9XP2FHUj/5APvXTUKk9dqHm5iFz4oH+W24cmhjkJirNujh9hKeTyrpWSe3no9JZKowIw==,
-            }
-        cpu: [arm64]
-        os: [freebsd]
-
-    '@oven/bun-freebsd-x64@1.3.14':
-        resolution:
-            {
-                integrity: sha512-uwD+fGUH1ADpIF3B1U2jWzzb20QwRLZfj5QZ28GUCGrAJ/nTmWrD6YYGsblCY1wuhldRez3lU40AyuvSCyLYmw==,
-            }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@oven/bun-linux-aarch64-android@1.3.14':
-        resolution:
-            {
-                integrity: sha512-y4kq5b85lsrmFb9Xvi4w9mA5IEFJkLMrSmYn06q24KjL9rUWDWO3VFZEtteZxUN5+ec3Zm5S8OnJw1umaCbVjA==,
-            }
-        cpu: [arm64]
-        os: [android]
-
-    '@oven/bun-linux-aarch64-musl@1.3.14':
-        resolution:
-            {
-                integrity: sha512-jmqOA92Cd1NL/1XBd4bFkJLxQ86K0RW7ohxS2qzzAvuitO4JiIxjjTeCspoU44zCozH72HpfZfUE2On31OjnWA==,
-            }
-        cpu: [arm64]
-        os: [linux]
-
-    '@oven/bun-linux-aarch64@1.3.14':
-        resolution:
-            {
-                integrity: sha512-X5SsPZHs+iYO8R/efIcRtc7gT2Q2DgPfliCxEkx4cXBumwkw0c/EsHMNwH3EgGpCDaZ7IYVPhpCG/xBOQHEwZw==,
-            }
-        cpu: [arm64]
-        os: [linux]
-
-    '@oven/bun-linux-x64-android@1.3.14':
-        resolution:
-            {
-                integrity: sha512-qe9e1d+3VAEU7nAA2ol9Jvmy/o99PVMSgZhHn7Q/9O3YcDrfEqyQ8zm4zoe5qTEo8HZH0dN03Le0Ys2eQPs7eg==,
-            }
-        cpu: [x64]
-        os: [android]
-
-    '@oven/bun-linux-x64-baseline@1.3.14':
-        resolution:
-            {
-                integrity: sha512-q/8EdOC0yUE8FPeoOVq8/Pw5I9/tJaYmUfO/uDUAREx8IUnOJH1RJ5A3BjFqre8pvJoiZA9AovPJq5FnNNjSxA==,
-            }
-        cpu: [x64]
-        os: [linux]
-
-    '@oven/bun-linux-x64-musl-baseline@1.3.14':
-        resolution:
-            {
-                integrity: sha512-n6iE71G4lQE4XkrZhQQcL5YUlxDbnq6nqV7zeQi33PMsLT/0kYE+RvHOtBWZ3w0wMdXZfINmp63hIb9ijUBGtw==,
-            }
-        cpu: [x64]
-        os: [linux]
-
-    '@oven/bun-linux-x64-musl@1.3.14':
-        resolution:
-            {
-                integrity: sha512-GBCB/k/sIqcr06eTNgg7g46qiUv35Jasx4XiccJ/n7RGqrE4RWUD/XJBbWFprVPjvqd59+QtSnS99XGqvftHfg==,
-            }
-        cpu: [x64]
-        os: [linux]
-
-    '@oven/bun-linux-x64@1.3.14':
-        resolution:
-            {
-                integrity: sha512-7OVTAKvwfPmSbIV1HpdOoVVx5VRc427GuPPne93N6vk4eQBPId9nXmZDh9/zGaKPdbVjVtQSZafWQoUjx38Utw==,
-            }
-        cpu: [x64]
-        os: [linux]
-
-    '@oven/bun-windows-aarch64@1.3.14':
-        resolution:
-            {
-                integrity: sha512-T7s3x/BsVKQObGU6QDkZeI6wKynzqGbBH1yI77jrrj5siElclxr3DQrDIk8CV4G5/SJq2HHq4kpLyYY2DKCSmA==,
-            }
-        cpu: [arm64]
-        os: [win32]
-
-    '@oven/bun-windows-x64-baseline@1.3.14':
-        resolution:
-            {
-                integrity: sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw==,
-            }
-        cpu: [x64]
-        os: [win32]
-
-    '@oven/bun-windows-x64@1.3.14':
-        resolution:
-            {
-                integrity: sha512-mUFWL3BoYkNpjd8e9PqROiFF/1Xeotq20mABJsiQH62jM1g5zqWh4khw1RZ6bX8Q8fWvlPaxG1PjofkmjUi3vg==,
-            }
-        cpu: [x64]
-        os: [win32]
-
-    '@oxc-parser/binding-android-arm-eabi@0.124.0':
-        resolution:
-            {
-                integrity: sha512-+R9zCafSL8ovjokdPtorUp3sXrh8zQ2AC2L0ivXNvlLR0WS+5WdPkNVrnENq5UvzagM4Xgl0NPsJKz3Hv9+y8g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [android]
-
-    '@oxc-parser/binding-android-arm64@0.124.0':
-        resolution:
-            {
-                integrity: sha512-ULHC/gVZ+nP4pd3kNNQTYaQ/e066BW/KuY5qUsvwkVWwOUQGDg+WpfyVOmQ4xfxoue6cMlkKkJ+ntdzfDXpNlg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [android]
-
-    '@oxc-parser/binding-darwin-arm64@0.124.0':
-        resolution:
-            {
-                integrity: sha512-fGJ2hw7bnbUYn6UvTjp0m4WJ9zXz3cohgcwcgeo7gUZehpPNpvcVEVeIVHNmHnAuAw/ysf4YJR8DA1E+xCA4Lw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@oxc-parser/binding-darwin-x64@0.124.0':
-        resolution:
-            {
-                integrity: sha512-j0+re9pgps5BH2Tk3fm59Hi3QuLP3C4KhqXi6A+wRHHHJWDFR8mc/KI9mBrfk2JRT+15doGo+zv1eN75/9DuOw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [darwin]
-
-    '@oxc-parser/binding-freebsd-x64@0.124.0':
-        resolution:
-            {
-                integrity: sha512-0k5mS0npnrhKy72UfF51lpOZ2ESoPWn6gdFw+RdeRWcokraDW1O2kSx3laQ+yk7cCEavQdJSpWCYS/GvBbUCXQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@oxc-parser/binding-linux-arm-gnueabihf@0.124.0':
-        resolution:
-            {
-                integrity: sha512-P/i4eguRWvAUfGdfhQYg1jpwYkyUV6D3gefIH7HhmRl1Ph6P4IqTIEVcyJr1i/3vr1V5OHU4wonH6/ue/Qzvrw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxc-parser/binding-linux-arm-musleabihf@0.124.0':
-        resolution:
-            {
-                integrity: sha512-/ameqFQH5fFP+66Atr8Ynv/2rYe4utcU7L4MoWS5JtrFLVO78g4qDLavyIlJxa6caSwYOvG/eO3c/DXqY5/6Rw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxc-parser/binding-linux-arm64-gnu@0.124.0':
-        resolution:
-            {
-                integrity: sha512-gNeyEcXTtfrRCbj2EfxWU85Fs0wIX3p44Y3twnvuMfkWlLrb9M1Z25AYNSKjJM+fdAjeeQCjw0on47zFuBYwQw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-arm64-musl@0.124.0':
-        resolution:
-            {
-                integrity: sha512-uvG7v4Tz9S8/PVqY0SP0DLHxo4hZGe+Pv2tGVnwcsjKCCUPjplbrFVvDzXq+kOaEoUkiCY0Kt1hlZ6FDJ1LKNQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-parser/binding-linux-ppc64-gnu@0.124.0':
-        resolution:
-            {
-                integrity: sha512-t7KZaaUhfp2au0MRpoENEFqwLKYDdptEry6V7pTAVdPEcFG4P6ii8yeGU9m6p5vb+b8WEKmdpGMNXBEYy7iJdw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-riscv64-gnu@0.124.0':
-        resolution:
-            {
-                integrity: sha512-eurGGaxHZiIQ+fBSageS8TAkRqZgdOiBeqNrWAqAPup9hXBTmQ0WcBjwsLElf+3jvDL9NhnX0dOgOqPfsjSjdg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-riscv64-musl@0.124.0':
-        resolution:
-            {
-                integrity: sha512-d1V7/ll1i/LhqE/gZy6Wbz6evlk0egh2XKkwMI3epiojtbtUwQSLIER0Y3yDBBocPuWOjJdvmjtEmPTTLXje/w==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-parser/binding-linux-s390x-gnu@0.124.0':
-        resolution:
-            {
-                integrity: sha512-w1+cBvriUteOpox6ATqCFVkpGL47PFdcfCPGmgUZbd78Fw44U0gQkc+kVGvAOTvGrptMYgwomD1c6OTVvkrpGg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-x64-gnu@0.124.0':
-        resolution:
-            {
-                integrity: sha512-RRB1evQiXRtMCsQQiAh9U0H3HzguLpE0ytfStuhRgmOj7tqUCOVxkHsvM9geZjAax6NqVRj7VXx32qjjkZPsBw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-x64-musl@0.124.0':
-        resolution:
-            {
-                integrity: sha512-asVYN0qmSHlCU8H9Q47SmeJ/Z5EG4IWCC+QGxkfFboI5qh15aLlJnHmnrV61MwQRPXGnVC/sC3qKhrUyqGxUqw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-parser/binding-openharmony-arm64@0.124.0':
-        resolution:
-            {
-                integrity: sha512-nhwuxm6B8pn9lzAzMUfa571L5hCXYwQo8C8cx5aGOuHWCzruR8gPJnRRXGBci+uGaIIQEZDyU/U6HDgrSp/JlQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@oxc-parser/binding-wasm32-wasi@0.124.0':
-        resolution:
-            {
-                integrity: sha512-LWuq4Dl9tff7n+HjJcqoBjDlVCtruc0shgtdtGM+rTUIE9aFxHA/P+wCYR+aWMjN8m9vNaRME/sKXErmhmeKrA==,
-            }
-        engines: { node: '>=14.0.0' }
-        cpu: [wasm32]
-
-    '@oxc-parser/binding-win32-arm64-msvc@0.124.0':
-        resolution:
-            {
-                integrity: sha512-aOh3Lf3AeH0dgzT4yBXcArFZ8VhqNXwZ/xlN0GqBtgVaGoHOOqL2YHlcVIgT+ghsXPVR2PTtYgBiQ1CNK7jp5A==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [win32]
-
-    '@oxc-parser/binding-win32-ia32-msvc@0.124.0':
-        resolution:
-            {
-                integrity: sha512-sib5xC0nz/+SCpaETBuHBz4SXS02KuG5HtyOcHsO/SK5ZvLRGhOZx0elDKawjb6adFkD7dQCqpXUS25wY6ELKQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ia32]
-        os: [win32]
-
-    '@oxc-parser/binding-win32-x64-msvc@0.124.0':
-        resolution:
-            {
-                integrity: sha512-UgojtjGUgZgAZQYt7SC6VO65OVdxEkRe2q+2vbHJO//18qw3Hrk6UvHGQKldsQKgbVcIBT/YBrt85YberiYIPQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [win32]
-
-    '@oxc-project/runtime@0.134.0':
-        resolution:
-            {
-                integrity: sha512-PhlC0Gh07BXtuyedE8WA7Z42gIlf3PmBDv/CqrJi4/yfVC9/D1iCOU7YjzB4ITQT1gOdrf228uROOeK7aPnyTg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-
-    '@oxc-project/types@0.122.0':
-        resolution:
-            {
-                integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==,
-            }
-
-    '@oxc-project/types@0.124.0':
-        resolution:
-            {
-                integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==,
-            }
-
-    '@oxc-project/types@0.133.0':
-        resolution:
-            {
-                integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==,
-            }
-
-    '@oxc-project/types@0.135.0':
-        resolution:
-            {
-                integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==,
-            }
-
-    '@oxc-transform/binding-android-arm-eabi@0.124.0':
-        resolution:
-            {
-                integrity: sha512-A7r8E94VSRnWlsquGXaW2rmpVcruNOTE4a/7+NCVOtlRUlbmd37bOfv0T47MLIN378uES7yldftCwcVMBG39ig==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [android]
-
-    '@oxc-transform/binding-android-arm64@0.124.0':
-        resolution:
-            {
-                integrity: sha512-vfxxGti1ihWIOjgJOhS6HKIDqp7rszhmbTTgi81otUbJZ/1OWAMcKQyBvKb80hZabdvxU+dxzjGXottW2K/LMw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [android]
-
-    '@oxc-transform/binding-darwin-arm64@0.124.0':
-        resolution:
-            {
-                integrity: sha512-goa0sKt6dymRY9kUCA/EgXDJUQq0dj8Acedn7FkjV77RxYZjykexlAV+amM7FnuD3vGTiG5DfL3j4WKWFGnFKA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@oxc-transform/binding-darwin-x64@0.124.0':
-        resolution:
-            {
-                integrity: sha512-fNzAFPbPPZDtoXlVwfXWaqp75bPdsNNqbCTnBSsT8qssQoo3Wy8H0fF1U+ltv/9z/UxkGwKow3X4LUaWiHacfw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [darwin]
-
-    '@oxc-transform/binding-freebsd-x64@0.124.0':
-        resolution:
-            {
-                integrity: sha512-GxMoOttUJBXjTYrpj0S24dpDSuTqUScgNmNHN9ICIh5uN4pTQ/2DI+tp8LX5170fZuvU2dpkZvhJT7hNthqWhA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@oxc-transform/binding-linux-arm-gnueabihf@0.124.0':
-        resolution:
-            {
-                integrity: sha512-Tjhs7VKsFoyZ6+sYLJ4JeQuqxouTMTSdkxPeCPJuQ9TkAlA8Pz8JnlF3V0fxSLkQfz0lYSRvA6J9/RUO5r7+8Q==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxc-transform/binding-linux-arm-musleabihf@0.124.0':
-        resolution:
-            {
-                integrity: sha512-3GFThaQKrokWlz5PxclCwuYmNJpiqJ8pECShmaUJ0ACQlzlvXmXLdWy7ImfygGeqKIWq0N7Ps/+fH4gIrsaVRg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxc-transform/binding-linux-arm64-gnu@0.124.0':
-        resolution:
-            {
-                integrity: sha512-dY4cbuDbKPEpbxRe85imTO7pRba83z/sAmcYPUtb6ZvOEI4cEY8h0nMI5YRmeZMBF5xXQ1a95fyiDf35f63keQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-transform/binding-linux-arm64-musl@0.124.0':
-        resolution:
-            {
-                integrity: sha512-X5jBDOv7df39YNp9rq3oGo9SAWhtChJYxPnwHzm9FdvbQ6NmASxylipWXnKu6M025Dwpg/1bjiBbG9XuYhXBFA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-transform/binding-linux-ppc64-gnu@0.124.0':
-        resolution:
-            {
-                integrity: sha512-e4oc7gBUPnroe+dhTT+mOtXkXcWkSZZojd4xDpMKAhy6hpKUVBotnudoEPIR7HAOXRmktlgx5ab2zSnYR2kydA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-transform/binding-linux-riscv64-gnu@0.124.0':
-        resolution:
-            {
-                integrity: sha512-t+WUSyPoq0kobE+AKVHOHQMdijjA8RxhDwYSVgPHAF5c4mPwkD9EtZj1FyBNtRYgRuPQq8dWHGnNZXyFouNJ5w==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-transform/binding-linux-riscv64-musl@0.124.0':
-        resolution:
-            {
-                integrity: sha512-jNApR8gnWbR2zYM+a04jve2xa7qi25zYYb7feTrpV98J+YJaiPVJhzoXHxnKQGKSj7oMt6n6YK1QQVG+LlVpjw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-transform/binding-linux-s390x-gnu@0.124.0':
-        resolution:
-            {
-                integrity: sha512-SxLmO/ycauLKadwP9dvRpt8qRKZKaQER1OnvC6eY8hKXiN0EF+pL5QaPIIje7PV8sieRrrOcrSeKFBv+C6t0Ug==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-transform/binding-linux-x64-gnu@0.124.0':
-        resolution:
-            {
-                integrity: sha512-TsPm58U1lq3rzhxegdMiy7ej0M3xKIxm+IHfgOg/n8g95fGT9D0E1sswTRBlAQtkXPnVfuqW8Hxf8t/4fCjqzw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-transform/binding-linux-x64-musl@0.124.0':
-        resolution:
-            {
-                integrity: sha512-nRg8/cItmAlKZD+jE5YqwDdvZ0GkvJAMavBshm0awhDn5RURWE5317QwDOvR3bZviRInv62C3eYMZdk0O64zPw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-transform/binding-openharmony-arm64@0.124.0':
-        resolution:
-            {
-                integrity: sha512-NBDXwqbaYvjRy0wslzP/2V4L59r930htq4merS3HHBKI994J36zPZF6732bw6CUfUnXObe0qfOWPMmH+8f3ktw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@oxc-transform/binding-wasm32-wasi@0.124.0':
-        resolution:
-            {
-                integrity: sha512-iK+9DYYI/eqEWAMZ40b2ip5OiMv/BSyR0jCc5rLE1PAVUFyFHglxLv8sInZqFnkWpnlvlfTZy71GNDn6fq+xFQ==,
-            }
-        engines: { node: '>=14.0.0' }
-        cpu: [wasm32]
-
-    '@oxc-transform/binding-win32-arm64-msvc@0.124.0':
-        resolution:
-            {
-                integrity: sha512-GffpZFW5mBAIxbFoNrGagNqloFU2gAM+wFEuzGsPu2CmcZqsbKzbf5ydU3sUlEt0kxXqW9IYsZhXsa2fnkzMpw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [win32]
-
-    '@oxc-transform/binding-win32-ia32-msvc@0.124.0':
-        resolution:
-            {
-                integrity: sha512-S+GHzB7y62H0tZIMRC5NIuB247xb5DYhnha/KcIBCCmcxl8rg9bJOez5Kyfd2yfda2LjqPdrx6GalZmhj2wJgg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ia32]
-        os: [win32]
-
-    '@oxc-transform/binding-win32-x64-msvc@0.124.0':
-        resolution:
-            {
-                integrity: sha512-zRQMSYNrqUJfbAKOPhFFqo0aiAA850/ZVyrDIGbbbCaF499OwdK6Odt7TRsy97hgEW1w73gKO4KV6Y/HZV42Zg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [win32]
-
-    '@oxlint/binding-android-arm-eabi@1.69.0':
-        resolution:
-            {
-                integrity: sha512-DKQQbD5cZ/MYfDgDI7YGyGD9FSxABlsBsYFo5p26lloob543tP9+4N3guwdXIYJN+7HSZxLe8YJuwcOWw5qnHg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [android]
-
-    '@oxlint/binding-android-arm64@1.69.0':
-        resolution:
-            {
-                integrity: sha512-lEhb+I5pr4inux+JFwfCa1HRq3Os7NirEFQ0H1I35SVEHPm6byX0Ah47xmRha3qi6LAkxUcxViL8o/9PivjzBg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [android]
-
-    '@oxlint/binding-darwin-arm64@1.69.0':
-        resolution:
-            {
-                integrity: sha512-GY2YE8lOZW59BW1Ia1y+1gR0XyjrZRvVWHAr8LGeGhYHE0OQJ/7cRKXTkx1P+E9/6awEc3SX8a68SFTjh/E//A==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@oxlint/binding-darwin-x64@1.69.0':
-        resolution:
-            {
-                integrity: sha512-ax1oZnOjHX3LB7myQyHEaQkDwfLb6str3/nSP6O7EVUviQGNkEGzGV0EqcBJWK+Ufwx0l4xPgyYayurvhAdl2Q==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [darwin]
-
-    '@oxlint/binding-freebsd-x64@1.69.0':
-        resolution:
-            {
-                integrity: sha512-kHWeHv4g2h8NY+mpCxzCtY4uerMJWTN/TSnNj1CPbakFpHEJ6cTya2wWV0pDSYWOJ2+0UiEbhn3AtXxHtsnKjg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@oxlint/binding-linux-arm-gnueabihf@1.69.0':
-        resolution:
-            {
-                integrity: sha512-gq84vM1a1oEehXo27YCDzGVcxPsZDI1yswZwz2Da1/cbnWtrL16XZZnz0G/+gIU8edtHpfjxq5c+vWEHqJfWoQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxlint/binding-linux-arm-musleabihf@1.69.0':
-        resolution:
-            {
-                integrity: sha512-kIqEa98JQ0VRyrcncxA417m2AzasqTlD+FyVT1AksjvjkqQcvm7pBWYvoW3/mpyOP2XYvi5nSCCTIe6De1yu5g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxlint/binding-linux-arm64-gnu@1.69.0':
-        resolution:
-            {
-                integrity: sha512-j+xYiXozxGWx2cpjCrwwGR4awTxPFsRv3JZrv23RCogEPMc4R7UqjHW47p/RG0aRlbWiROCJ8coUfCwy0dvzHA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxlint/binding-linux-arm64-musl@1.69.0':
-        resolution:
-            {
-                integrity: sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxlint/binding-linux-ppc64-gnu@1.69.0':
-        resolution:
-            {
-                integrity: sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxlint/binding-linux-riscv64-gnu@1.69.0':
-        resolution:
-            {
-                integrity: sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxlint/binding-linux-riscv64-musl@1.69.0':
-        resolution:
-            {
-                integrity: sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxlint/binding-linux-s390x-gnu@1.69.0':
-        resolution:
-            {
-                integrity: sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxlint/binding-linux-x64-gnu@1.69.0':
-        resolution:
-            {
-                integrity: sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxlint/binding-linux-x64-musl@1.69.0':
-        resolution:
-            {
-                integrity: sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxlint/binding-openharmony-arm64@1.69.0':
-        resolution:
-            {
-                integrity: sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@oxlint/binding-win32-arm64-msvc@1.69.0':
-        resolution:
-            {
-                integrity: sha512-9RExaLgmaw6IoIkU9cTpT71mLfI0xZ86iZH8x518LVsOkjquJMYqb9P7KpC8lgd1t0Dxs41p2pxynq4XR3Ttzw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [win32]
-
-    '@oxlint/binding-win32-ia32-msvc@1.69.0':
-        resolution:
-            {
-                integrity: sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ia32]
-        os: [win32]
-
-    '@oxlint/binding-win32-x64-msvc@1.69.0':
-        resolution:
-            {
-                integrity: sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [win32]
-
-    '@parse5/tools@0.3.0':
-        resolution:
-            {
-                integrity: sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==,
-            }
-
-    '@playwright/test@1.60.0':
-        resolution:
-            {
-                integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==,
-            }
-        engines: { node: '>=18' }
-        hasBin: true
-
-    '@polka/url@1.0.0-next.29':
-        resolution:
-            {
-                integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==,
-            }
-
-    '@react-types/shared@3.35.0':
-        resolution:
-            {
-                integrity: sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==,
-            }
-        peerDependencies:
-            react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-    '@rehype-pretty/transformers@0.13.2':
-        resolution:
-            {
-                integrity: sha512-p2ciQSwqy5Ip8aNUa9q6rdS/hJZXrxHYYfDVOHvKOsBu3t9HDmQ65YX6r9Qbl19vi160OAxmGF7MIoCRDJrRhg==,
-            }
-        engines: { node: '>=18' }
-
-    '@rolldown/binding-android-arm64@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [android]
-
-    '@rolldown/binding-android-arm64@1.0.3':
-        resolution:
-            {
-                integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [android]
-
-    '@rolldown/binding-android-arm64@1.1.1':
-        resolution:
-            {
-                integrity: sha512-BLf9Wak/gfwVb7NQTQW4wBgL3oAfPy7ArEkhwV543OVw/uY6B47z5xYsqPSZ9PDOorvURPinws6ThaFuNgGLgA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [android]
-
-    '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@rolldown/binding-darwin-arm64@1.0.3':
-        resolution:
-            {
-                integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@rolldown/binding-darwin-arm64@1.1.1':
-        resolution:
-            {
-                integrity: sha512-rRZRPy/Ynb+Mxu0O6tfPldHeDgAn0sRij+IOUy6sFdUlv3hArGW/DloE3GfAxtqpOJuRNgF74Nr5gM4xBeU2jQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@rolldown/binding-darwin-x64@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [darwin]
-
-    '@rolldown/binding-darwin-x64@1.0.3':
-        resolution:
-            {
-                integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [darwin]
-
-    '@rolldown/binding-darwin-x64@1.1.1':
-        resolution:
-            {
-                integrity: sha512-/MtefPxhKPyWWFM8L45OWiEqRf+eSU2Qv9ZAyTaoZOoGcoPKxbbhjTJO2/U2IThv0uDZ4NWHc3/oTsR6IEOtww==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [darwin]
-
-    '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@rolldown/binding-freebsd-x64@1.0.3':
-        resolution:
-            {
-                integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@rolldown/binding-freebsd-x64@1.1.1':
-        resolution:
-            {
-                integrity: sha512-202K+cpIi1kx/Zn7AtxBi4LTXSY67Aszb2K9rNsuW7FeBeh0nqoNmYLOSZidV0p88VPBzMmTZcHAdPNo3kRYzQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
-        resolution:
-            {
-                integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
-        resolution:
-            {
-                integrity: sha512-wl9NfeXNUwrXtUc063tddmZFUI6qiNs1CNOwni0OL4vC7MqVSYugra3ZgtDmtVy8e0DluJTENmzIv2BwqLzT4Q==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-arm64-gnu@1.0.3':
-        resolution:
-            {
-                integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-arm64-gnu@1.1.1':
-        resolution:
-            {
-                integrity: sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@rolldown/binding-linux-arm64-musl@1.0.3':
-        resolution:
-            {
-                integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@rolldown/binding-linux-arm64-musl@1.1.1':
-        resolution:
-            {
-                integrity: sha512-5PUjZx366h9tkJTPJF5eibxOlK3sGoeRiBJLLjjEB5/kLDuhr6qB3LkhqLz1smXNgsX+pBhnbcJBrPE30HznAA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-ppc64-gnu@1.0.3':
-        resolution:
-            {
-                integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-ppc64-gnu@1.1.1':
-        resolution:
-            {
-                integrity: sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-s390x-gnu@1.0.3':
-        resolution:
-            {
-                integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-s390x-gnu@1.1.1':
-        resolution:
-            {
-                integrity: sha512-1nS1X5z1uMJ369RU25hTpKCFvUwXZp12dIzlzk4S+UxCTcSVGsAE6tzkOSufv/7jnmAtK0ZlrsJxh2fGmsnVSw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-x64-gnu@1.0.3':
-        resolution:
-            {
-                integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-x64-gnu@1.1.1':
-        resolution:
-            {
-                integrity: sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@rolldown/binding-linux-x64-musl@1.0.3':
-        resolution:
-            {
-                integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@rolldown/binding-linux-x64-musl@1.1.1':
-        resolution:
-            {
-                integrity: sha512-+n46LhDrJFQM+229y4oXtVpj1G50U/+XuHMlpnisFTEXhrg9f/YIjp/HymX+PVJjBEr7XHRs3CFLelV464pqwA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@rolldown/binding-openharmony-arm64@1.0.3':
-        resolution:
-            {
-                integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@rolldown/binding-openharmony-arm64@1.1.1':
-        resolution:
-            {
-                integrity: sha512-qGwEu47zOWYo7LdRHhCWTNhzwGtxXpdY6CERs8QEOqC0PXGGics/e3vHnyEUKt8xK6YkbZXFUCeklrpB6js8ag==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==,
-            }
-        engines: { node: '>=14.0.0' }
-        cpu: [wasm32]
-
-    '@rolldown/binding-wasm32-wasi@1.0.3':
-        resolution:
-            {
-                integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [wasm32]
-
-    '@rolldown/binding-wasm32-wasi@1.1.1':
-        resolution:
-            {
-                integrity: sha512-qczfgEH8u0wHGGOXtA7UMAybNKuQjjEXairyQaw4WzjiMztfbgatG1h4OKays/smhtwbWltpKCRGtVhU6h40Sg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [wasm32]
-
-    '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [win32]
-
-    '@rolldown/binding-win32-arm64-msvc@1.0.3':
-        resolution:
-            {
-                integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [win32]
-
-    '@rolldown/binding-win32-arm64-msvc@1.1.1':
-        resolution:
-            {
-                integrity: sha512-4psXSh63mSbwJF+mB8/9yfUUEzBiHYcUjxa32EO9ZwKy0Ypwjcg4F10D8SvVXgd+isy2UUUjF9HJJnDu1T/4Gg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [win32]
-
-    '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [win32]
-
-    '@rolldown/binding-win32-x64-msvc@1.0.3':
-        resolution:
-            {
-                integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [win32]
-
-    '@rolldown/binding-win32-x64-msvc@1.1.1':
-        resolution:
-            {
-                integrity: sha512-MUvC/HLXVjzkQkWiExdVTEEWf0py+GfWm8WKSZsekG3ih6a21iy0BHPF07X3JIf3ifoklZXTIaHTLPBgH1C3dw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [win32]
-
-    '@rolldown/pluginutils@1.0.0-rc.12':
-        resolution:
-            {
-                integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==,
-            }
-
-    '@rolldown/pluginutils@1.0.1':
-        resolution:
-            {
-                integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
-            }
-
-    '@shikijs/core@1.29.2':
-        resolution:
-            {
-                integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==,
-            }
-
-    '@shikijs/core@3.23.0':
-        resolution:
-            {
-                integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==,
-            }
-
-    '@shikijs/engine-javascript@1.29.2':
-        resolution:
-            {
-                integrity: sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==,
-            }
-
-    '@shikijs/engine-javascript@3.23.0':
-        resolution:
-            {
-                integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==,
-            }
-
-    '@shikijs/engine-oniguruma@1.29.2':
-        resolution:
-            {
-                integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==,
-            }
-
-    '@shikijs/engine-oniguruma@3.23.0':
-        resolution:
-            {
-                integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==,
-            }
-
-    '@shikijs/langs@1.29.2':
-        resolution:
-            {
-                integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==,
-            }
-
-    '@shikijs/langs@3.23.0':
-        resolution:
-            {
-                integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==,
-            }
-
-    '@shikijs/themes@1.29.2':
-        resolution:
-            {
-                integrity: sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==,
-            }
-
-    '@shikijs/themes@3.23.0':
-        resolution:
-            {
-                integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==,
-            }
-
-    '@shikijs/types@1.29.2':
-        resolution:
-            {
-                integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==,
-            }
-
-    '@shikijs/types@3.23.0':
-        resolution:
-            {
-                integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==,
-            }
-
-    '@shikijs/vscode-textmate@10.0.2':
-        resolution:
-            {
-                integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==,
-            }
-
-    '@standard-schema/spec@1.1.0':
-        resolution:
-            {
-                integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
-            }
-
-    '@stardazed/streams-compression@1.0.0':
-        resolution:
-            {
-                integrity: sha512-SQCiwxdIVJ5xxUBYptN+fc+tJpSDbxQuJ0+3u2SmHjIzr6JIRZ28AVFtFnGy6x6j3UBlaLx73w9rC6UAFxnd1g==,
-            }
-
-    '@stardazed/zlib@1.0.1':
-        resolution:
-            {
-                integrity: sha512-MS6PCYiRNJ32c69+3NPyL+bu7LpiFDvMcBXnlhQnF8CKMG0R/xRVCCo422NPkQ0+Cox3xKpk5Lc1LfWFS4b3cw==,
-            }
-
-    '@swc/helpers@0.5.23':
-        resolution:
-            {
-                integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==,
-            }
-
-    '@tailwindcss/node@4.3.1':
-        resolution:
-            {
-                integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==,
-            }
-
-    '@tailwindcss/oxide-android-arm64@4.3.1':
-        resolution:
-            {
-                integrity: sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [arm64]
-        os: [android]
-
-    '@tailwindcss/oxide-darwin-arm64@4.3.1':
-        resolution:
-            {
-                integrity: sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@tailwindcss/oxide-darwin-x64@4.3.1':
-        resolution:
-            {
-                integrity: sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [x64]
-        os: [darwin]
-
-    '@tailwindcss/oxide-freebsd-x64@4.3.1':
-        resolution:
-            {
-                integrity: sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
-        resolution:
-            {
-                integrity: sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [arm]
-        os: [linux]
-
-    '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
-        resolution:
-            {
-                integrity: sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
-        resolution:
-            {
-                integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
-        resolution:
-            {
-                integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@tailwindcss/oxide-linux-x64-musl@4.3.1':
-        resolution:
-            {
-                integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@tailwindcss/oxide-wasm32-wasi@4.3.1':
-        resolution:
-            {
-                integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==,
-            }
-        engines: { node: '>=14.0.0' }
-        cpu: [wasm32]
-        bundledDependencies:
-            - '@napi-rs/wasm-runtime'
-            - '@emnapi/core'
-            - '@emnapi/runtime'
-            - '@tybys/wasm-util'
-            - '@emnapi/wasi-threads'
-            - tslib
-
-    '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
-        resolution:
-            {
-                integrity: sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [arm64]
-        os: [win32]
-
-    '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
-        resolution:
-            {
-                integrity: sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [x64]
-        os: [win32]
-
-    '@tailwindcss/oxide@4.3.1':
-        resolution:
-            {
-                integrity: sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==,
-            }
-        engines: { node: '>= 20' }
-
-    '@tailwindcss/postcss@4.3.1':
-        resolution:
-            {
-                integrity: sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==,
-            }
-
-    '@tanstack/react-table@8.21.3':
-        resolution:
-            {
-                integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==,
-            }
-        engines: { node: '>=12' }
-        peerDependencies:
-            react: '>=16.8'
-            react-dom: '>=16.8'
-
-    '@tanstack/table-core@8.21.3':
-        resolution:
-            {
-                integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==,
-            }
-        engines: { node: '>=12' }
-
-    '@testing-library/dom@10.4.1':
-        resolution:
-            {
-                integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==,
-            }
-        engines: { node: '>=18' }
-
-    '@testing-library/react@16.3.2':
-        resolution:
-            {
-                integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==,
-            }
-        engines: { node: '>=18' }
-        peerDependencies:
-            '@testing-library/dom': ^10.0.0
-            '@types/react': ^18.0.0 || ^19.0.0
-            '@types/react-dom': ^18.0.0 || ^19.0.0
-            react: ^18.0.0 || ^19.0.0
-            react-dom: ^18.0.0 || ^19.0.0
-        peerDependenciesMeta:
-            '@types/react':
-                optional: true
-            '@types/react-dom':
-                optional: true
-
-    '@testing-library/user-event@14.6.1':
-        resolution:
-            {
-                integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==,
-            }
-        engines: { node: '>=12', npm: '>=6' }
-        peerDependencies:
-            '@testing-library/dom': '>=7.21.4'
-
-    '@tiptap/core@3.27.1':
-        resolution:
-            {
-                integrity: sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ==,
-            }
-        peerDependencies:
-            '@tiptap/pm': 3.27.1
-
-    '@tiptap/extension-blockquote@3.27.1':
-        resolution:
-            {
-                integrity: sha512-VMF7xJx6qEGiX6DTKNiL31NLqypOcd/4sNjFSe8rb41PwejBJh/nOqVIbBvWkiT6NMGFLxMhj7zJ8/zPo1hXeg==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-
-    '@tiptap/extension-bold@3.27.1':
-        resolution:
-            {
-                integrity: sha512-TlC5bsS+pqETTrlz4CZz9RO/cKBYtELGIxwtKeivUn3eNfnOxQbbu4WDsiwIfzRFyd0OMnKl6BPM2KnYEehoEQ==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-
-    '@tiptap/extension-bullet-list@3.27.1':
-        resolution:
-            {
-                integrity: sha512-faCUHnRP47o9Zh9VZZX6EX/569udw9Vopm2PgEKPWuKLE2qaS5WBuUVU0iItdJmKUqaWiOZkpoW4jvnDmj0dfg==,
-            }
-        peerDependencies:
-            '@tiptap/extension-list': 3.27.1
-
-    '@tiptap/extension-code-block@3.27.1':
-        resolution:
-            {
-                integrity: sha512-pHlzmZx2OlHfyQ0yRlT5UL4mGokz947DthZuYefN1OleVqOkHpWBG+2JQwqoNq6bmzMne92zbH32rhcJUEYSjA==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-            '@tiptap/pm': 3.27.1
-
-    '@tiptap/extension-code@3.27.1':
-        resolution:
-            {
-                integrity: sha512-epOUpFfEmBzjvnqvjv2qHX7NAuLo5dlOGV690lWu+sAYMjibuJBeVvAiKPyFCfRCCTUxdbDB3jbaOA1yEcEJ7w==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-
-    '@tiptap/extension-document@3.27.1':
-        resolution:
-            {
-                integrity: sha512-8FbBTkfnRP4iVaoj+2h3iWa+H0eGDD3yTyVCwrmue/sQTkqUNUoSuAZa3GDG4Sd41xdPwTJxl9nUWGgM1qDCnw==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-
-    '@tiptap/extension-dropcursor@3.27.1':
-        resolution:
-            {
-                integrity: sha512-blFf9x9RG0Qr7P3FoAH/033ffa+mMLZn34trVs8Vi0Ppk6FmJAg5HpYFOtmYoeREdNDJ5rHJKV7SoACbOHgskQ==,
-            }
-        peerDependencies:
-            '@tiptap/extensions': 3.27.1
-
-    '@tiptap/extension-gapcursor@3.27.1':
-        resolution:
-            {
-                integrity: sha512-QoezN0wdvXIwLQ4ee2ccWDaX3RG0lzgQpIMpMz55oPDhpUVax1+19ApsS53LkcktpS4EbnPL4xO4DaJk0Vp7PQ==,
-            }
-        peerDependencies:
-            '@tiptap/extensions': 3.27.1
-
-    '@tiptap/extension-hard-break@3.27.1':
-        resolution:
-            {
-                integrity: sha512-iv/m9hzl6jfSj9Q8UEjAxONvCoUDaP7M9SRCPx3PaLNxA230TTD6RE0Ye4zFJ8ze7ZVoJJMAqg9Qpq1iYg2JOQ==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-
-    '@tiptap/extension-heading@3.27.1':
-        resolution:
-            {
-                integrity: sha512-SrC4l1kEIyv9ZXFaI/8LQqU2MyMmjczw7XXsWUQOTN4YXv0JyVgMNR3cI/wz0d2xsTfBdZ1N85Tdng+Ga1t0Sg==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-
-    '@tiptap/extension-horizontal-rule@3.27.1':
-        resolution:
-            {
-                integrity: sha512-QlKE7qn5qMnIGVGhXQlvYedvLtNJ9z0dmit5w8vPb8tKzW4Spk6M7N2kruprrDA8GBwHfeR5wmF+njfUm34qxg==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-            '@tiptap/pm': 3.27.1
-
-    '@tiptap/extension-image@3.26.1':
-        resolution:
-            {
-                integrity: sha512-IjoT+kRK4a1sTImvUz257yfk5l9kMxXxfxCfix5AUKdiWyn8SGUjJZapLICcZVY05UDqXmwsBvBK9lHkKX5ERg==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.26.1
-
-    '@tiptap/extension-italic@3.27.1':
-        resolution:
-            {
-                integrity: sha512-jGGeyn9uRUnNjSTHpbqhiGsp6KaYTSbV09jDXPJI9cDwfV9hpugLvpaCZd0BMBbhU1B1W6kOfX0BE15qX/HQfA==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-
-    '@tiptap/extension-link@3.27.1':
-        resolution:
-            {
-                integrity: sha512-/2jBfsxBZUDGJmpZifqRQPz7f1E5qpS1BckTZ39TADzUJX+feKy7RJ3DtQ02+8y6SSMzvP9loGVjrk6zEMTk4g==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-            '@tiptap/pm': 3.27.1
-
-    '@tiptap/extension-list-item@3.27.1':
-        resolution:
-            {
-                integrity: sha512-zwRl01ETfCkWUvtvK5fw9bXtAajMPkvlkE3Cq6JvH3LF7XXJwDtNj5Tj7exacMpCaSZmlNc43vFb2rAYnrnwMA==,
-            }
-        peerDependencies:
-            '@tiptap/extension-list': 3.27.1
-
-    '@tiptap/extension-list-keymap@3.27.1':
-        resolution:
-            {
-                integrity: sha512-OIMZNlzPSO8WRd4ic73Fxckzl4N1tesjjLL2XApaNA/uMpO0LoF6WSRPAWv+Z24Wp92ARRJAnRP7iZoI5+Jxig==,
-            }
-        peerDependencies:
-            '@tiptap/extension-list': 3.27.1
-
-    '@tiptap/extension-list@3.27.1':
-        resolution:
-            {
-                integrity: sha512-c2Upru7lj0/ZV/Ibww6cNz6sUS8m6Dp/9uygFhYcZOd3X8M0xBIEk42c6m6SQehkPziVA8QOgNJz7sMqsbz1OQ==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-            '@tiptap/pm': 3.27.1
-
-    '@tiptap/extension-ordered-list@3.27.1':
-        resolution:
-            {
-                integrity: sha512-GYrKqD//9nHJ2r80uXqbDMzRnFpGzbaEQRTSGaO/SH7DvXWFMow8evkOdjQ7PCQO07jNjJo75+A85Jwu3Ov3AA==,
-            }
-        peerDependencies:
-            '@tiptap/extension-list': 3.27.1
-
-    '@tiptap/extension-paragraph@3.27.1':
-        resolution:
-            {
-                integrity: sha512-7K7eo1gruOgAsnbK+GCV23AUVUI0cL1bTig8HaPneoFMVbig7vddk8jNLKBWO8TXVbG7TuHdnDN4F98vdtwh5Q==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-
-    '@tiptap/extension-strike@3.27.1':
-        resolution:
-            {
-                integrity: sha512-Y3DW1jlSlCNCyMGHP3+3qBNNPS83wuFz4RTYGjZtvRRTCRh7apZme9XRWMq1rN5mJ2Cr7fKocA2/5Bs13KgN6Q==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-
-    '@tiptap/extension-text@3.27.1':
-        resolution:
-            {
-                integrity: sha512-6ZwaZwSrDh+KFFv6V1J79oO37yPs7y1bFxvk1/9Ih2rn3Xr5AWz+eMS+n8RpH3djBVVAQpdIAeYQgcn+VCSsTg==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-
-    '@tiptap/extension-underline@3.27.1':
-        resolution:
-            {
-                integrity: sha512-N889J4nXN/TPfVt8uF9N1A0SY82E90zwc1y26lqOcw6KWNLmQrlhMh/9OD4ikLDbekmFpOBq/UicpHf/6S8hbQ==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-
-    '@tiptap/extensions@3.27.1':
-        resolution:
-            {
-                integrity: sha512-1Tdx9faw8k0/83V6X+xCDVhV8yElGt95JxeW3YMkKQJI56QdlPz0xOdJPlMiSGJKinPyVier+x9LJD/YZUZIaw==,
-            }
-        peerDependencies:
-            '@tiptap/core': 3.27.1
-            '@tiptap/pm': 3.27.1
-
-    '@tiptap/pm@3.27.1':
-        resolution:
-            {
-                integrity: sha512-Ffjx+vimmBU7zH/KrpXzJid3+pziCe/VL2aexSTP63cyQwKQ65LkFkCKaIsSpFdQQuakVZBGWjCA5RoBV852pw==,
-            }
-
-    '@tiptap/starter-kit@3.27.1':
-        resolution:
-            {
-                integrity: sha512-vfxRsqW8rCc0k4pzo0ilU3wobVi2wqVj88VZI2SlgZlNnUAkrDGDIAph7CTa9k9fshV+O1ivpEgPC5yC046jow==,
-            }
-
-    '@tybys/wasm-util@0.10.2':
-        resolution:
-            {
-                integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==,
-            }
-
-    '@types/alpinejs@3.13.11':
-        resolution:
-            {
-                integrity: sha512-3KhGkDixCPiLdL3Z/ok1GxHwLxEWqQOKJccgaQL01wc0EVM2tCTaqlC3NIedmxAXkVzt/V6VTM8qPgnOHKJ1MA==,
-            }
-
-    '@types/aria-query@5.0.4':
-        resolution:
-            {
-                integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==,
-            }
-
-    '@types/bun@1.3.14':
-        resolution:
-            {
-                integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==,
-            }
-
-    '@types/chai@5.2.3':
-        resolution:
-            {
-                integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
-            }
-
-    '@types/debug@4.1.13':
-        resolution:
-            {
-                integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==,
-            }
-
-    '@types/deep-eql@4.0.2':
-        resolution:
-            {
-                integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
-            }
-
-    '@types/estree-jsx@1.0.5':
-        resolution:
-            {
-                integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==,
-            }
-
-    '@types/estree@1.0.9':
-        resolution:
-            {
-                integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
-            }
-
-    '@types/hast@3.0.4':
-        resolution:
-            {
-                integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==,
-            }
-
-    '@types/jscodeshift@17.3.0':
-        resolution:
-            {
-                integrity: sha512-ogvGG8VQQqAQQ096uRh+d6tBHrYuZjsumHirKtvBa5qEyTMN3IQJ7apo+sw9lxaB/iKWIhbbLlF3zmAWk9XQIg==,
-            }
-
-    '@types/linkify-it@3.0.5':
-        resolution:
-            {
-                integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==,
-            }
-
-    '@types/linkify-it@5.0.0':
-        resolution:
-            {
-                integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==,
-            }
-
-    '@types/markdown-it@13.0.9':
-        resolution:
-            {
-                integrity: sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==,
-            }
-
-    '@types/markdown-it@14.1.2':
-        resolution:
-            {
-                integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==,
-            }
-
-    '@types/mdast@4.0.4':
-        resolution:
-            {
-                integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==,
-            }
-
-    '@types/mdurl@1.0.5':
-        resolution:
-            {
-                integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==,
-            }
-
-    '@types/mdurl@2.0.0':
-        resolution:
-            {
-                integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==,
-            }
-
-    '@types/mdx@2.0.14':
-        resolution:
-            {
-                integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==,
-            }
-
-    '@types/ms@2.1.0':
-        resolution:
-            {
-                integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==,
-            }
-
-    '@types/node@16.18.126':
-        resolution:
-            {
-                integrity: sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==,
-            }
-
-    '@types/node@24.13.2':
-        resolution:
-            {
-                integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==,
-            }
-
-    '@types/postcss-import@14.0.3':
-        resolution:
-            {
-                integrity: sha512-raZhRVTf6Vw5+QbmQ7LOHSDML71A5rj4+EqDzAbrZPfxfoGzFxMHRCq16VlddGIZpHELw0BG4G0YE2ANkdZiIQ==,
-            }
-
-    '@types/react-dom@19.2.3':
-        resolution:
-            {
-                integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==,
-            }
-        peerDependencies:
-            '@types/react': ^19.2.0
-
-    '@types/react@19.2.17':
-        resolution:
-            {
-                integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==,
-            }
-
-    '@types/trusted-types@2.0.7':
-        resolution:
-            {
-                integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==,
-            }
-
-    '@types/unist@2.0.11':
-        resolution:
-            {
-                integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==,
-            }
-
-    '@types/unist@3.0.3':
-        resolution:
-            {
-                integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==,
-            }
-
-    '@types/ws@8.18.1':
-        resolution:
-            {
-                integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==,
-            }
-
-    '@ungap/structured-clone@1.3.1':
-        resolution:
-            {
-                integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==,
-            }
-
-    '@vitest/browser-playwright@4.1.8':
-        resolution:
-            {
-                integrity: sha512-SR7FqgegaexEg73xvf3ArtygXegagMdXnL0EZMpxrWvvhQxvicD/E8p0ib0J91riPRtQUViyh67Xjw3NqvyhVg==,
-            }
-        peerDependencies:
-            playwright: '*'
-            vitest: 4.1.8
-
-    '@vitest/browser@4.1.8':
-        resolution:
-            {
-                integrity: sha512-u21VzX07HzlJYpFgkxmjEXar/tG2UqWGgyGG/46SrrPc7rSdCTPw5vuowopO9CIqF8UCUQzDFdbVnNpw6N0BfQ==,
-            }
-        peerDependencies:
-            vitest: 4.1.8
-
-    '@vitest/expect@4.1.8':
-        resolution:
-            {
-                integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==,
-            }
-
-    '@vitest/mocker@4.1.8':
-        resolution:
-            {
-                integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==,
-            }
-        peerDependencies:
-            msw: ^2.4.9
-            vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-        peerDependenciesMeta:
-            msw:
-                optional: true
-            vite:
-                optional: true
-
-    '@vitest/pretty-format@4.1.8':
-        resolution:
-            {
-                integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==,
-            }
-
-    '@vitest/runner@4.1.8':
-        resolution:
-            {
-                integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==,
-            }
-
-    '@vitest/snapshot@4.1.8':
-        resolution:
-            {
-                integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==,
-            }
-
-    '@vitest/spy@4.1.8':
-        resolution:
-            {
-                integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==,
-            }
-
-    '@vitest/utils@4.1.8':
-        resolution:
-            {
-                integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==,
-            }
-
-    '@vue/reactivity@3.1.5':
-        resolution:
-            {
-                integrity: sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==,
-            }
-
-    '@vue/shared@3.1.5':
-        resolution:
-            {
-                integrity: sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==,
-            }
-
-    '@worker-tools/html-rewriter@0.1.0-pre.19':
-        resolution:
-            {
-                integrity: sha512-IUbEZwvSdp8vtaB1LAZ/sBRJGNycd9a8cbkqO05rMEPm5MC59Sb+wiGCWaaRXrwQLDAyWeod4QC/q0TuSUI5EA==,
-            }
-
-    '@worker-tools/resolvable-promise@0.2.0-pre.6':
-        resolution:
-            {
-                integrity: sha512-+5RcuruCLB/P3FYYb376RgyImXaq9BBQoOskUbgPyNK3O0AXPakrXUj1EELv+lcnUSdFws/ufdrrWODLJyoTmg==,
-            }
-
-    acorn-jsx@5.3.2:
-        resolution:
-            {
-                integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
-            }
-        peerDependencies:
-            acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-    acorn@8.17.0:
-        resolution:
-            {
-                integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==,
-            }
-        engines: { node: '>=0.4.0' }
-        hasBin: true
-
-    alpinejs@3.15.12:
-        resolution:
-            {
-                integrity: sha512-nJvPAQVNPdZZ0NrExJ/kzQco3ijR8LwvCOadQecllESiqT4NyZ/57sN9V2XyvhlBGAbmlKYgeWZvYdKq99ij/Q==,
-            }
-
-    ansi-escapes@7.3.0:
-        resolution:
-            {
-                integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==,
-            }
-        engines: { node: '>=18' }
-
-    ansi-regex@5.0.1:
-        resolution:
-            {
-                integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
-            }
-        engines: { node: '>=8' }
-
-    ansi-regex@6.2.2:
-        resolution:
-            {
-                integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
-            }
-        engines: { node: '>=12' }
-
-    ansi-styles@5.2.0:
-        resolution:
-            {
-                integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==,
-            }
-        engines: { node: '>=10' }
-
-    ansi-styles@6.2.3:
-        resolution:
-            {
-                integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==,
-            }
-        engines: { node: '>=12' }
-
-    any-promise@1.3.0:
-        resolution:
-            {
-                integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==,
-            }
-
-    anymatch@3.1.3:
-        resolution:
-            {
-                integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==,
-            }
-        engines: { node: '>= 8' }
-
-    arg@5.0.2:
-        resolution:
-            {
-                integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==,
-            }
-
-    argparse@2.0.1:
-        resolution:
-            {
-                integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
-            }
-
-    aria-hidden@1.2.6:
-        resolution:
-            {
-                integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==,
-            }
-        engines: { node: '>=10' }
-
-    aria-query@5.3.0:
-        resolution:
-            {
-                integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==,
-            }
-
-    arkregex@0.0.5:
-        resolution:
-            {
-                integrity: sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==,
-            }
-
-    arktype@2.2.0:
-        resolution:
-            {
-                integrity: sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ==,
-            }
-
-    assertion-error@2.0.1:
-        resolution:
-            {
-                integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
-            }
-        engines: { node: '>=12' }
-
-    ast-types@0.16.1:
-        resolution:
-            {
-                integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==,
-            }
-        engines: { node: '>=4' }
-
-    astring@1.9.0:
-        resolution:
-            {
-                integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==,
-            }
-        hasBin: true
-
-    atomically@2.1.1:
-        resolution:
-            {
-                integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==,
-            }
-
-    autoprefixer@10.5.0:
-        resolution:
-            {
-                integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==,
-            }
-        engines: { node: ^10 || ^12 || >=14 }
-        hasBin: true
-        peerDependencies:
-            postcss: ^8.1.0
-
-    bail@2.0.2:
-        resolution:
-            {
-                integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
-            }
-
-    baseline-browser-mapping@2.10.37:
-        resolution:
-            {
-                integrity: sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==,
-            }
-        engines: { node: '>=6.0.0' }
-        hasBin: true
-
-    better-auth@1.6.18:
-        resolution:
-            {
-                integrity: sha512-6jONqD0gNjE0S6ehhSZhZ7We0rBwjAzbqnQMJQg/zY0387M+agak7VsOAuE78r7Z0Qv7C/KBRKhHSuyJDQ4iLw==,
-            }
-        peerDependencies:
-            '@lynx-js/react': '*'
-            '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
-            '@sveltejs/kit': ^2.0.0
-            '@tanstack/react-start': ^1.0.0
-            '@tanstack/solid-start': ^1.0.0
-            better-sqlite3: ^12.0.0
-            drizzle-kit: '>=0.31.4'
-            drizzle-orm: ^0.45.2
-            mongodb: ^6.0.0 || ^7.0.0
-            mysql2: ^3.0.0
-            next: ^14.0.0 || ^15.0.0 || ^16.0.0
-            pg: ^8.0.0
-            prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
-            react: ^18.0.0 || ^19.0.0
-            react-dom: ^18.0.0 || ^19.0.0
-            solid-js: ^1.0.0
-            svelte: ^4.0.0 || ^5.0.0
-            vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
-            vue: ^3.0.0
-        peerDependenciesMeta:
-            '@lynx-js/react':
-                optional: true
-            '@prisma/client':
-                optional: true
-            '@sveltejs/kit':
-                optional: true
-            '@tanstack/react-start':
-                optional: true
-            '@tanstack/solid-start':
-                optional: true
-            better-sqlite3:
-                optional: true
-            drizzle-kit:
-                optional: true
-            drizzle-orm:
-                optional: true
-            mongodb:
-                optional: true
-            mysql2:
-                optional: true
-            next:
-                optional: true
-            pg:
-                optional: true
-            prisma:
-                optional: true
-            react:
-                optional: true
-            react-dom:
-                optional: true
-            solid-js:
-                optional: true
-            svelte:
-                optional: true
-            vitest:
-                optional: true
-            vue:
-                optional: true
-
-    better-auth@1.6.20:
-        resolution:
-            {
-                integrity: sha512-fSpGHGRKiGRiYVd3QTQtuVZ8oxpiSe/7ip0Rpvt/Sy8zQbEbVKUPMOhE0gLXg+FjqTUsIo7582hxUYxtEcqUpA==,
-            }
-        peerDependencies:
-            '@lynx-js/react': '*'
-            '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
-            '@sveltejs/kit': ^2.0.0
-            '@tanstack/react-start': ^1.0.0
-            '@tanstack/solid-start': ^1.0.0
-            better-sqlite3: ^12.0.0
-            drizzle-kit: '>=0.31.4'
-            drizzle-orm: ^0.45.2
-            mongodb: ^6.0.0 || ^7.0.0
-            mysql2: ^3.0.0
-            next: ^14.0.0 || ^15.0.0 || ^16.0.0
-            pg: ^8.0.0
-            prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
-            react: ^18.0.0 || ^19.0.0
-            react-dom: ^18.0.0 || ^19.0.0
-            solid-js: ^1.0.0
-            svelte: ^4.0.0 || ^5.0.0
-            vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
-            vue: ^3.0.0
-        peerDependenciesMeta:
-            '@lynx-js/react':
-                optional: true
-            '@prisma/client':
-                optional: true
-            '@sveltejs/kit':
-                optional: true
-            '@tanstack/react-start':
-                optional: true
-            '@tanstack/solid-start':
-                optional: true
-            better-sqlite3:
-                optional: true
-            drizzle-kit:
-                optional: true
-            drizzle-orm:
-                optional: true
-            mongodb:
-                optional: true
-            mysql2:
-                optional: true
-            next:
-                optional: true
-            pg:
-                optional: true
-            prisma:
-                optional: true
-            react:
-                optional: true
-            react-dom:
-                optional: true
-            solid-js:
-                optional: true
-            svelte:
-                optional: true
-            vitest:
-                optional: true
-            vue:
-                optional: true
-
-    better-call@1.3.6:
-        resolution:
-            {
-                integrity: sha512-no1jI+h6Bkxs1NVBo4rONbVIzsPjZ8IUu7IHaJBiFwVX1XEQGN8KpHots5fSWmXe9nNyLuLIcgx6WEUcE6EDaA==,
-            }
-        peerDependencies:
-            zod: ^4.0.0
-        peerDependenciesMeta:
-            zod:
-                optional: true
-
-    better-commits@1.24.0:
-        resolution:
-            {
-                integrity: sha512-Vkr/gLvNSLyfRmS4N/9EVc65vImcqNZe42DudlPBXsfNqW8RhYMAzuUjAgupunDpFloYkkoChkKQnQSuotcqkA==,
-            }
-        engines: { node: '>=20.19.0' }
-        hasBin: true
-
-    binary-extensions@2.3.0:
-        resolution:
-            {
-                integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==,
-            }
-        engines: { node: '>=8' }
-
-    boolbase@1.0.0:
-        resolution:
-            {
-                integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==,
-            }
-
-    braces@3.0.3:
-        resolution:
-            {
-                integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
-            }
-        engines: { node: '>=8' }
-
-    browserslist@4.28.2:
-        resolution:
-            {
-                integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==,
-            }
-        engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
-        hasBin: true
-
-    buffer-from@1.1.2:
-        resolution:
-            {
-                integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
-            }
-
-    bun-types@1.3.14:
-        resolution:
-            {
-                integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==,
-            }
-
-    bun@1.3.14:
-        resolution:
-            {
-                integrity: sha512-aB6GVd42x1Y5ie1K16SF+oLGtgSkwX9hgoDdIW88pjvfTccU8F1vfpoOt34QLv0dZ1v3XimtaxPlZUG81Gx9Zg==,
-            }
-        cpu: [arm64, x64]
-        os: [darwin, linux, android, freebsd, win32]
-        hasBin: true
-
-    camelcase-css@2.0.1:
-        resolution:
-            {
-                integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==,
-            }
-        engines: { node: '>= 6' }
-
-    caniuse-api@3.0.0:
-        resolution:
-            {
-                integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==,
-            }
-
-    caniuse-lite@1.0.30001799:
-        resolution:
-            {
-                integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==,
-            }
-
-    ccount@2.0.1:
-        resolution:
-            {
-                integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
-            }
-
-    chai@6.2.2:
-        resolution:
-            {
-                integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
-            }
-        engines: { node: '>=18' }
-
-    chalk@5.6.2:
-        resolution:
-            {
-                integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==,
-            }
-        engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
-
-    character-entities-html4@2.1.0:
-        resolution:
-            {
-                integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==,
-            }
-
-    character-entities-legacy@3.0.0:
-        resolution:
-            {
-                integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==,
-            }
-
-    character-entities@2.0.2:
-        resolution:
-            {
-                integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==,
-            }
-
-    character-reference-invalid@2.0.1:
-        resolution:
-            {
-                integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==,
-            }
-
-    chokidar@3.6.0:
-        resolution:
-            {
-                integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==,
-            }
-        engines: { node: '>= 8.10.0' }
-
-    chokidar@5.0.0:
-        resolution:
-            {
-                integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==,
-            }
-        engines: { node: '>= 20.19.0' }
-
-    citty@0.1.6:
-        resolution:
-            {
-                integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==,
-            }
-
-    citty@0.2.2:
-        resolution:
-            {
-                integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==,
-            }
-
-    cli-cursor@5.0.0:
-        resolution:
-            {
-                integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==,
-            }
-        engines: { node: '>=18' }
-
-    cli-truncate@4.0.0:
-        resolution:
-            {
-                integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==,
-            }
-        engines: { node: '>=18' }
-
-    client-only@0.0.1:
-        resolution:
-            {
-                integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==,
-            }
-
-    cliui@9.0.1:
-        resolution:
-            {
-                integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==,
-            }
-        engines: { node: '>=20' }
-
-    clone-deep@4.0.1:
-        resolution:
-            {
-                integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==,
-            }
-        engines: { node: '>=6' }
-
-    clsx@2.1.1:
-        resolution:
-            {
-                integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==,
-            }
-        engines: { node: '>=6' }
-
-    collapse-white-space@2.1.0:
-        resolution:
-            {
-                integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==,
-            }
-
-    colorette@2.0.20:
-        resolution:
-            {
-                integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
-            }
-
-    comma-separated-tokens@2.0.3:
-        resolution:
-            {
-                integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==,
-            }
-
-    commander@11.1.0:
-        resolution:
-            {
-                integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==,
-            }
-        engines: { node: '>=16' }
-
-    commander@13.1.0:
-        resolution:
-            {
-                integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==,
-            }
-        engines: { node: '>=18' }
-
-    commander@4.1.1:
-        resolution:
-            {
-                integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==,
-            }
-        engines: { node: '>= 6' }
-
-    commondir@1.0.1:
-        resolution:
-            {
-                integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==,
-            }
-
-    configstore@8.0.0:
-        resolution:
-            {
-                integrity: sha512-U51WPZg+o6FDFhBCV6yYFEspGMCoHvCgJSGFw9AwsW2u75gYBPoDlYca5XfDs4TdMUu3/y0R6FFdvvgyH31mKQ==,
-            }
-        engines: { node: '>=20' }
-
-    consola@3.4.2:
-        resolution:
-            {
-                integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==,
-            }
-        engines: { node: ^14.18.0 || >=16.10.0 }
-
-    convert-source-map@2.0.0:
-        resolution:
-            {
-                integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
-            }
-
-    cross-spawn@7.0.6:
-        resolution:
-            {
-                integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
-            }
-        engines: { node: '>= 8' }
-
-    css-declaration-sorter@7.4.0:
-        resolution:
-            {
-                integrity: sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==,
-            }
-        engines: { node: ^14 || ^16 || >=18 }
-        peerDependencies:
-            postcss: ^8.0.9
-
-    css-select@5.2.2:
-        resolution:
-            {
-                integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==,
-            }
-
-    css-tree@2.2.1:
-        resolution:
-            {
-                integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==,
-            }
-        engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0' }
-
-    css-tree@3.2.1:
-        resolution:
-            {
-                integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==,
-            }
-        engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0 }
-
-    css-what@6.2.2:
-        resolution:
-            {
-                integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==,
-            }
-        engines: { node: '>= 6' }
-
-    cssesc@3.0.0:
-        resolution:
-            {
-                integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==,
-            }
-        engines: { node: '>=4' }
-        hasBin: true
-
-    cssnano-preset-default@7.0.17:
-        resolution:
-            {
-                integrity: sha512-11qO63A+czwguQFJCaTdICvbaxn0pJzz/XghLlv+OT7WyToDxAMR0Xb3/26/l0y0hQJywwNbj/SLSQlGBHE1OA==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    cssnano-utils@5.0.3:
-        resolution:
-            {
-                integrity: sha512-ynIREMICLxkxm7e9bCR9sh75s4Q5drICi0ua1yxo5jH2XPBqSKkl4dOh4EbFqtUmnTMhRffHgYL0EKKkMjtJTg==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    cssnano@7.1.9:
-        resolution:
-            {
-                integrity: sha512-uPR75+5Dk/WJ/YSPR1/YDHdwMM9c5FsaARljfKWgeCKLKOtJ0we21xy/RcCjn53fZnD/f6yYEIZ8pu18+GnbNQ==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    csso@5.0.5:
-        resolution:
-            {
-                integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==,
-            }
-        engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0' }
-
-    csstype@3.2.3:
-        resolution:
-            {
-                integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
-            }
-
-    data-uri-to-buffer@4.0.1:
-        resolution:
-            {
-                integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==,
-            }
-        engines: { node: '>= 12' }
-
-    debug@4.4.3:
-        resolution:
-            {
-                integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
-            }
-        engines: { node: '>=6.0' }
-        peerDependencies:
-            supports-color: '*'
-        peerDependenciesMeta:
-            supports-color:
-                optional: true
-
-    decode-named-character-reference@1.3.0:
-        resolution:
-            {
-                integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==,
-            }
-
-    defu@6.1.7:
-        resolution:
-            {
-                integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==,
-            }
-
-    dequal@2.0.3:
-        resolution:
-            {
-                integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
-            }
-        engines: { node: '>=6' }
-
-    detect-libc@2.1.2:
-        resolution:
-            {
-                integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
-            }
-        engines: { node: '>=8' }
-
-    devlop@1.1.0:
-        resolution:
-            {
-                integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
-            }
-
-    didyoumean@1.2.2:
-        resolution:
-            {
-                integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==,
-            }
-
-    dlv@1.1.3:
-        resolution:
-            {
-                integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==,
-            }
-
-    dom-accessibility-api@0.5.16:
-        resolution:
-            {
-                integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==,
-            }
-
-    dom-serializer@2.0.0:
-        resolution:
-            {
-                integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==,
-            }
-
-    domelementtype@2.3.0:
-        resolution:
-            {
-                integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==,
-            }
-
-    domhandler@5.0.3:
-        resolution:
-            {
-                integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==,
-            }
-        engines: { node: '>= 4' }
-
-    domutils@3.2.2:
-        resolution:
-            {
-                integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==,
-            }
-
-    dot-prop@10.1.0:
-        resolution:
-            {
-                integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==,
-            }
-        engines: { node: '>=20' }
-
-    drizzle-kit@1.0.0-rc.4-ca0f029:
-        resolution:
-            {
-                integrity: sha512-hM1K72ptIPOpJDScHo7cAF+K8A8Tr3q2yHvBJvOZWvLn2lN+G4RDUvG3rT3ohlSE2O3BN/s7g3e3JiQLStt8iQ==,
-            }
-        hasBin: true
-
-    drizzle-orm@0.45.2:
-        resolution:
-            {
-                integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==,
-            }
-        peerDependencies:
-            '@aws-sdk/client-rds-data': '>=3'
-            '@cloudflare/workers-types': '>=4'
-            '@electric-sql/pglite': '>=0.2.0'
-            '@libsql/client': '>=0.10.0'
-            '@libsql/client-wasm': '>=0.10.0'
-            '@neondatabase/serverless': '>=0.10.0'
-            '@op-engineering/op-sqlite': '>=2'
-            '@opentelemetry/api': ^1.4.1
-            '@planetscale/database': '>=1.13'
-            '@prisma/client': '*'
-            '@tidbcloud/serverless': '*'
-            '@types/better-sqlite3': '*'
-            '@types/pg': '*'
-            '@types/sql.js': '*'
-            '@upstash/redis': '>=1.34.7'
-            '@vercel/postgres': '>=0.8.0'
-            '@xata.io/client': '*'
-            better-sqlite3: '>=7'
-            bun-types: '*'
-            expo-sqlite: '>=14.0.0'
-            gel: '>=2'
-            knex: '*'
-            kysely: '*'
-            mysql2: '>=2'
-            pg: '>=8'
-            postgres: '>=3'
-            prisma: '*'
-            sql.js: '>=1'
-            sqlite3: '>=5'
-        peerDependenciesMeta:
-            '@aws-sdk/client-rds-data':
-                optional: true
-            '@cloudflare/workers-types':
-                optional: true
-            '@electric-sql/pglite':
-                optional: true
-            '@libsql/client':
-                optional: true
-            '@libsql/client-wasm':
-                optional: true
-            '@neondatabase/serverless':
-                optional: true
-            '@op-engineering/op-sqlite':
-                optional: true
-            '@opentelemetry/api':
-                optional: true
-            '@planetscale/database':
-                optional: true
-            '@prisma/client':
-                optional: true
-            '@tidbcloud/serverless':
-                optional: true
-            '@types/better-sqlite3':
-                optional: true
-            '@types/pg':
-                optional: true
-            '@types/sql.js':
-                optional: true
-            '@upstash/redis':
-                optional: true
-            '@vercel/postgres':
-                optional: true
-            '@xata.io/client':
-                optional: true
-            better-sqlite3:
-                optional: true
-            bun-types:
-                optional: true
-            expo-sqlite:
-                optional: true
-            gel:
-                optional: true
-            knex:
-                optional: true
-            kysely:
-                optional: true
-            mysql2:
-                optional: true
-            pg:
-                optional: true
-            postgres:
-                optional: true
-            prisma:
-                optional: true
-            sql.js:
-                optional: true
-            sqlite3:
-                optional: true
-
-    electron-to-chromium@1.5.372:
-        resolution:
-            {
-                integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==,
-            }
-
-    emoji-regex-xs@1.0.0:
-        resolution:
-            {
-                integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==,
-            }
-
-    emoji-regex@10.6.0:
-        resolution:
-            {
-                integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==,
-            }
-
-    enhanced-resolve@5.21.6:
-        resolution:
-            {
-                integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==,
-            }
-        engines: { node: '>=10.13.0' }
-
-    enhanced-resolve@5.24.0:
-        resolution:
-            {
-                integrity: sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==,
-            }
-        engines: { node: '>=10.13.0' }
-
-    entities@4.5.0:
-        resolution:
-            {
-                integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==,
-            }
-        engines: { node: '>=0.12' }
-
-    entities@6.0.1:
-        resolution:
-            {
-                integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==,
-            }
-        engines: { node: '>=0.12' }
-
-    environment@1.1.0:
-        resolution:
-            {
-                integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==,
-            }
-        engines: { node: '>=18' }
-
-    es-errors@1.3.0:
-        resolution:
-            {
-                integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
-            }
-        engines: { node: '>= 0.4' }
-
-    es-module-lexer@2.1.0:
-        resolution:
-            {
-                integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
-            }
-
-    esast-util-from-estree@2.0.0:
-        resolution:
-            {
-                integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==,
-            }
-
-    esast-util-from-js@2.0.1:
-        resolution:
-            {
-                integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
-            }
-
-    esbuild@0.25.12:
-        resolution:
-            {
-                integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
-            }
-        engines: { node: '>=18' }
-        hasBin: true
-
-    esbuild@0.28.1:
-        resolution:
-            {
-                integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==,
-            }
-        engines: { node: '>=18' }
-        hasBin: true
-
-    escalade@3.2.0:
-        resolution:
-            {
-                integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
-            }
-        engines: { node: '>=6' }
-
-    escape-string-regexp@5.0.0:
-        resolution:
-            {
-                integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==,
-            }
-        engines: { node: '>=12' }
-
-    esprima@4.0.1:
-        resolution:
-            {
-                integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==,
-            }
-        engines: { node: '>=4' }
-        hasBin: true
-
-    estree-util-attach-comments@3.0.0:
-        resolution:
-            {
-                integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==,
-            }
-
-    estree-util-build-jsx@3.0.1:
-        resolution:
-            {
-                integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==,
-            }
-
-    estree-util-is-identifier-name@3.0.0:
-        resolution:
-            {
-                integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==,
-            }
-
-    estree-util-scope@1.0.0:
-        resolution:
-            {
-                integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==,
-            }
-
-    estree-util-to-js@2.0.0:
-        resolution:
-            {
-                integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==,
-            }
-
-    estree-util-visit@2.0.0:
-        resolution:
-            {
-                integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==,
-            }
-
-    estree-walker@3.0.3:
-        resolution:
-            {
-                integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
-            }
-
-    eventemitter3@5.0.4:
-        resolution:
-            {
-                integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
-            }
-
-    execa@8.0.1:
-        resolution:
-            {
-                integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==,
-            }
-        engines: { node: '>=16.17' }
-
-    expect-type@1.3.0:
-        resolution:
-            {
-                integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
-            }
-        engines: { node: '>=12.0.0' }
-
-    extend@3.0.2:
-        resolution:
-            {
-                integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
-            }
-
-    fast-glob@3.3.3:
-        resolution:
-            {
-                integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==,
-            }
-        engines: { node: '>=8.6.0' }
-
-    fast-string-truncated-width@3.0.3:
-        resolution:
-            {
-                integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==,
-            }
-
-    fast-string-width@3.0.2:
-        resolution:
-            {
-                integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==,
-            }
-
-    fast-wrap-ansi@0.2.2:
-        resolution:
-            {
-                integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==,
-            }
-
-    fastq@1.20.1:
-        resolution:
-            {
-                integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==,
-            }
-
-    fdir@6.5.0:
-        resolution:
-            {
-                integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
-            }
-        engines: { node: '>=12.0.0' }
-        peerDependencies:
-            picomatch: ^3 || ^4
-        peerDependenciesMeta:
-            picomatch:
-                optional: true
-
-    fetch-blob@3.2.0:
-        resolution:
-            {
-                integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==,
-            }
-        engines: { node: ^12.20 || >= 14.13 }
-
-    fill-range@7.1.1:
-        resolution:
-            {
-                integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
-            }
-        engines: { node: '>=8' }
-
-    find-cache-dir@2.1.0:
-        resolution:
-            {
-                integrity: sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==,
-            }
-        engines: { node: '>=6' }
-
-    find-up@3.0.0:
-        resolution:
-            {
-                integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==,
-            }
-        engines: { node: '>=6' }
-
-    flow-parser@0.318.0:
-        resolution:
-            {
-                integrity: sha512-66vPPqpjOcroUke2vbiyRNS87lbTi7ib80CM9lsn45qymGHPL4nrdY9FKo0TvtrFFqHQErfB/BJeqVkEnWeK/g==,
-            }
-        engines: { node: '>=0.4.0' }
-
-    formdata-polyfill@4.0.10:
-        resolution:
-            {
-                integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==,
-            }
-        engines: { node: '>=12.20.0' }
-
-    fraction.js@5.3.4:
-        resolution:
-            {
-                integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==,
-            }
-
-    fsevents@2.3.2:
-        resolution:
-            {
-                integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
-            }
-        engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
-        os: [darwin]
-
-    fsevents@2.3.3:
-        resolution:
-            {
-                integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
-            }
-        engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
-        os: [darwin]
-
-    function-bind@1.1.2:
-        resolution:
-            {
-                integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
-            }
-
-    gensync@1.0.0-beta.2:
-        resolution:
-            {
-                integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    get-caller-file@2.0.5:
-        resolution:
-            {
-                integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==,
-            }
-        engines: { node: 6.* || 8.* || >= 10.* }
-
-    get-east-asian-width@1.6.0:
-        resolution:
-            {
-                integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==,
-            }
-        engines: { node: '>=18' }
-
-    get-stream@8.0.1:
-        resolution:
-            {
-                integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==,
-            }
-        engines: { node: '>=16' }
-
-    get-tsconfig@4.14.0:
-        resolution:
-            {
-                integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==,
-            }
-
-    ghtml@4.0.2:
-        resolution:
-            {
-                integrity: sha512-ymJljsiXUc6hrq2407EnkyCQ8dk5NVEvpAbB4fhnZ+oqP0u9Aq/YWsNkDh+Ew5lBz2uGqyLfzCBdE8J8g4NNgg==,
-            }
-        engines: { node: '>=18' }
-
-    giget@2.0.0:
-        resolution:
-            {
-                integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==,
-            }
-        hasBin: true
-
-    glob-parent@5.1.2:
-        resolution:
-            {
-                integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
-            }
-        engines: { node: '>= 6' }
-
-    glob-parent@6.0.2:
-        resolution:
-            {
-                integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
-            }
-        engines: { node: '>=10.13.0' }
-
-    graceful-fs@4.2.11:
-        resolution:
-            {
-                integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
-            }
-
-    hasown@2.0.4:
-        resolution:
-            {
-                integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==,
-            }
-        engines: { node: '>= 0.4' }
-
-    hast-util-from-html@2.0.3:
-        resolution:
-            {
-                integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==,
-            }
-
-    hast-util-from-parse5@8.0.3:
-        resolution:
-            {
-                integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==,
-            }
-
-    hast-util-parse-selector@4.0.0:
-        resolution:
-            {
-                integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==,
-            }
-
-    hast-util-raw@9.1.0:
-        resolution:
-            {
-                integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==,
-            }
-
-    hast-util-to-estree@3.1.3:
-        resolution:
-            {
-                integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==,
-            }
-
-    hast-util-to-html@9.0.5:
-        resolution:
-            {
-                integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==,
-            }
-
-    hast-util-to-jsx-runtime@2.3.6:
-        resolution:
-            {
-                integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==,
-            }
-
-    hast-util-to-parse5@8.0.1:
-        resolution:
-            {
-                integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==,
-            }
-
-    hast-util-to-string@3.0.1:
-        resolution:
-            {
-                integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==,
-            }
-
-    hast-util-whitespace@3.0.0:
-        resolution:
-            {
-                integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==,
-            }
-
-    hastscript@9.0.1:
-        resolution:
-            {
-                integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==,
-            }
-
-    html-void-elements@3.0.0:
-        resolution:
-            {
-                integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==,
-            }
-
-    human-signals@5.0.0:
-        resolution:
-            {
-                integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==,
-            }
-        engines: { node: '>=16.17.0' }
-
-    husky@9.1.7:
-        resolution:
-            {
-                integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==,
-            }
-        engines: { node: '>=18' }
-        hasBin: true
-
-    imurmurhash@0.1.4:
-        resolution:
-            {
-                integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
-            }
-        engines: { node: '>=0.8.19' }
-
-    inline-style-parser@0.2.7:
-        resolution:
-            {
-                integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==,
-            }
-
-    is-alphabetical@2.0.1:
-        resolution:
-            {
-                integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==,
-            }
-
-    is-alphanumerical@2.0.1:
-        resolution:
-            {
-                integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==,
-            }
-
-    is-binary-path@2.1.0:
-        resolution:
-            {
-                integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==,
-            }
-        engines: { node: '>=8' }
-
-    is-core-module@2.16.2:
-        resolution:
-            {
-                integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==,
-            }
-        engines: { node: '>= 0.4' }
-
-    is-decimal@2.0.1:
-        resolution:
-            {
-                integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==,
-            }
-
-    is-extglob@2.1.1:
-        resolution:
-            {
-                integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    is-fullwidth-code-point@4.0.0:
-        resolution:
-            {
-                integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==,
-            }
-        engines: { node: '>=12' }
-
-    is-fullwidth-code-point@5.1.0:
-        resolution:
-            {
-                integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==,
-            }
-        engines: { node: '>=18' }
-
-    is-glob@4.0.3:
-        resolution:
-            {
-                integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    is-hexadecimal@2.0.1:
-        resolution:
-            {
-                integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==,
-            }
-
-    is-number@7.0.0:
-        resolution:
-            {
-                integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
-            }
-        engines: { node: '>=0.12.0' }
-
-    is-plain-obj@4.1.0:
-        resolution:
-            {
-                integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==,
-            }
-        engines: { node: '>=12' }
-
-    is-plain-object@2.0.4:
-        resolution:
-            {
-                integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    is-safe-filename@0.1.1:
-        resolution:
-            {
-                integrity: sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==,
-            }
-        engines: { node: '>=20' }
-
-    is-stream@3.0.0:
-        resolution:
-            {
-                integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==,
-            }
-        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-
-    isexe@2.0.0:
-        resolution:
-            {
-                integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
-            }
-
-    isobject@3.0.1:
-        resolution:
-            {
-                integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    jiti@1.21.7:
-        resolution:
-            {
-                integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==,
-            }
-        hasBin: true
-
-    jiti@2.7.0:
-        resolution:
-            {
-                integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==,
-            }
-        hasBin: true
-
-    jose@6.2.3:
-        resolution:
-            {
-                integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==,
-            }
-
-    js-tokens@4.0.0:
-        resolution:
-            {
-                integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
-            }
-
-    jsbi@4.3.2:
-        resolution:
-            {
-                integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==,
-            }
-
-    jscodeshift@17.3.0:
-        resolution:
-            {
-                integrity: sha512-LjFrGOIORqXBU+jwfC9nbkjmQfFldtMIoS6d9z2LG/lkmyNXsJAySPT+2SWXJEoE68/bCWcxKpXH37npftgmow==,
-            }
-        engines: { node: '>=16' }
-        hasBin: true
-        peerDependencies:
-            '@babel/preset-env': ^7.1.6
-        peerDependenciesMeta:
-            '@babel/preset-env':
-                optional: true
-
-    jsesc@3.1.0:
-        resolution:
-            {
-                integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
-            }
-        engines: { node: '>=6' }
-        hasBin: true
-
-    json5@2.2.3:
-        resolution:
-            {
-                integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
-            }
-        engines: { node: '>=6' }
-        hasBin: true
-
-    jsonc-parser@3.3.1:
-        resolution:
-            {
-                integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==,
-            }
-
-    kind-of@6.0.3:
-        resolution:
-            {
-                integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    kysely@0.29.2:
-        resolution:
-            {
-                integrity: sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==,
-            }
-        engines: { node: '>=22.0.0' }
-
-    lightningcss-android-arm64@1.32.0:
-        resolution:
-            {
-                integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [android]
-
-    lightningcss-darwin-arm64@1.32.0:
-        resolution:
-            {
-                integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [darwin]
-
-    lightningcss-darwin-x64@1.32.0:
-        resolution:
-            {
-                integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [darwin]
-
-    lightningcss-freebsd-x64@1.32.0:
-        resolution:
-            {
-                integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [freebsd]
-
-    lightningcss-linux-arm-gnueabihf@1.32.0:
-        resolution:
-            {
-                integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm]
-        os: [linux]
-
-    lightningcss-linux-arm64-gnu@1.32.0:
-        resolution:
-            {
-                integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    lightningcss-linux-arm64-musl@1.32.0:
-        resolution:
-            {
-                integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    lightningcss-linux-x64-gnu@1.32.0:
-        resolution:
-            {
-                integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    lightningcss-linux-x64-musl@1.32.0:
-        resolution:
-            {
-                integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    lightningcss-win32-arm64-msvc@1.32.0:
-        resolution:
-            {
-                integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [win32]
-
-    lightningcss-win32-x64-msvc@1.32.0:
-        resolution:
-            {
-                integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [win32]
-
-    lightningcss@1.32.0:
-        resolution:
-            {
-                integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
-            }
-        engines: { node: '>= 12.0.0' }
-
-    lilconfig@3.1.3:
-        resolution:
-            {
-                integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==,
-            }
-        engines: { node: '>=14' }
-
-    lines-and-columns@1.2.4:
-        resolution:
-            {
-                integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==,
-            }
-
-    linkify-it@5.0.1:
-        resolution:
-            {
-                integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==,
-            }
-
-    linkifyjs@4.3.3:
-        resolution:
-            {
-                integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==,
-            }
-
-    lint-staged@15.5.2:
-        resolution:
-            {
-                integrity: sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==,
-            }
-        engines: { node: '>=18.12.0' }
-        hasBin: true
-
-    listr2@8.3.3:
-        resolution:
-            {
-                integrity: sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==,
-            }
-        engines: { node: '>=18.0.0' }
-
-    lit-element@4.2.2:
-        resolution:
-            {
-                integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==,
-            }
-
-    lit-html@3.3.3:
-        resolution:
-            {
-                integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==,
-            }
-
-    lit@3.3.3:
-        resolution:
-            {
-                integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==,
-            }
-
-    locate-path@3.0.0:
-        resolution:
-            {
-                integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==,
-            }
-        engines: { node: '>=6' }
-
-    lodash.memoize@4.1.2:
-        resolution:
-            {
-                integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==,
-            }
-
-    lodash.uniq@4.5.0:
-        resolution:
-            {
-                integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==,
-            }
-
-    log-update@6.1.0:
-        resolution:
-            {
-                integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==,
-            }
-        engines: { node: '>=18' }
-
-    longest-streak@3.1.0:
-        resolution:
-            {
-                integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
-            }
-
-    lru-cache@5.1.1:
-        resolution:
-            {
-                integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
-            }
-
-    lz-string@1.5.0:
-        resolution:
-            {
-                integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==,
-            }
-        hasBin: true
-
-    magic-string@0.30.21:
-        resolution:
-            {
-                integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
-            }
-
-    make-dir@2.1.0:
-        resolution:
-            {
-                integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==,
-            }
-        engines: { node: '>=6' }
-
-    markdown-extensions@2.0.0:
-        resolution:
-            {
-                integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==,
-            }
-        engines: { node: '>=16' }
-
-    markdown-it-task-lists@2.1.1:
-        resolution:
-            {
-                integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==,
-            }
-
-    markdown-it@14.2.0:
-        resolution:
-            {
-                integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==,
-            }
-        hasBin: true
-
-    markdown-table@3.0.4:
-        resolution:
-            {
-                integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==,
-            }
-
-    mdast-util-find-and-replace@3.0.2:
-        resolution:
-            {
-                integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==,
-            }
-
-    mdast-util-from-markdown@2.0.3:
-        resolution:
-            {
-                integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==,
-            }
-
-    mdast-util-gfm-autolink-literal@2.0.1:
-        resolution:
-            {
-                integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==,
-            }
-
-    mdast-util-gfm-footnote@2.1.0:
-        resolution:
-            {
-                integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==,
-            }
-
-    mdast-util-gfm-strikethrough@2.0.0:
-        resolution:
-            {
-                integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==,
-            }
-
-    mdast-util-gfm-table@2.0.0:
-        resolution:
-            {
-                integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==,
-            }
-
-    mdast-util-gfm-task-list-item@2.0.0:
-        resolution:
-            {
-                integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==,
-            }
-
-    mdast-util-gfm@3.1.0:
-        resolution:
-            {
-                integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==,
-            }
-
-    mdast-util-mdx-expression@2.0.1:
-        resolution:
-            {
-                integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==,
-            }
-
-    mdast-util-mdx-jsx@3.2.0:
-        resolution:
-            {
-                integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==,
-            }
-
-    mdast-util-mdx@3.0.0:
-        resolution:
-            {
-                integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==,
-            }
-
-    mdast-util-mdxjs-esm@2.0.1:
-        resolution:
-            {
-                integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==,
-            }
-
-    mdast-util-phrasing@4.1.0:
-        resolution:
-            {
-                integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==,
-            }
-
-    mdast-util-to-hast@13.2.1:
-        resolution:
-            {
-                integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==,
-            }
-
-    mdast-util-to-markdown@2.1.2:
-        resolution:
-            {
-                integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==,
-            }
-
-    mdast-util-to-string@4.0.0:
-        resolution:
-            {
-                integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==,
-            }
-
-    mdn-data@2.0.28:
-        resolution:
-            {
-                integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==,
-            }
-
-    mdn-data@2.27.1:
-        resolution:
-            {
-                integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==,
-            }
-
-    mdurl@2.0.0:
-        resolution:
-            {
-                integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==,
-            }
-
-    merge-stream@2.0.0:
-        resolution:
-            {
-                integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==,
-            }
-
-    merge2@1.4.1:
-        resolution:
-            {
-                integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
-            }
-        engines: { node: '>= 8' }
-
-    micromark-core-commonmark@2.0.3:
-        resolution:
-            {
-                integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==,
-            }
-
-    micromark-extension-gfm-autolink-literal@2.1.0:
-        resolution:
-            {
-                integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==,
-            }
-
-    micromark-extension-gfm-footnote@2.1.0:
-        resolution:
-            {
-                integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==,
-            }
-
-    micromark-extension-gfm-strikethrough@2.1.0:
-        resolution:
-            {
-                integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==,
-            }
-
-    micromark-extension-gfm-table@2.1.1:
-        resolution:
-            {
-                integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==,
-            }
-
-    micromark-extension-gfm-tagfilter@2.0.0:
-        resolution:
-            {
-                integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==,
-            }
-
-    micromark-extension-gfm-task-list-item@2.1.0:
-        resolution:
-            {
-                integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==,
-            }
-
-    micromark-extension-gfm@3.0.0:
-        resolution:
-            {
-                integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==,
-            }
-
-    micromark-extension-mdx-expression@3.0.1:
-        resolution:
-            {
-                integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==,
-            }
-
-    micromark-extension-mdx-jsx@3.0.2:
-        resolution:
-            {
-                integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==,
-            }
-
-    micromark-extension-mdx-md@2.0.0:
-        resolution:
-            {
-                integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==,
-            }
-
-    micromark-extension-mdxjs-esm@3.0.0:
-        resolution:
-            {
-                integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==,
-            }
-
-    micromark-extension-mdxjs@3.0.0:
-        resolution:
-            {
-                integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==,
-            }
-
-    micromark-factory-destination@2.0.1:
-        resolution:
-            {
-                integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==,
-            }
-
-    micromark-factory-label@2.0.1:
-        resolution:
-            {
-                integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==,
-            }
-
-    micromark-factory-mdx-expression@2.0.3:
-        resolution:
-            {
-                integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==,
-            }
-
-    micromark-factory-space@2.0.1:
-        resolution:
-            {
-                integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==,
-            }
-
-    micromark-factory-title@2.0.1:
-        resolution:
-            {
-                integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==,
-            }
-
-    micromark-factory-whitespace@2.0.1:
-        resolution:
-            {
-                integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==,
-            }
-
-    micromark-util-character@2.1.1:
-        resolution:
-            {
-                integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==,
-            }
-
-    micromark-util-chunked@2.0.1:
-        resolution:
-            {
-                integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==,
-            }
-
-    micromark-util-classify-character@2.0.1:
-        resolution:
-            {
-                integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==,
-            }
-
-    micromark-util-combine-extensions@2.0.1:
-        resolution:
-            {
-                integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==,
-            }
-
-    micromark-util-decode-numeric-character-reference@2.0.2:
-        resolution:
-            {
-                integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==,
-            }
-
-    micromark-util-decode-string@2.0.1:
-        resolution:
-            {
-                integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==,
-            }
-
-    micromark-util-encode@2.0.1:
-        resolution:
-            {
-                integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==,
-            }
-
-    micromark-util-events-to-acorn@2.0.3:
-        resolution:
-            {
-                integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==,
-            }
-
-    micromark-util-html-tag-name@2.0.1:
-        resolution:
-            {
-                integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==,
-            }
-
-    micromark-util-normalize-identifier@2.0.1:
-        resolution:
-            {
-                integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==,
-            }
-
-    micromark-util-resolve-all@2.0.1:
-        resolution:
-            {
-                integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==,
-            }
-
-    micromark-util-sanitize-uri@2.0.1:
-        resolution:
-            {
-                integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==,
-            }
-
-    micromark-util-subtokenize@2.1.0:
-        resolution:
-            {
-                integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==,
-            }
-
-    micromark-util-symbol@2.0.1:
-        resolution:
-            {
-                integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==,
-            }
-
-    micromark-util-types@2.0.2:
-        resolution:
-            {
-                integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==,
-            }
-
-    micromark@4.0.2:
-        resolution:
-            {
-                integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==,
-            }
-
-    micromatch@4.0.8:
-        resolution:
-            {
-                integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
-            }
-        engines: { node: '>=8.6' }
-
-    mimic-fn@4.0.0:
-        resolution:
-            {
-                integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==,
-            }
-        engines: { node: '>=12' }
-
-    mimic-function@5.0.1:
-        resolution:
-            {
-                integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==,
-            }
-        engines: { node: '>=18' }
-
-    mitata@1.0.34:
-        resolution:
-            {
-                integrity: sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==,
-            }
-
-    morphdom@2.7.8:
-        resolution:
-            {
-                integrity: sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg==,
-            }
-
-    mrmime@2.0.1:
-        resolution:
-            {
-                integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==,
-            }
-        engines: { node: '>=10' }
-
-    ms@2.1.3:
-        resolution:
-            {
-                integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
-            }
-
-    mz@2.7.0:
-        resolution:
-            {
-                integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
-            }
-
-    nanoid@3.3.12:
-        resolution:
-            {
-                integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
-            }
-        engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
-        hasBin: true
-
-    nanostores@1.3.0:
-        resolution:
-            {
-                integrity: sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==,
-            }
-        engines: { node: ^20.0.0 || >=22.0.0 }
-
-    neo-async@2.6.2:
-        resolution:
-            {
-                integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==,
-            }
-
-    node-domexception@1.0.0:
-        resolution:
-            {
-                integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==,
-            }
-        engines: { node: '>=10.5.0' }
-        deprecated: Use your platform's native DOMException instead
-
-    node-fetch-native@1.6.7:
-        resolution:
-            {
-                integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==,
-            }
-
-    node-fetch@3.3.2:
-        resolution:
-            {
-                integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==,
-            }
-        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-
-    node-releases@2.0.47:
-        resolution:
-            {
-                integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==,
-            }
-        engines: { node: '>=18' }
-
-    normalize-path@3.0.0:
-        resolution:
-            {
-                integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    npm-run-path@5.3.0:
-        resolution:
-            {
-                integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==,
-            }
-        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-
-    nth-check@2.1.1:
-        resolution:
-            {
-                integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==,
-            }
-
-    nypm@0.6.7:
-        resolution:
-            {
-                integrity: sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==,
-            }
-        engines: { node: '>=18' }
-        hasBin: true
-
-    object-assign@4.1.1:
-        resolution:
-            {
-                integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    object-hash@3.0.0:
-        resolution:
-            {
-                integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==,
-            }
-        engines: { node: '>= 6' }
-
-    obug@2.1.3:
-        resolution:
-            {
-                integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==,
-            }
-        engines: { node: '>=12.20.0' }
-
-    onetime@6.0.0:
-        resolution:
-            {
-                integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==,
-            }
-        engines: { node: '>=12' }
-
-    onetime@7.0.0:
-        resolution:
-            {
-                integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==,
-            }
-        engines: { node: '>=18' }
-
-    oniguruma-parser@0.12.2:
-        resolution:
-            {
-                integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==,
-            }
-
-    oniguruma-to-es@2.3.0:
-        resolution:
-            {
-                integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==,
-            }
-
-    oniguruma-to-es@4.3.6:
-        resolution:
-            {
-                integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==,
-            }
-
-    orderedmap@2.1.1:
-        resolution:
-            {
-                integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==,
-            }
-
-    oxc-parser@0.124.0:
-        resolution:
-            {
-                integrity: sha512-h07SFj/tp2U3cf3+LFX6MmOguQiM9ahwpGs0ZK5CGhgL8p4kk24etrJKsEzhXAvo7mfvoKTZooZ5MLKAPRmJ1g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-
-    oxc-transform@0.124.0:
-        resolution:
-            {
-                integrity: sha512-uxVsQFZAaMv4cL3ijc1tx0WczUoBJBbwIFbtTf2QOdRww1s12Ib8dGc5Og63Fh4tmHt9ajYu+9BjxCRSL0b9/g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-
-    oxlint@1.69.0:
-        resolution:
-            {
-                integrity: sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        hasBin: true
-        peerDependencies:
-            oxlint-tsgolint: '>=0.22.1'
-            vite-plus: '*'
-        peerDependenciesMeta:
-            oxlint-tsgolint:
-                optional: true
-            vite-plus:
-                optional: true
-
-    p-limit@2.3.0:
-        resolution:
-            {
-                integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==,
-            }
-        engines: { node: '>=6' }
-
-    p-locate@3.0.0:
-        resolution:
-            {
-                integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==,
-            }
-        engines: { node: '>=6' }
-
-    p-try@2.2.0:
-        resolution:
-            {
-                integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==,
-            }
-        engines: { node: '>=6' }
-
-    parse-entities@4.0.2:
-        resolution:
-            {
-                integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==,
-            }
-
-    parse-numeric-range@1.3.0:
-        resolution:
-            {
-                integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==,
-            }
-
-    parse5@7.3.0:
-        resolution:
-            {
-                integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==,
-            }
-
-    path-exists@3.0.0:
-        resolution:
-            {
-                integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==,
-            }
-        engines: { node: '>=4' }
-
-    path-key@3.1.1:
-        resolution:
-            {
-                integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
-            }
-        engines: { node: '>=8' }
-
-    path-key@4.0.0:
-        resolution:
-            {
-                integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==,
-            }
-        engines: { node: '>=12' }
-
-    path-parse@1.0.7:
-        resolution:
-            {
-                integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
-            }
-
-    pathe@2.0.3:
-        resolution:
-            {
-                integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
-            }
-
-    picocolors@1.1.1:
-        resolution:
-            {
-                integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
-            }
-
-    picomatch@2.3.2:
-        resolution:
-            {
-                integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==,
-            }
-        engines: { node: '>=8.6' }
-
-    picomatch@4.0.4:
-        resolution:
-            {
-                integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
-            }
-        engines: { node: '>=12' }
-
-    pidtree@0.6.1:
-        resolution:
-            {
-                integrity: sha512-e0F9AOF1JMrCfBsyJOwU9lNvQ0WtXTq0j/4jk0BQ5JSI9VAybPXmDpPRw/2FQ3e5d3ZFN1mLh7jW99m/jjaptw==,
-            }
-        engines: { node: '>=0.10' }
-        hasBin: true
-
-    pify@2.3.0:
-        resolution:
-            {
-                integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    pify@4.0.1:
-        resolution:
-            {
-                integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==,
-            }
-        engines: { node: '>=6' }
-
-    pirates@4.0.7:
-        resolution:
-            {
-                integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==,
-            }
-        engines: { node: '>= 6' }
-
-    pkg-dir@3.0.0:
-        resolution:
-            {
-                integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==,
-            }
-        engines: { node: '>=6' }
-
-    playwright-core@1.60.0:
-        resolution:
-            {
-                integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==,
-            }
-        engines: { node: '>=18' }
-        hasBin: true
-
-    playwright@1.60.0:
-        resolution:
-            {
-                integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==,
-            }
-        engines: { node: '>=18' }
-        hasBin: true
-
-    pngjs@7.0.0:
-        resolution:
-            {
-                integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==,
-            }
-        engines: { node: '>=14.19.0' }
-
-    postcss-calc@10.1.1:
-        resolution:
-            {
-                integrity: sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==,
-            }
-        engines: { node: ^18.12 || ^20.9 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.4.38
-
-    postcss-colormin@7.0.10:
-        resolution:
-            {
-                integrity: sha512-yFr6JezOolHLta/buLE71VKPh2mXursp4saVe98/ol8ZnEWhL+racShqPKlvd/DKWLre/39B6HhcMXf7RZ3hxg==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-convert-values@7.0.12:
-        resolution:
-            {
-                integrity: sha512-xurKu5qqk4viR3Cp3p4xBR4KfnZm4w4ys6+UBwBmeuBSNkH7+DtLnYOYnOffgtE4yx8sH9S1VZ6RAAvROXzP2Q==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-discard-comments@7.0.8:
-        resolution:
-            {
-                integrity: sha512-CvvS5S9WrXblFXCEJ9nVo+4z+eA7zSC7Z88V1HEJuwlQhlFnYTIjg1xJY+BCUiG2bvICap2tXii4mP22BD108Q==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-discard-duplicates@7.0.4:
-        resolution:
-            {
-                integrity: sha512-VBNn1+EuMZkeGVVtz0gRfbNGtx9IFgAsAV+E2pHtXPrp4qfGBkhTIiAuE/wrb+Y6Pakg9NewAlfTpYIFAWODtw==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-discard-empty@7.0.3:
-        resolution:
-            {
-                integrity: sha512-M2pyjQCU+/7cMHVtL6bKTHjv0lZnPLMpicgr67Dlth7AbuV9gjVTtUqaRwn6Pp6BwSDspUzhz8SaUrRykJU5Dw==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-discard-overridden@7.0.3:
-        resolution:
-            {
-                integrity: sha512-aNovXo9UsZuRNLzHJtp13lHIvinDPfiXBPePpXkSjCbgp++iU2FqE+YxvjIsg6EdyPZsASFbfu+JcBFVsErXIQ==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-import@15.1.0:
-        resolution:
-            {
-                integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==,
-            }
-        engines: { node: '>=14.0.0' }
-        peerDependencies:
-            postcss: ^8.0.0
-
-    postcss-import@16.1.1:
-        resolution:
-            {
-                integrity: sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==,
-            }
-        engines: { node: '>=18.0.0' }
-        peerDependencies:
-            postcss: ^8.0.0
-
-    postcss-js@4.1.0:
-        resolution:
-            {
-                integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==,
-            }
-        engines: { node: ^12 || ^14 || >= 16 }
-        peerDependencies:
-            postcss: ^8.4.21
-
-    postcss-load-config@6.0.1:
-        resolution:
-            {
-                integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==,
-            }
-        engines: { node: '>= 18' }
-        peerDependencies:
-            jiti: '>=1.21.0'
-            postcss: '>=8.0.9'
-            tsx: ^4.8.1
-            yaml: ^2.4.2
-        peerDependenciesMeta:
-            jiti:
-                optional: true
-            postcss:
-                optional: true
-            tsx:
-                optional: true
-            yaml:
-                optional: true
-
-    postcss-merge-longhand@7.0.7:
-        resolution:
-            {
-                integrity: sha512-b3mfYUxR388u5Pt0HPcVIUtUDn/k15UfTY9M+ORW+meCR6JLNxoZffiYvXyOYQoRYQNZyX/UFkMCM/mNHxe1qA==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-merge-rules@7.0.11:
-        resolution:
-            {
-                integrity: sha512-SJUPM18g2BmPhf8BVlbwqWz4aK3pLu6u6xjfwEzra7xL6IBR10sUaiB++EzqcVfadPHrKBSMlNdP+XieykhI+Q==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-minify-font-values@7.0.3:
-        resolution:
-            {
-                integrity: sha512-yilG/VOaNI74IylQvAQQxm3/wZVBkXyYUqNUAdxqwtbWUXPsbK1q8Ms0mL83v+f8YicgcyfYCRZtWACUdYajpA==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-minify-gradients@7.0.5:
-        resolution:
-            {
-                integrity: sha512-YraROyQRg3BI1+Hg8E05B/JPdnTm8EDSVu4P2BxdM+CRiOyfmou809+chGIqo6fQqwjPGQ947nbGncSjmTU1WQ==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-minify-params@7.0.9:
-        resolution:
-            {
-                integrity: sha512-R8itbB8BhlpoYyBm1ou0dD+vJnQ3F6adQipR4UnkCHUwlo+S9WXJaDRg1RHjC8YVAtIdrQzSWvJl40HnGDTKjA==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-minify-selectors@7.1.2:
-        resolution:
-            {
-                integrity: sha512-aQtrEWKwqafNlExcKHQvPGsXR2+vlUqqJtf5XsCQcgsSb5PL4wlujWBYDJuWsP4UnQX1YHDHU8qRlD+1PzTQ+Q==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-nested@6.2.0:
-        resolution:
-            {
-                integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==,
-            }
-        engines: { node: '>=12.0' }
-        peerDependencies:
-            postcss: ^8.2.14
-
-    postcss-nested@7.0.2:
-        resolution:
-            {
-                integrity: sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==,
-            }
-        engines: { node: '>=18.0' }
-        peerDependencies:
-            postcss: ^8.2.14
-
-    postcss-normalize-charset@7.0.3:
-        resolution:
-            {
-                integrity: sha512-NoBfZu8PR4c2NlmjvrqQTzCzLY79hwcSRgNQ3ZiNK0ABzf9kYKloE/jNj+/8GQY1wsm8pRRgANk6ydLH8cwo0Q==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-normalize-display-values@7.0.3:
-        resolution:
-            {
-                integrity: sha512-ldsCX0QIt05pKIOobZtVQ48wXJecr+czw4+e1/YjVhLMqslShgpVxgPtI2CefURR8oyVoYaU/l829MMwExDMLw==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-normalize-positions@7.0.4:
-        resolution:
-            {
-                integrity: sha512-VEvlpeGd3Ju1Hqa/oN4jaP3+ms4laYwkEL9N9u+B6k54PZjXbW1n6wI+aVprf1BQXlCYpS5+1pl/7/vHiKgARg==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-normalize-repeat-style@7.0.4:
-        resolution:
-            {
-                integrity: sha512-6mPKlY/8cSaDHxX502wERADarJsccwlky6yIrOapHH2ZgfoKAV94SbiTKfKEs4EEpdazuc3J72WsqeYk7hp9+Q==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-normalize-string@7.0.3:
-        resolution:
-            {
-                integrity: sha512-HnEQPUchi1eznmDKEYrKUTqrprEq97SrpUYClgUkv7V2zRODD9DFoUsYU+m9ZOetmD5ku7fEMZB/lwy8IT6xVQ==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-normalize-timing-functions@7.0.3:
-        resolution:
-            {
-                integrity: sha512-zmEzHdvpZBZu0OKlbJSfgASQvaayyAoVuWtvyr34IJ/LyS+DaOKvvR3EvFJ9RWWtNIx+CMvO125OVophaxNYew==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-normalize-unicode@7.0.9:
-        resolution:
-            {
-                integrity: sha512-DRAdWfeh/TjmhLJsw91vdiWCnUod9iwvM7xyS02/nF/sLsCR3A8l3pztrSUrWG8DSBqfX7yEk9FM0USaVJ2mSg==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-normalize-url@7.0.3:
-        resolution:
-            {
-                integrity: sha512-CL93wmloq5qsffmFv+bw24MIRbmhHrp53qoh1LDAb/5TtjWEXI/np4xcP/Gw9oWCb2XyWnqHYLDUwiKRoJBA1Q==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-normalize-whitespace@7.0.3:
-        resolution:
-            {
-                integrity: sha512-FdHjjn+Ht5Z2ZRjNOmeCbNq6lq09sUYKpmlF/Aq0XjVNSLTL6fmHlA/3swN2wP2caY9GV/tjSDcIIyS7aN7W0A==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-ordered-values@7.0.4:
-        resolution:
-            {
-                integrity: sha512-nubSi49hDHQk4E8KIj+IbLY8Bg+8OcSUEhgyolgM+atnOvXjV7EjaR6bac4YGZoFyPa9mWoAF3EaYbWdFkKqVg==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-reduce-initial@7.0.9:
-        resolution:
-            {
-                integrity: sha512-ztTNPdIxXTxtBcG03E9u8v44M4ElXbMIRT7pf2onlquGula0Y83nKKxqM22FA/hMgkfCjN7ohevkVlaNwI8iOQ==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-reduce-transforms@7.0.3:
-        resolution:
-            {
-                integrity: sha512-FXsnN9ZwcZTT8Yf8cAHA8qIGUXcX6WfLd9JoYhrdDfmvsVhhfqkkv7m4AC3rwFOfz+GzkUa87OCKF9dUcicd+g==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-selector-parser@6.1.4:
-        resolution:
-            {
-                integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==,
-            }
-        engines: { node: '>=4' }
-
-    postcss-selector-parser@7.1.4:
-        resolution:
-            {
-                integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==,
-            }
-        engines: { node: '>=4' }
-
-    postcss-simple-vars@7.0.1:
-        resolution:
-            {
-                integrity: sha512-5GLLXaS8qmzHMOjVxqkk1TZPf1jMqesiI7qLhnlyERalG0sMbHIbJqrcnrpmZdKCLglHnRHoEBB61RtGTsj++A==,
-            }
-        engines: { node: '>=14.0' }
-        peerDependencies:
-            postcss: ^8.2.1
-
-    postcss-svgo@7.1.3:
-        resolution:
-            {
-                integrity: sha512-2QfoFOYMcj8lwcVEf9WeTlkVIAm7u2QvOEhMzkQU3KUhhGX/l8hVV9EtjMv4iq3E9iI3OeeMN0YoMLbGusuigw==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >= 18 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-unique-selectors@7.0.7:
-        resolution:
-            {
-                integrity: sha512-d+sCkaRnSefghOUdH8CMJZV9yUQhj2ojpe8Nw/lA+LV1UOfeleGkLTl6XdCFFSai9UJ+DJPb69FFuqthXYsY8w==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    postcss-value-parser@4.2.0:
-        resolution:
-            {
-                integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
-            }
-
-    postcss@8.5.15:
-        resolution:
-            {
-                integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
-            }
-        engines: { node: ^10 || ^12 || >=14 }
-
-    prettier@3.8.4:
-        resolution:
-            {
-                integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==,
-            }
-        engines: { node: '>=14' }
-        hasBin: true
-
-    pretty-format@27.5.1:
-        resolution:
-            {
-                integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==,
-            }
-        engines: { node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0 }
-
-    property-information@7.2.0:
-        resolution:
-            {
-                integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==,
-            }
-
-    prosemirror-changeset@2.4.1:
-        resolution:
-            {
-                integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==,
-            }
-
-    prosemirror-commands@1.7.1:
-        resolution:
-            {
-                integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==,
-            }
-
-    prosemirror-dropcursor@1.8.2:
-        resolution:
-            {
-                integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==,
-            }
-
-    prosemirror-gapcursor@1.4.1:
-        resolution:
-            {
-                integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==,
-            }
-
-    prosemirror-history@1.5.0:
-        resolution:
-            {
-                integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==,
-            }
-
-    prosemirror-inputrules@1.5.1:
-        resolution:
-            {
-                integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==,
-            }
-
-    prosemirror-keymap@1.2.3:
-        resolution:
-            {
-                integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==,
-            }
-
-    prosemirror-markdown@1.13.4:
-        resolution:
-            {
-                integrity: sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==,
-            }
-
-    prosemirror-model@1.25.8:
-        resolution:
-            {
-                integrity: sha512-BswA4BLSFEiORV6Vjj/yZBXDbos1zTEnhyeSSgT8psGFhstQS7UJ8/WOLiDos9Byaee27+tml0/DuMNxYR84zg==,
-            }
-
-    prosemirror-schema-list@1.5.1:
-        resolution:
-            {
-                integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==,
-            }
-
-    prosemirror-state@1.4.4:
-        resolution:
-            {
-                integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==,
-            }
-
-    prosemirror-tables@1.8.5:
-        resolution:
-            {
-                integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==,
-            }
-
-    prosemirror-transform@1.12.0:
-        resolution:
-            {
-                integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==,
-            }
-
-    prosemirror-view@1.41.9:
-        resolution:
-            {
-                integrity: sha512-clTunTX+eaLbr87L1V1QPheRlEQJyTlL3gXe9x3jQIk3rL0RVWxviDGz8tFaydwIVm+hKhYCyr+R/zBtWr9s6A==,
-            }
-
-    punycode.js@2.3.1:
-        resolution:
-            {
-                integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==,
-            }
-        engines: { node: '>=6' }
-
-    queue-microtask@1.2.3:
-        resolution:
-            {
-                integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
-            }
-
-    react-aria-components@1.18.0:
-        resolution:
-            {
-                integrity: sha512-FhRQjuDkH4WhgFv+O2sYTzK3JzdZTGpBeaqfRlfTo+DcSZzD8elJEkytHe7SDpcexVKeire8NVd7OruZHfCVoA==,
-            }
-        peerDependencies:
-            react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-            react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-    react-aria@3.49.0:
-        resolution:
-            {
-                integrity: sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==,
-            }
-        peerDependencies:
-            react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-            react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-    react-dom@19.2.7:
-        resolution:
-            {
-                integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==,
-            }
-        peerDependencies:
-            react: ^19.2.7
-
-    react-is@17.0.2:
-        resolution:
-            {
-                integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==,
-            }
-
-    react-stately@3.47.0:
-        resolution:
-            {
-                integrity: sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==,
-            }
-        peerDependencies:
-            react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-    react@19.2.7:
-        resolution:
-            {
-                integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    read-cache@1.0.0:
-        resolution:
-            {
-                integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==,
-            }
-
-    readdirp@3.6.0:
-        resolution:
-            {
-                integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==,
-            }
-        engines: { node: '>=8.10.0' }
-
-    readdirp@5.0.0:
-        resolution:
-            {
-                integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==,
-            }
-        engines: { node: '>= 20.19.0' }
-
-    recast@0.23.11:
-        resolution:
-            {
-                integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==,
-            }
-        engines: { node: '>= 4' }
-
-    recma-build-jsx@1.0.0:
-        resolution:
-            {
-                integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==,
-            }
-
-    recma-jsx@1.0.1:
-        resolution:
-            {
-                integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==,
-            }
-        peerDependencies:
-            acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-    recma-parse@1.0.0:
-        resolution:
-            {
-                integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==,
-            }
-
-    recma-stringify@1.0.0:
-        resolution:
-            {
-                integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==,
-            }
-
-    regex-recursion@5.1.1:
-        resolution:
-            {
-                integrity: sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==,
-            }
-
-    regex-recursion@6.0.2:
-        resolution:
-            {
-                integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==,
-            }
-
-    regex-utilities@2.3.0:
-        resolution:
-            {
-                integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==,
-            }
-
-    regex@5.1.1:
-        resolution:
-            {
-                integrity: sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==,
-            }
-
-    regex@6.1.0:
-        resolution:
-            {
-                integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==,
-            }
-
-    rehype-parse@9.0.1:
-        resolution:
-            {
-                integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==,
-            }
-
-    rehype-pretty-code@0.14.3:
-        resolution:
-            {
-                integrity: sha512-Cz692FeYusTjT5cfFWLc4r7JhgC3/JlJptgUh4iffBxWxUnWW1oqbWFi7jGCeq00DYUm8yzoTnvpocaYa5x82g==,
-            }
-        engines: { node: '>=18' }
-        peerDependencies:
-            shiki: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
-
-    rehype-raw@7.0.0:
-        resolution:
-            {
-                integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==,
-            }
-
-    rehype-recma@1.0.0:
-        resolution:
-            {
-                integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==,
-            }
-
-    rehype-stringify@10.0.1:
-        resolution:
-            {
-                integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==,
-            }
-
-    rehype@13.0.2:
-        resolution:
-            {
-                integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==,
-            }
-
-    remark-gfm@4.0.1:
-        resolution:
-            {
-                integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==,
-            }
-
-    remark-mdx@3.1.1:
-        resolution:
-            {
-                integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==,
-            }
-
-    remark-parse@11.0.0:
-        resolution:
-            {
-                integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==,
-            }
-
-    remark-rehype@11.1.2:
-        resolution:
-            {
-                integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==,
-            }
-
-    remark-stringify@11.0.0:
-        resolution:
-            {
-                integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==,
-            }
-
-    resolve-pkg-maps@1.0.0:
-        resolution:
-            {
-                integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
-            }
-
-    resolve@1.22.12:
-        resolution:
-            {
-                integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==,
-            }
-        engines: { node: '>= 0.4' }
-        hasBin: true
-
-    restore-cursor@5.1.0:
-        resolution:
-            {
-                integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==,
-            }
-        engines: { node: '>=18' }
-
-    reusify@1.1.0:
-        resolution:
-            {
-                integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==,
-            }
-        engines: { iojs: '>=1.0.0', node: '>=0.10.0' }
-
-    rfdc@1.4.1:
-        resolution:
-            {
-                integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
-            }
-
-    rolldown@1.0.0-rc.12:
-        resolution:
-            {
-                integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        hasBin: true
-
-    rolldown@1.0.3:
-        resolution:
-            {
-                integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        hasBin: true
-
-    rolldown@1.1.1:
-        resolution:
-            {
-                integrity: sha512-IN750c0p+s3jqJIsFLRZrQazmbAB1kkQDTtQjSt/gbS2ywLhlv4R5Shazer0FZKmuo/BsO3/w2UoYnUjuOZqHg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        hasBin: true
-
-    rope-sequence@1.3.4:
-        resolution:
-            {
-                integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==,
-            }
-
-    rou3@0.7.12:
-        resolution:
-            {
-                integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==,
-            }
-
-    run-parallel@1.2.0:
-        resolution:
-            {
-                integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
-            }
-
-    sax@1.6.0:
-        resolution:
-            {
-                integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==,
-            }
-        engines: { node: '>=11.0.0' }
-
-    scheduler@0.27.0:
-        resolution:
-            {
-                integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==,
-            }
-
-    semver@5.7.2:
-        resolution:
-            {
-                integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==,
-            }
-        hasBin: true
-
-    semver@6.3.1:
-        resolution:
-            {
-                integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
-            }
-        hasBin: true
-
-    semver@7.8.4:
-        resolution:
-            {
-                integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==,
-            }
-        engines: { node: '>=10' }
-        hasBin: true
-
-    set-cookie-parser@3.1.0:
-        resolution:
-            {
-                integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==,
-            }
-
-    shallow-clone@3.0.1:
-        resolution:
-            {
-                integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==,
-            }
-        engines: { node: '>=8' }
-
-    sharp@0.34.5:
-        resolution:
-            {
-                integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==,
-            }
-        engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-
-    shebang-command@2.0.0:
-        resolution:
-            {
-                integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
-            }
-        engines: { node: '>=8' }
-
-    shebang-regex@3.0.0:
-        resolution:
-            {
-                integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
-            }
-        engines: { node: '>=8' }
-
-    shiki@1.29.2:
-        resolution:
-            {
-                integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==,
-            }
-
-    shiki@3.23.0:
-        resolution:
-            {
-                integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==,
-            }
-
-    siginfo@2.0.0:
-        resolution:
-            {
-                integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
-            }
-
-    signal-exit@4.1.0:
-        resolution:
-            {
-                integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
-            }
-        engines: { node: '>=14' }
-
-    sirv@3.0.2:
-        resolution:
-            {
-                integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==,
-            }
-        engines: { node: '>=18' }
-
-    sisteransi@1.0.5:
-        resolution:
-            {
-                integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
-            }
-
-    slice-ansi@5.0.0:
-        resolution:
-            {
-                integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==,
-            }
-        engines: { node: '>=12' }
-
-    slice-ansi@7.1.2:
-        resolution:
-            {
-                integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==,
-            }
-        engines: { node: '>=18' }
-
-    source-map-js@1.2.1:
-        resolution:
-            {
-                integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    source-map-support@0.5.21:
-        resolution:
-            {
-                integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==,
-            }
-
-    source-map@0.6.1:
-        resolution:
-            {
-                integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    source-map@0.7.6:
-        resolution:
-            {
-                integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==,
-            }
-        engines: { node: '>= 12' }
-
-    space-separated-tokens@2.0.2:
-        resolution:
-            {
-                integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==,
-            }
-
-    stackback@0.0.2:
-        resolution:
-            {
-                integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
-            }
-
-    std-env@4.1.0:
-        resolution:
-            {
-                integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==,
-            }
-
-    string-argv@0.3.2:
-        resolution:
-            {
-                integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==,
-            }
-        engines: { node: '>=0.6.19' }
-
-    string-width@7.2.0:
-        resolution:
-            {
-                integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==,
-            }
-        engines: { node: '>=18' }
-
-    stringify-entities@4.0.4:
-        resolution:
-            {
-                integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==,
-            }
-
-    strip-ansi@7.2.0:
-        resolution:
-            {
-                integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==,
-            }
-        engines: { node: '>=12' }
-
-    strip-final-newline@3.0.0:
-        resolution:
-            {
-                integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==,
-            }
-        engines: { node: '>=12' }
-
-    stubborn-fs@2.0.0:
-        resolution:
-            {
-                integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==,
-            }
-
-    stubborn-utils@1.0.2:
-        resolution:
-            {
-                integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==,
-            }
-
-    style-to-js@1.1.21:
-        resolution:
-            {
-                integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==,
-            }
-
-    style-to-object@1.0.14:
-        resolution:
-            {
-                integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==,
-            }
-
-    stylehacks@7.0.11:
-        resolution:
-            {
-                integrity: sha512-iODNfhXVLqc5LADs+Y6Oh5wJuK5ZcHbVng8aiK3y9pjMQdc5hLrBW0eFU6FtnpNrE6PoEg/MmFTU4waotj5WNg==,
-            }
-        engines: { node: ^18.12.0 || ^20.9.0 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.5.13
-
-    sucrase@3.35.1:
-        resolution:
-            {
-                integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==,
-            }
-        engines: { node: '>=16 || 14 >=14.17' }
-        hasBin: true
-
-    supports-preserve-symlinks-flag@1.0.0:
-        resolution:
-            {
-                integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
-            }
-        engines: { node: '>= 0.4' }
-
-    svgo@4.0.1:
-        resolution:
-            {
-                integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==,
-            }
-        engines: { node: '>=16' }
-        hasBin: true
-
-    tagged-tag@1.0.0:
-        resolution:
-            {
-                integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==,
-            }
-        engines: { node: '>=20' }
-
-    tailwindcss@3.4.19:
-        resolution:
-            {
-                integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==,
-            }
-        engines: { node: '>=14.0.0' }
-        hasBin: true
-
-    tailwindcss@4.3.1:
-        resolution:
-            {
-                integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==,
-            }
-
-    tapable@2.3.3:
-        resolution:
-            {
-                integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==,
-            }
-        engines: { node: '>=6' }
-
-    thenify-all@1.6.0:
-        resolution:
-            {
-                integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==,
-            }
-        engines: { node: '>=0.8' }
-
-    thenify@3.3.1:
-        resolution:
-            {
-                integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
-            }
-
-    tiny-invariant@1.3.3:
-        resolution:
-            {
-                integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==,
-            }
-
-    tinybench@2.9.0:
-        resolution:
-            {
-                integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
-            }
-
-    tinyexec@1.2.4:
-        resolution:
-            {
-                integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==,
-            }
-        engines: { node: '>=18' }
-
-    tinyglobby@0.2.17:
-        resolution:
-            {
-                integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==,
-            }
-        engines: { node: '>=12.0.0' }
-
-    tinyrainbow@3.1.0:
-        resolution:
-            {
-                integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
-            }
-        engines: { node: '>=14.0.0' }
-
-    tiptap-markdown@0.9.0:
-        resolution:
-            {
-                integrity: sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==,
-            }
-        peerDependencies:
-            '@tiptap/core': ^3.0.1
-
-    tmp@0.2.7:
-        resolution:
-            {
-                integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==,
-            }
-        engines: { node: '>=14.14' }
-
-    to-regex-range@5.0.1:
-        resolution:
-            {
-                integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
-            }
-        engines: { node: '>=8.0' }
-
-    totalist@3.0.1:
-        resolution:
-            {
-                integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==,
-            }
-        engines: { node: '>=6' }
-
-    trim-lines@3.0.1:
-        resolution:
-            {
-                integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==,
-            }
-
-    trough@2.2.0:
-        resolution:
-            {
-                integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==,
-            }
-
-    ts-interface-checker@0.1.13:
-        resolution:
-            {
-                integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==,
-            }
-
-    tslib@2.8.1:
-        resolution:
-            {
-                integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
-            }
-
-    tsx@4.22.4:
-        resolution:
-            {
-                integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==,
-            }
-        engines: { node: '>=18.0.0' }
-        hasBin: true
-
-    type-fest@5.7.0:
-        resolution:
-            {
-                integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==,
-            }
-        engines: { node: '>=20' }
-
-    typescript@5.9.3:
-        resolution:
-            {
-                integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
-            }
-        engines: { node: '>=14.17' }
-        hasBin: true
-
-    uc.micro@2.1.0:
-        resolution:
-            {
-                integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==,
-            }
-
-    undici-types@7.18.2:
-        resolution:
-            {
-                integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==,
-            }
-
-    unified@11.0.5:
-        resolution:
-            {
-                integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==,
-            }
-
-    unist-util-is@6.0.1:
-        resolution:
-            {
-                integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==,
-            }
-
-    unist-util-position-from-estree@2.0.0:
-        resolution:
-            {
-                integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==,
-            }
-
-    unist-util-position@5.0.0:
-        resolution:
-            {
-                integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==,
-            }
-
-    unist-util-stringify-position@4.0.0:
-        resolution:
-            {
-                integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==,
-            }
-
-    unist-util-visit-parents@6.0.2:
-        resolution:
-            {
-                integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==,
-            }
-
-    unist-util-visit@5.1.0:
-        resolution:
-            {
-                integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==,
-            }
-
-    update-browserslist-db@1.2.3:
-        resolution:
-            {
-                integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
-            }
-        hasBin: true
-        peerDependencies:
-            browserslist: '>= 4.21.0'
-
-    use-sync-external-store@1.6.0:
-        resolution:
-            {
-                integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==,
-            }
-        peerDependencies:
-            react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-    util-deprecate@1.0.2:
-        resolution:
-            {
-                integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
-            }
-
-    valibot@1.4.1:
-        resolution:
-            {
-                integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==,
-            }
-        peerDependencies:
-            typescript: '>=5'
-        peerDependenciesMeta:
-            typescript:
-                optional: true
-
-    vfile-location@5.0.3:
-        resolution:
-            {
-                integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==,
-            }
-
-    vfile-message@4.0.3:
-        resolution:
-            {
-                integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==,
-            }
-
-    vfile@6.0.3:
-        resolution:
-            {
-                integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
-            }
-
-    vite@8.0.16:
-        resolution:
-            {
-                integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        hasBin: true
-        peerDependencies:
-            '@types/node': ^20.19.0 || >=22.12.0
-            '@vitejs/devtools': ^0.1.18
-            esbuild: ^0.27.0 || ^0.28.0
-            jiti: '>=1.21.0'
-            less: ^4.0.0
-            sass: ^1.70.0
-            sass-embedded: ^1.70.0
-            stylus: '>=0.54.8'
-            sugarss: ^5.0.0
-            terser: ^5.16.0
-            tsx: ^4.8.1
-            yaml: ^2.4.2
-        peerDependenciesMeta:
-            '@types/node':
-                optional: true
-            '@vitejs/devtools':
-                optional: true
-            esbuild:
-                optional: true
-            jiti:
-                optional: true
-            less:
-                optional: true
-            sass:
-                optional: true
-            sass-embedded:
-                optional: true
-            stylus:
-                optional: true
-            sugarss:
-                optional: true
-            terser:
-                optional: true
-            tsx:
-                optional: true
-            yaml:
-                optional: true
-
-    vite@8.0.4:
-        resolution:
-            {
-                integrity: sha512-baBr4jUVSLJ0RPyZ2nK0zS2+W8hNHbM4hEzfvllukmRPVS3xDG5ATTNtbRXrKIOE2b8/FsPWJAOnuIxcs7g3cw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        hasBin: true
-        peerDependencies:
-            '@types/node': ^20.19.0 || >=22.12.0
-            '@vitejs/devtools': ^0.1.0
-            esbuild: ^0.27.0 || ^0.28.0
-            jiti: '>=1.21.0'
-            less: ^4.0.0
-            sass: ^1.70.0
-            sass-embedded: ^1.70.0
-            stylus: '>=0.54.8'
-            sugarss: ^5.0.0
-            terser: ^5.16.0
-            tsx: ^4.8.1
-            yaml: ^2.4.2
-        peerDependenciesMeta:
-            '@types/node':
-                optional: true
-            '@vitejs/devtools':
-                optional: true
-            esbuild:
-                optional: true
-            jiti:
-                optional: true
-            less:
-                optional: true
-            sass:
-                optional: true
-            sass-embedded:
-                optional: true
-            stylus:
-                optional: true
-            sugarss:
-                optional: true
-            terser:
-                optional: true
-            tsx:
-                optional: true
-            yaml:
-                optional: true
-
-    vitest@4.1.8:
-        resolution:
-            {
-                integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==,
-            }
-        engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
-        hasBin: true
-        peerDependencies:
-            '@edge-runtime/vm': '*'
-            '@opentelemetry/api': ^1.9.0
-            '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-            '@vitest/browser-playwright': 4.1.8
-            '@vitest/browser-preview': 4.1.8
-            '@vitest/browser-webdriverio': 4.1.8
-            '@vitest/coverage-istanbul': 4.1.8
-            '@vitest/coverage-v8': 4.1.8
-            '@vitest/ui': 4.1.8
-            happy-dom: '*'
-            jsdom: '*'
-            vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-        peerDependenciesMeta:
-            '@edge-runtime/vm':
-                optional: true
-            '@opentelemetry/api':
-                optional: true
-            '@types/node':
-                optional: true
-            '@vitest/browser-playwright':
-                optional: true
-            '@vitest/browser-preview':
-                optional: true
-            '@vitest/browser-webdriverio':
-                optional: true
-            '@vitest/coverage-istanbul':
-                optional: true
-            '@vitest/coverage-v8':
-                optional: true
-            '@vitest/ui':
-                optional: true
-            happy-dom:
-                optional: true
-            jsdom:
-                optional: true
-
-    w3c-keyname@2.2.8:
-        resolution:
-            {
-                integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==,
-            }
-
-    web-namespaces@2.0.1:
-        resolution:
-            {
-                integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==,
-            }
-
-    web-streams-polyfill@3.3.3:
-        resolution:
-            {
-                integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==,
-            }
-        engines: { node: '>= 8' }
-
-    when-exit@2.1.5:
-        resolution:
-            {
-                integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==,
-            }
-
-    which@2.0.2:
-        resolution:
-            {
-                integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
-            }
-        engines: { node: '>= 8' }
-        hasBin: true
-
-    why-is-node-running@2.3.0:
-        resolution:
-            {
-                integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
-            }
-        engines: { node: '>=8' }
-        hasBin: true
-
-    wrap-ansi@9.0.2:
-        resolution:
-            {
-                integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==,
-            }
-        engines: { node: '>=18' }
-
-    write-file-atomic@5.0.1:
-        resolution:
-            {
-                integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==,
-            }
-        engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
-
-    ws@8.21.0:
-        resolution:
-            {
-                integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==,
-            }
-        engines: { node: '>=10.0.0' }
-        peerDependencies:
-            bufferutil: ^4.0.1
-            utf-8-validate: '>=5.0.2'
-        peerDependenciesMeta:
-            bufferutil:
-                optional: true
-            utf-8-validate:
-                optional: true
-
-    xdg-basedir@5.1.0:
-        resolution:
-            {
-                integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==,
-            }
-        engines: { node: '>=12' }
-
-    y18n@5.0.8:
-        resolution:
-            {
-                integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==,
-            }
-        engines: { node: '>=10' }
-
-    yallist@3.1.1:
-        resolution:
-            {
-                integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
-            }
-
-    yaml@2.9.0:
-        resolution:
-            {
-                integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==,
-            }
-        engines: { node: '>= 14.6' }
-        hasBin: true
-
-    yargs-parser@22.0.0:
-        resolution:
-            {
-                integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==,
-            }
-        engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
-
-    yargs@18.0.0:
-        resolution:
-            {
-                integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==,
-            }
-        engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
-
-    zod@4.4.3:
-        resolution:
-            {
-                integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==,
-            }
-
-    zwitch@2.0.4:
-        resolution:
-            {
-                integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==,
-            }
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@ark/schema@0.56.0':
+    resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
+
+  '@ark/util@0.56.0':
+    resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-create-class-features-plugin@7.29.7':
+    resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.29.7':
+    resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-syntax-flow@7.29.7':
+    resolution: {integrity: sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-jsx@7.29.7':
+    resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.29.7':
+    resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-class-properties@7.29.7':
+    resolution: {integrity: sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-flow-strip-types@7.29.7':
+    resolution: {integrity: sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-commonjs@7.29.7':
+    resolution: {integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7':
+    resolution: {integrity: sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-optional-chaining@7.29.7':
+    resolution: {integrity: sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-private-methods@7.29.7':
+    resolution: {integrity: sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@7.29.7':
+    resolution: {integrity: sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-flow@7.29.7':
+    resolution: {integrity: sha512-KYIRV0BuaN68CDdsqFkAD7MU7yipUqQNuNElwATdxaIdpTjhvtY82QvkBJs7zV3Evxj2jFAAZ1iO8nyy0nhjqA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-typescript@7.29.7':
+    resolution: {integrity: sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/register@7.29.7':
+    resolution: {integrity: sha512-AMGJoWuES861riy6pcB0fphE1YXybtQnBYQMuIyPv6mKLiosfa79BKTnAOyx215c/3RJPJpdQwoHZ3earVH7AA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@better-auth/core@1.6.18':
+    resolution: {integrity: sha512-mlPZBKHY6gZdJtuY6LiuKjN2r8AWu0LCss7CEnI0xMbE9D7Sw6WofwPPwiMm+0Hi0QBKIaZGYRmR7/WasbOs+Q==}
+    peerDependencies:
+      '@better-auth/utils': 0.4.1
+      '@better-fetch/fetch': 1.3.0
+      '@cloudflare/workers-types': '>=4'
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.3.6
+      jose: ^6.1.0
+      kysely: ^0.28.5 || ^0.29.0
+      nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@better-auth/core@1.6.21':
+    resolution: {integrity: sha512-vIZCHw4ntWUE+CIXxiVmpa1S/YtX0tDtylV5HyaqvAf9AuUKsU1TXbKVYCKkLrgwMaVGGrVNcvVS6WN2KWS9IA==}
+    peerDependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@cloudflare/workers-types': '>=4'
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.3.7
+      jose: ^6.1.0
+      kysely: ^0.28.5 || ^0.29.0
+      nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@better-auth/drizzle-adapter@1.6.18':
+    resolution: {integrity: sha512-VFcW2YMLZt0YAD0hy6BcMkjPh4Rh9khV71jnV2uL3udqz599Z1P4PiuWO6XZLELTvb/bbAUnxS5ZnyXQwFDAPQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.18
+      '@better-auth/utils': 0.4.1
+      drizzle-orm: ^0.45.2
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
+
+  '@better-auth/drizzle-adapter@1.6.21':
+    resolution: {integrity: sha512-f2BMUnFBwbX94lxZP05ygOOCfwD4t5jAQY5PAZiNTrLhDyUKoVPoLP1j+t8kRvC09SlzC3HR/AwAIFKO4OVNRw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.21
+      '@better-auth/utils': 0.4.2
+      drizzle-orm: ^0.45.2
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
+
+  '@better-auth/kysely-adapter@1.6.18':
+    resolution: {integrity: sha512-7Q9+LYWiVD8t3nrxN/fPqZOgUQFcVh+KUo95CDj2+Hfnf4GCb6/ZsQrEnBXBgplwBQbUOYN58Lp/uevb6ugwFQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.18
+      '@better-auth/utils': 0.4.1
+      kysely: ^0.28.17 || ^0.29.0
+    peerDependenciesMeta:
+      kysely:
+        optional: true
+
+  '@better-auth/kysely-adapter@1.6.21':
+    resolution: {integrity: sha512-UlyCG+HU3PePk3bfO1WdQwGPGqOZuQmnjq94nCwlYhDbHX2KW/cJD9iFdDubPSao0+FXJe5znMsB5U6AHCrV4w==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.21
+      '@better-auth/utils': 0.4.2
+      kysely: ^0.28.17 || ^0.29.0
+    peerDependenciesMeta:
+      kysely:
+        optional: true
+
+  '@better-auth/memory-adapter@1.6.18':
+    resolution: {integrity: sha512-jHulNRsA0OGKAACmsCNfAbH2z0NEoLQCLdZTU6Pvqn/Cd+xh7aFz0oys69KyKZp2r30QUjuEG9FrrqS8ASWDiw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.18
+      '@better-auth/utils': 0.4.1
+
+  '@better-auth/memory-adapter@1.6.21':
+    resolution: {integrity: sha512-qh85wUK7nYa5+7ihhg2viDpMexUZr23JClaNlnbtB/DdIcRsxHTUmzVcSZw1DUmYJA0+iOiDvI02O1CWpeiRfw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.21
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.6.18':
+    resolution: {integrity: sha512-A6aD3sKsptQl5sBq2wFoLGckEIM5Pa93T//R1DR+erAZOMejZGyaqYaPXWwRk7ZejFOyrftMm98OP0IJsz52gg==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.18
+      '@better-auth/utils': 0.4.1
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  '@better-auth/mongo-adapter@1.6.21':
+    resolution: {integrity: sha512-GSiVOn3ozuSkYWprahBpouEMYn+oHWptoa12AgBR3WM0g2+ENX3ThewCx2BEwCIZrwxNzaYagrl3H7C2UgKrGw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.21
+      '@better-auth/utils': 0.4.2
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  '@better-auth/prisma-adapter@1.6.18':
+    resolution: {integrity: sha512-9hJrDYDqGpb53o8BUuB8uunkkeY+nACzYpZr06R8+22zTFS/NL/jLwgUlK3Xf+1VjhBoXAoEBKJ3ghVUGu6jFw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.18
+      '@better-auth/utils': 0.4.1
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
+  '@better-auth/prisma-adapter@1.6.21':
+    resolution: {integrity: sha512-k5sjva/Ng1ITaNTgk/Mxz3+jeNtaPGubN4SHXuCSm1i8JwPE17k15hbHbVM1enMYtBnzG59/fuqgNAsKKUGgYQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.21
+      '@better-auth/utils': 0.4.2
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
+  '@better-auth/telemetry@1.6.18':
+    resolution: {integrity: sha512-C/sWZzDAFrtb8bFs+yLHLYYfk1Yffw2GnKXerxTGO3rHI7qV2Ktf359nAf3IdZr+cC/404fFk4hkDCnQiGCkZA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.18
+      '@better-auth/utils': 0.4.1
+      '@better-fetch/fetch': 1.3.0
+
+  '@better-auth/telemetry@1.6.21':
+    resolution: {integrity: sha512-iOx85H/q91yxjpUTTHpphOmsq/iADrTd2ZO+ehELQIeszU71o9FGE6a4TJdXVQXUeRpSMzaZ9tCi3R+h8/lDBw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.21
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.1':
+    resolution: {integrity: sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==}
+
+  '@better-auth/utils@0.4.2':
+    resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
+
+  '@better-fetch/fetch@1.3.0':
+    resolution: {integrity: sha512-Lgkl18IrUURFqa1nE38GNDWXf7XGzfxXQDCE/alCQV0yZ98YrPGtlmW61ch1T4YRt3lxrSAGA+Ft73FzuWWb3A==}
+
+  '@better-fetch/fetch@1.3.1':
+    resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
+  '@bomb.sh/args@0.3.1':
+    resolution: {integrity: sha512-CwxKrfgcorUPP6KfYD59aRdBYWBTsfsxT+GmoLVnKo5Tmyoqbpo0UNcjngRMyU+6tiPbd18RuIYxhgAn44wU/Q==}
+
+  '@clack/core@1.4.1':
+    resolution: {integrity: sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.5.1':
+    resolution: {integrity: sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==}
+    engines: {node: '>= 20.12.0'}
+
+  '@colordx/core@5.4.3':
+    resolution: {integrity: sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==}
+
+  '@drizzle-team/brocli@0.11.0':
+    resolution: {integrity: sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg==}
+
+  '@ecopages/jsx@0.3.0-alpha.25':
+    resolution: {integrity: sha512-sEjCLWEosxIHmsDzkhFix79B8km2jhwE8KPjTcmegw/EmAr7NPjIxerVnHE1sT4+o6VR9p+NrEhu82v05LRuGw==}
+    peerDependencies:
+      typescript: ^5
+
+  '@ecopages/logger@0.2.3':
+    resolution: {integrity: sha512-Hkt5H9Kzv6y07aiPZPaDkJ6/Bp7+Aen5ZFuI5zQ6ON7PyeuVu1lMiQy9pL+9Wm8yeO3wnMO44Jmph84Cc0X0lQ==}
+    peerDependencies:
+      typescript: ^5.0.0
+
+  '@ecopages/radiant@0.3.0-alpha.25':
+    resolution: {integrity: sha512-qz6FP2ymTAR1lR1AoM7RjQBmPM4vEQ1dv8YijZpCBDKy4IWDzSK3hZHgK2MGC5KvnPdUC6HZwDh380Qzxxg1Pg==}
+    peerDependencies:
+      '@ecopages/jsx': '>=0.3.0-alpha.0 <1.0.0'
+      '@ecopages/signals': '>=0.3.0-alpha.0 <1.0.0'
+
+  '@ecopages/scripts-injector@0.1.5':
+    resolution: {integrity: sha512-4julGcmVkf4G8asK0/vAZ9o9bIWudEyGk4D/rRF/IE2J4ePT5FgmR8QdzRxD+DElzEnkJTnS7gyX2Dj7JeNtdg==}
+    peerDependencies:
+      typescript: ^5.0.0
+
+  '@ecopages/signals@0.3.0-alpha.25':
+    resolution: {integrity: sha512-X4zEa2KONuJI84uGy0iTAMcYhvRPsSzj4swuHZVIhxudexkr/GLK1zcv4nXDa5ggB4kj/pCXbn3jMOVSkNB0xA==}
+    peerDependencies:
+      typescript: ^5
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/core@1.11.0':
+    resolution: {integrity: sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.11.0':
+    resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@faker-js/faker@10.4.0':
+    resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
+
+  '@faker-js/faker@9.7.0':
+    resolution: {integrity: sha512-aozo5vqjCmDoXLNUJarFZx2IN/GgGaogY4TMJ6so/WLZOWpSV7fvj2dmrV6sEAnUm1O7aCrhTibjpzeDFgNqbg==}
+    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
+
+  '@fontsource-variable/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@internationalized/date@3.12.2':
+    resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
+
+  '@internationalized/number@3.6.7':
+    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+
+  '@internationalized/string@3.2.9':
+    resolution: {integrity: sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@js-temporal/polyfill@0.5.1':
+    resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
+    engines: {node: '>=12'}
+
+  '@kitajs/html@4.2.13':
+    resolution: {integrity: sha512-o+8e61EsoLDPTP7rsPkYolca1YFybHuxU2Lr5fWDZCUkYT/6uBlVkvnZUdCXMQKentJL9dxwpR8/xK2Q+U4LhA==}
+    engines: {node: '>=12'}
+
+  '@kitajs/ts-html-plugin@4.1.4':
+    resolution: {integrity: sha512-xK5mNrhnIy73kJFKx5yVGChJyWFRGmIaE0sjlVxVYllk5dyaEYVCrIh1N8AfnseEHka8gAqzPGW95HlkhDvnJA==}
+    hasBin: true
+    peerDependencies:
+      '@kitajs/html': ^4.2.10
+      typescript: ^5.9.3
+
+  '@lit-labs/ssr-client@1.1.8':
+    resolution: {integrity: sha512-PjGh81oKsoI64m3IDjTqqjhC7dr2uC/o0jrllUb5gRAyp/RlAHxapgJrjq9kWz97faCHLQ8jUlTi6tGm+8fgyA==}
+
+  '@lit-labs/ssr-dom-shim@1.6.0':
+    resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
+
+  '@lit-labs/ssr@3.3.1':
+    resolution: {integrity: sha512-JlF1PempxvzrGEpRFrF+Ki0MHzR3HA51SK8Zv0cFpW9p0bPW4k0FeCwrElCu371UEpXF7RcaE2wgYaE1az0XKg==}
+    engines: {node: '>=13.9.0'}
+
+  '@lit/reactive-element@2.1.2':
+    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
+
+  '@mdx-js/mdx@3.1.1':
+    resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@noble/ciphers@2.2.0':
+    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
+
+  '@oven/bun-darwin-aarch64@1.3.14':
+    resolution: {integrity: sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oven/bun-darwin-x64-baseline@1.3.14':
+    resolution: {integrity: sha512-OSfsTZstc898HHElhU4NccaBGOSSDn5VfahiVTnidZ9B/+wb7WTyfZJaBeJcfjwJ9H2W9uTh2TGtl3UfcXgV9g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oven/bun-darwin-x64@1.3.14':
+    resolution: {integrity: sha512-FFj3QdU/OhlDyZOJ8CWfN5eWLpRlT4qjZg7lMQi7jA6GuoY5ajlO1zWLP/MuHYRSbXQUvV52RejNi8DVnAp13w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oven/bun-freebsd-aarch64@1.3.14':
+    resolution: {integrity: sha512-LIKrXaFxAHybVO5Pf+9XP2FHUj/5APvXTUKk9dqHm5iFz4oH+W24cmhjkJirNujh9hKeTyrpWSe3no9JZKowIw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@oven/bun-freebsd-x64@1.3.14':
+    resolution: {integrity: sha512-uwD+fGUH1ADpIF3B1U2jWzzb20QwRLZfj5QZ28GUCGrAJ/nTmWrD6YYGsblCY1wuhldRez3lU40AyuvSCyLYmw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oven/bun-linux-aarch64-android@1.3.14':
+    resolution: {integrity: sha512-y4kq5b85lsrmFb9Xvi4w9mA5IEFJkLMrSmYn06q24KjL9rUWDWO3VFZEtteZxUN5+ec3Zm5S8OnJw1umaCbVjA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oven/bun-linux-aarch64-musl@1.3.14':
+    resolution: {integrity: sha512-jmqOA92Cd1NL/1XBd4bFkJLxQ86K0RW7ohxS2qzzAvuitO4JiIxjjTeCspoU44zCozH72HpfZfUE2On31OjnWA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oven/bun-linux-aarch64@1.3.14':
+    resolution: {integrity: sha512-X5SsPZHs+iYO8R/efIcRtc7gT2Q2DgPfliCxEkx4cXBumwkw0c/EsHMNwH3EgGpCDaZ7IYVPhpCG/xBOQHEwZw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oven/bun-linux-x64-android@1.3.14':
+    resolution: {integrity: sha512-qe9e1d+3VAEU7nAA2ol9Jvmy/o99PVMSgZhHn7Q/9O3YcDrfEqyQ8zm4zoe5qTEo8HZH0dN03Le0Ys2eQPs7eg==}
+    cpu: [x64]
+    os: [android]
+
+  '@oven/bun-linux-x64-baseline@1.3.14':
+    resolution: {integrity: sha512-q/8EdOC0yUE8FPeoOVq8/Pw5I9/tJaYmUfO/uDUAREx8IUnOJH1RJ5A3BjFqre8pvJoiZA9AovPJq5FnNNjSxA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-linux-x64-musl-baseline@1.3.14':
+    resolution: {integrity: sha512-n6iE71G4lQE4XkrZhQQcL5YUlxDbnq6nqV7zeQi33PMsLT/0kYE+RvHOtBWZ3w0wMdXZfINmp63hIb9ijUBGtw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-linux-x64-musl@1.3.14':
+    resolution: {integrity: sha512-GBCB/k/sIqcr06eTNgg7g46qiUv35Jasx4XiccJ/n7RGqrE4RWUD/XJBbWFprVPjvqd59+QtSnS99XGqvftHfg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-linux-x64@1.3.14':
+    resolution: {integrity: sha512-7OVTAKvwfPmSbIV1HpdOoVVx5VRc427GuPPne93N6vk4eQBPId9nXmZDh9/zGaKPdbVjVtQSZafWQoUjx38Utw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-windows-aarch64@1.3.14':
+    resolution: {integrity: sha512-T7s3x/BsVKQObGU6QDkZeI6wKynzqGbBH1yI77jrrj5siElclxr3DQrDIk8CV4G5/SJq2HHq4kpLyYY2DKCSmA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oven/bun-windows-x64-baseline@1.3.14':
+    resolution: {integrity: sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oven/bun-windows-x64@1.3.14':
+    resolution: {integrity: sha512-mUFWL3BoYkNpjd8e9PqROiFF/1Xeotq20mABJsiQH62jM1g5zqWh4khw1RZ6bX8Q8fWvlPaxG1PjofkmjUi3vg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-parser/binding-android-arm-eabi@0.124.0':
+    resolution: {integrity: sha512-+R9zCafSL8ovjokdPtorUp3sXrh8zQ2AC2L0ivXNvlLR0WS+5WdPkNVrnENq5UvzagM4Xgl0NPsJKz3Hv9+y8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.124.0':
+    resolution: {integrity: sha512-ULHC/gVZ+nP4pd3kNNQTYaQ/e066BW/KuY5qUsvwkVWwOUQGDg+WpfyVOmQ4xfxoue6cMlkKkJ+ntdzfDXpNlg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.124.0':
+    resolution: {integrity: sha512-fGJ2hw7bnbUYn6UvTjp0m4WJ9zXz3cohgcwcgeo7gUZehpPNpvcVEVeIVHNmHnAuAw/ysf4YJR8DA1E+xCA4Lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.124.0':
+    resolution: {integrity: sha512-j0+re9pgps5BH2Tk3fm59Hi3QuLP3C4KhqXi6A+wRHHHJWDFR8mc/KI9mBrfk2JRT+15doGo+zv1eN75/9DuOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.124.0':
+    resolution: {integrity: sha512-0k5mS0npnrhKy72UfF51lpOZ2ESoPWn6gdFw+RdeRWcokraDW1O2kSx3laQ+yk7cCEavQdJSpWCYS/GvBbUCXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.124.0':
+    resolution: {integrity: sha512-P/i4eguRWvAUfGdfhQYg1jpwYkyUV6D3gefIH7HhmRl1Ph6P4IqTIEVcyJr1i/3vr1V5OHU4wonH6/ue/Qzvrw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.124.0':
+    resolution: {integrity: sha512-/ameqFQH5fFP+66Atr8Ynv/2rYe4utcU7L4MoWS5JtrFLVO78g4qDLavyIlJxa6caSwYOvG/eO3c/DXqY5/6Rw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.124.0':
+    resolution: {integrity: sha512-gNeyEcXTtfrRCbj2EfxWU85Fs0wIX3p44Y3twnvuMfkWlLrb9M1Z25AYNSKjJM+fdAjeeQCjw0on47zFuBYwQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.124.0':
+    resolution: {integrity: sha512-uvG7v4Tz9S8/PVqY0SP0DLHxo4hZGe+Pv2tGVnwcsjKCCUPjplbrFVvDzXq+kOaEoUkiCY0Kt1hlZ6FDJ1LKNQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.124.0':
+    resolution: {integrity: sha512-t7KZaaUhfp2au0MRpoENEFqwLKYDdptEry6V7pTAVdPEcFG4P6ii8yeGU9m6p5vb+b8WEKmdpGMNXBEYy7iJdw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.124.0':
+    resolution: {integrity: sha512-eurGGaxHZiIQ+fBSageS8TAkRqZgdOiBeqNrWAqAPup9hXBTmQ0WcBjwsLElf+3jvDL9NhnX0dOgOqPfsjSjdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.124.0':
+    resolution: {integrity: sha512-d1V7/ll1i/LhqE/gZy6Wbz6evlk0egh2XKkwMI3epiojtbtUwQSLIER0Y3yDBBocPuWOjJdvmjtEmPTTLXje/w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.124.0':
+    resolution: {integrity: sha512-w1+cBvriUteOpox6ATqCFVkpGL47PFdcfCPGmgUZbd78Fw44U0gQkc+kVGvAOTvGrptMYgwomD1c6OTVvkrpGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.124.0':
+    resolution: {integrity: sha512-RRB1evQiXRtMCsQQiAh9U0H3HzguLpE0ytfStuhRgmOj7tqUCOVxkHsvM9geZjAax6NqVRj7VXx32qjjkZPsBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.124.0':
+    resolution: {integrity: sha512-asVYN0qmSHlCU8H9Q47SmeJ/Z5EG4IWCC+QGxkfFboI5qh15aLlJnHmnrV61MwQRPXGnVC/sC3qKhrUyqGxUqw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.124.0':
+    resolution: {integrity: sha512-nhwuxm6B8pn9lzAzMUfa571L5hCXYwQo8C8cx5aGOuHWCzruR8gPJnRRXGBci+uGaIIQEZDyU/U6HDgrSp/JlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.124.0':
+    resolution: {integrity: sha512-LWuq4Dl9tff7n+HjJcqoBjDlVCtruc0shgtdtGM+rTUIE9aFxHA/P+wCYR+aWMjN8m9vNaRME/sKXErmhmeKrA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.124.0':
+    resolution: {integrity: sha512-aOh3Lf3AeH0dgzT4yBXcArFZ8VhqNXwZ/xlN0GqBtgVaGoHOOqL2YHlcVIgT+ghsXPVR2PTtYgBiQ1CNK7jp5A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.124.0':
+    resolution: {integrity: sha512-sib5xC0nz/+SCpaETBuHBz4SXS02KuG5HtyOcHsO/SK5ZvLRGhOZx0elDKawjb6adFkD7dQCqpXUS25wY6ELKQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.124.0':
+    resolution: {integrity: sha512-UgojtjGUgZgAZQYt7SC6VO65OVdxEkRe2q+2vbHJO//18qw3Hrk6UvHGQKldsQKgbVcIBT/YBrt85YberiYIPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/runtime@0.134.0':
+    resolution: {integrity: sha512-PhlC0Gh07BXtuyedE8WA7Z42gIlf3PmBDv/CqrJi4/yfVC9/D1iCOU7YjzB4ITQT1gOdrf228uROOeK7aPnyTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/types@0.122.0':
+    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@oxc-project/types@0.135.0':
+    resolution: {integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==}
+
+  '@oxc-transform/binding-android-arm-eabi@0.124.0':
+    resolution: {integrity: sha512-A7r8E94VSRnWlsquGXaW2rmpVcruNOTE4a/7+NCVOtlRUlbmd37bOfv0T47MLIN378uES7yldftCwcVMBG39ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-transform/binding-android-arm64@0.124.0':
+    resolution: {integrity: sha512-vfxxGti1ihWIOjgJOhS6HKIDqp7rszhmbTTgi81otUbJZ/1OWAMcKQyBvKb80hZabdvxU+dxzjGXottW2K/LMw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-transform/binding-darwin-arm64@0.124.0':
+    resolution: {integrity: sha512-goa0sKt6dymRY9kUCA/EgXDJUQq0dj8Acedn7FkjV77RxYZjykexlAV+amM7FnuD3vGTiG5DfL3j4WKWFGnFKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform/binding-darwin-x64@0.124.0':
+    resolution: {integrity: sha512-fNzAFPbPPZDtoXlVwfXWaqp75bPdsNNqbCTnBSsT8qssQoo3Wy8H0fF1U+ltv/9z/UxkGwKow3X4LUaWiHacfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform/binding-freebsd-x64@0.124.0':
+    resolution: {integrity: sha512-GxMoOttUJBXjTYrpj0S24dpDSuTqUScgNmNHN9ICIh5uN4pTQ/2DI+tp8LX5170fZuvU2dpkZvhJT7hNthqWhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.124.0':
+    resolution: {integrity: sha512-Tjhs7VKsFoyZ6+sYLJ4JeQuqxouTMTSdkxPeCPJuQ9TkAlA8Pz8JnlF3V0fxSLkQfz0lYSRvA6J9/RUO5r7+8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.124.0':
+    resolution: {integrity: sha512-3GFThaQKrokWlz5PxclCwuYmNJpiqJ8pECShmaUJ0ACQlzlvXmXLdWy7ImfygGeqKIWq0N7Ps/+fH4gIrsaVRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.124.0':
+    resolution: {integrity: sha512-dY4cbuDbKPEpbxRe85imTO7pRba83z/sAmcYPUtb6ZvOEI4cEY8h0nMI5YRmeZMBF5xXQ1a95fyiDf35f63keQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-arm64-musl@0.124.0':
+    resolution: {integrity: sha512-X5jBDOv7df39YNp9rq3oGo9SAWhtChJYxPnwHzm9FdvbQ6NmASxylipWXnKu6M025Dwpg/1bjiBbG9XuYhXBFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform/binding-linux-ppc64-gnu@0.124.0':
+    resolution: {integrity: sha512-e4oc7gBUPnroe+dhTT+mOtXkXcWkSZZojd4xDpMKAhy6hpKUVBotnudoEPIR7HAOXRmktlgx5ab2zSnYR2kydA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.124.0':
+    resolution: {integrity: sha512-t+WUSyPoq0kobE+AKVHOHQMdijjA8RxhDwYSVgPHAF5c4mPwkD9EtZj1FyBNtRYgRuPQq8dWHGnNZXyFouNJ5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.124.0':
+    resolution: {integrity: sha512-jNApR8gnWbR2zYM+a04jve2xa7qi25zYYb7feTrpV98J+YJaiPVJhzoXHxnKQGKSj7oMt6n6YK1QQVG+LlVpjw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.124.0':
+    resolution: {integrity: sha512-SxLmO/ycauLKadwP9dvRpt8qRKZKaQER1OnvC6eY8hKXiN0EF+pL5QaPIIje7PV8sieRrrOcrSeKFBv+C6t0Ug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-x64-gnu@0.124.0':
+    resolution: {integrity: sha512-TsPm58U1lq3rzhxegdMiy7ej0M3xKIxm+IHfgOg/n8g95fGT9D0E1sswTRBlAQtkXPnVfuqW8Hxf8t/4fCjqzw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-x64-musl@0.124.0':
+    resolution: {integrity: sha512-nRg8/cItmAlKZD+jE5YqwDdvZ0GkvJAMavBshm0awhDn5RURWE5317QwDOvR3bZviRInv62C3eYMZdk0O64zPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform/binding-openharmony-arm64@0.124.0':
+    resolution: {integrity: sha512-NBDXwqbaYvjRy0wslzP/2V4L59r930htq4merS3HHBKI994J36zPZF6732bw6CUfUnXObe0qfOWPMmH+8f3ktw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-transform/binding-wasm32-wasi@0.124.0':
+    resolution: {integrity: sha512-iK+9DYYI/eqEWAMZ40b2ip5OiMv/BSyR0jCc5rLE1PAVUFyFHglxLv8sInZqFnkWpnlvlfTZy71GNDn6fq+xFQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.124.0':
+    resolution: {integrity: sha512-GffpZFW5mBAIxbFoNrGagNqloFU2gAM+wFEuzGsPu2CmcZqsbKzbf5ydU3sUlEt0kxXqW9IYsZhXsa2fnkzMpw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.124.0':
+    resolution: {integrity: sha512-S+GHzB7y62H0tZIMRC5NIuB247xb5DYhnha/KcIBCCmcxl8rg9bJOez5Kyfd2yfda2LjqPdrx6GalZmhj2wJgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-x64-msvc@0.124.0':
+    resolution: {integrity: sha512-zRQMSYNrqUJfbAKOPhFFqo0aiAA850/ZVyrDIGbbbCaF499OwdK6Odt7TRsy97hgEW1w73gKO4KV6Y/HZV42Zg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.69.0':
+    resolution: {integrity: sha512-DKQQbD5cZ/MYfDgDI7YGyGD9FSxABlsBsYFo5p26lloob543tP9+4N3guwdXIYJN+7HSZxLe8YJuwcOWw5qnHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.69.0':
+    resolution: {integrity: sha512-lEhb+I5pr4inux+JFwfCa1HRq3Os7NirEFQ0H1I35SVEHPm6byX0Ah47xmRha3qi6LAkxUcxViL8o/9PivjzBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.69.0':
+    resolution: {integrity: sha512-GY2YE8lOZW59BW1Ia1y+1gR0XyjrZRvVWHAr8LGeGhYHE0OQJ/7cRKXTkx1P+E9/6awEc3SX8a68SFTjh/E//A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.69.0':
+    resolution: {integrity: sha512-ax1oZnOjHX3LB7myQyHEaQkDwfLb6str3/nSP6O7EVUviQGNkEGzGV0EqcBJWK+Ufwx0l4xPgyYayurvhAdl2Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.69.0':
+    resolution: {integrity: sha512-kHWeHv4g2h8NY+mpCxzCtY4uerMJWTN/TSnNj1CPbakFpHEJ6cTya2wWV0pDSYWOJ2+0UiEbhn3AtXxHtsnKjg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.69.0':
+    resolution: {integrity: sha512-gq84vM1a1oEehXo27YCDzGVcxPsZDI1yswZwz2Da1/cbnWtrL16XZZnz0G/+gIU8edtHpfjxq5c+vWEHqJfWoQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.69.0':
+    resolution: {integrity: sha512-kIqEa98JQ0VRyrcncxA417m2AzasqTlD+FyVT1AksjvjkqQcvm7pBWYvoW3/mpyOP2XYvi5nSCCTIe6De1yu5g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.69.0':
+    resolution: {integrity: sha512-j+xYiXozxGWx2cpjCrwwGR4awTxPFsRv3JZrv23RCogEPMc4R7UqjHW47p/RG0aRlbWiROCJ8coUfCwy0dvzHA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.69.0':
+    resolution: {integrity: sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.69.0':
+    resolution: {integrity: sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.69.0':
+    resolution: {integrity: sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.69.0':
+    resolution: {integrity: sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.69.0':
+    resolution: {integrity: sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.69.0':
+    resolution: {integrity: sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.69.0':
+    resolution: {integrity: sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.69.0':
+    resolution: {integrity: sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.69.0':
+    resolution: {integrity: sha512-9RExaLgmaw6IoIkU9cTpT71mLfI0xZ86iZH8x518LVsOkjquJMYqb9P7KpC8lgd1t0Dxs41p2pxynq4XR3Ttzw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.69.0':
+    resolution: {integrity: sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.69.0':
+    resolution: {integrity: sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@parse5/tools@0.3.0':
+    resolution: {integrity: sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@react-types/shared@3.35.0':
+    resolution: {integrity: sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@rehype-pretty/transformers@0.13.2':
+    resolution: {integrity: sha512-p2ciQSwqy5Ip8aNUa9q6rdS/hJZXrxHYYfDVOHvKOsBu3t9HDmQ65YX6r9Qbl19vi160OAxmGF7MIoCRDJrRhg==}
+    engines: {node: '>=18'}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.1.1':
+    resolution: {integrity: sha512-BLf9Wak/gfwVb7NQTQW4wBgL3oAfPy7ArEkhwV543OVw/uY6B47z5xYsqPSZ9PDOorvURPinws6ThaFuNgGLgA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.1.1':
+    resolution: {integrity: sha512-rRZRPy/Ynb+Mxu0O6tfPldHeDgAn0sRij+IOUy6sFdUlv3hArGW/DloE3GfAxtqpOJuRNgF74Nr5gM4xBeU2jQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.1':
+    resolution: {integrity: sha512-/MtefPxhKPyWWFM8L45OWiEqRf+eSU2Qv9ZAyTaoZOoGcoPKxbbhjTJO2/U2IThv0uDZ4NWHc3/oTsR6IEOtww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.1.1':
+    resolution: {integrity: sha512-202K+cpIi1kx/Zn7AtxBi4LTXSY67Aszb2K9rNsuW7FeBeh0nqoNmYLOSZidV0p88VPBzMmTZcHAdPNo3kRYzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
+    resolution: {integrity: sha512-wl9NfeXNUwrXtUc063tddmZFUI6qiNs1CNOwni0OL4vC7MqVSYugra3ZgtDmtVy8e0DluJTENmzIv2BwqLzT4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.1':
+    resolution: {integrity: sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.1':
+    resolution: {integrity: sha512-5PUjZx366h9tkJTPJF5eibxOlK3sGoeRiBJLLjjEB5/kLDuhr6qB3LkhqLz1smXNgsX+pBhnbcJBrPE30HznAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.1':
+    resolution: {integrity: sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.1':
+    resolution: {integrity: sha512-1nS1X5z1uMJ369RU25hTpKCFvUwXZp12dIzlzk4S+UxCTcSVGsAE6tzkOSufv/7jnmAtK0ZlrsJxh2fGmsnVSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.1':
+    resolution: {integrity: sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-x64-musl@1.1.1':
+    resolution: {integrity: sha512-+n46LhDrJFQM+229y4oXtVpj1G50U/+XuHMlpnisFTEXhrg9f/YIjp/HymX+PVJjBEr7XHRs3CFLelV464pqwA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.1.1':
+    resolution: {integrity: sha512-qGwEu47zOWYo7LdRHhCWTNhzwGtxXpdY6CERs8QEOqC0PXGGics/e3vHnyEUKt8xK6YkbZXFUCeklrpB6js8ag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-wasm32-wasi@1.1.1':
+    resolution: {integrity: sha512-qczfgEH8u0wHGGOXtA7UMAybNKuQjjEXairyQaw4WzjiMztfbgatG1h4OKays/smhtwbWltpKCRGtVhU6h40Sg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.1':
+    resolution: {integrity: sha512-4psXSh63mSbwJF+mB8/9yfUUEzBiHYcUjxa32EO9ZwKy0Ypwjcg4F10D8SvVXgd+isy2UUUjF9HJJnDu1T/4Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.1':
+    resolution: {integrity: sha512-MUvC/HLXVjzkQkWiExdVTEEWf0py+GfWm8WKSZsekG3ih6a21iy0BHPF07X3JIf3ifoklZXTIaHTLPBgH1C3dw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.12':
+    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@shikijs/core@1.29.2':
+    resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
+
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
+  '@shikijs/engine-javascript@1.29.2':
+    resolution: {integrity: sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
+
+  '@shikijs/engine-oniguruma@1.29.2':
+    resolution: {integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==}
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@1.29.2':
+    resolution: {integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@1.29.2':
+    resolution: {integrity: sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/types@1.29.2':
+    resolution: {integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@stardazed/streams-compression@1.0.0':
+    resolution: {integrity: sha512-SQCiwxdIVJ5xxUBYptN+fc+tJpSDbxQuJ0+3u2SmHjIzr6JIRZ28AVFtFnGy6x6j3UBlaLx73w9rC6UAFxnd1g==}
+
+  '@stardazed/zlib@1.0.1':
+    resolution: {integrity: sha512-MS6PCYiRNJ32c69+3NPyL+bu7LpiFDvMcBXnlhQnF8CKMG0R/xRVCCo422NPkQ0+Cox3xKpk5Lc1LfWFS4b3cw==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
+  '@tailwindcss/node@4.3.1':
+    resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.1':
+    resolution: {integrity: sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.1':
+    resolution: {integrity: sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.1':
+    resolution: {integrity: sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.1':
+    resolution: {integrity: sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
+    resolution: {integrity: sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
+    resolution: {integrity: sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
+    resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
+    resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
+    resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.1':
+    resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
+    resolution: {integrity: sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
+    resolution: {integrity: sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.1':
+    resolution: {integrity: sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/postcss@4.3.1':
+    resolution: {integrity: sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==}
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@tiptap/core@3.27.1':
+    resolution: {integrity: sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ==}
+    peerDependencies:
+      '@tiptap/pm': 3.27.1
+
+  '@tiptap/extension-blockquote@3.27.1':
+    resolution: {integrity: sha512-VMF7xJx6qEGiX6DTKNiL31NLqypOcd/4sNjFSe8rb41PwejBJh/nOqVIbBvWkiT6NMGFLxMhj7zJ8/zPo1hXeg==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extension-bold@3.27.1':
+    resolution: {integrity: sha512-TlC5bsS+pqETTrlz4CZz9RO/cKBYtELGIxwtKeivUn3eNfnOxQbbu4WDsiwIfzRFyd0OMnKl6BPM2KnYEehoEQ==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extension-bullet-list@3.27.1':
+    resolution: {integrity: sha512-faCUHnRP47o9Zh9VZZX6EX/569udw9Vopm2PgEKPWuKLE2qaS5WBuUVU0iItdJmKUqaWiOZkpoW4jvnDmj0dfg==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.27.1
+
+  '@tiptap/extension-code-block@3.27.1':
+    resolution: {integrity: sha512-pHlzmZx2OlHfyQ0yRlT5UL4mGokz947DthZuYefN1OleVqOkHpWBG+2JQwqoNq6bmzMne92zbH32rhcJUEYSjA==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+      '@tiptap/pm': 3.27.1
+
+  '@tiptap/extension-code@3.27.1':
+    resolution: {integrity: sha512-epOUpFfEmBzjvnqvjv2qHX7NAuLo5dlOGV690lWu+sAYMjibuJBeVvAiKPyFCfRCCTUxdbDB3jbaOA1yEcEJ7w==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extension-document@3.27.1':
+    resolution: {integrity: sha512-8FbBTkfnRP4iVaoj+2h3iWa+H0eGDD3yTyVCwrmue/sQTkqUNUoSuAZa3GDG4Sd41xdPwTJxl9nUWGgM1qDCnw==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extension-dropcursor@3.27.1':
+    resolution: {integrity: sha512-blFf9x9RG0Qr7P3FoAH/033ffa+mMLZn34trVs8Vi0Ppk6FmJAg5HpYFOtmYoeREdNDJ5rHJKV7SoACbOHgskQ==}
+    peerDependencies:
+      '@tiptap/extensions': 3.27.1
+
+  '@tiptap/extension-gapcursor@3.27.1':
+    resolution: {integrity: sha512-QoezN0wdvXIwLQ4ee2ccWDaX3RG0lzgQpIMpMz55oPDhpUVax1+19ApsS53LkcktpS4EbnPL4xO4DaJk0Vp7PQ==}
+    peerDependencies:
+      '@tiptap/extensions': 3.27.1
+
+  '@tiptap/extension-hard-break@3.27.1':
+    resolution: {integrity: sha512-iv/m9hzl6jfSj9Q8UEjAxONvCoUDaP7M9SRCPx3PaLNxA230TTD6RE0Ye4zFJ8ze7ZVoJJMAqg9Qpq1iYg2JOQ==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extension-heading@3.27.1':
+    resolution: {integrity: sha512-SrC4l1kEIyv9ZXFaI/8LQqU2MyMmjczw7XXsWUQOTN4YXv0JyVgMNR3cI/wz0d2xsTfBdZ1N85Tdng+Ga1t0Sg==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extension-horizontal-rule@3.27.1':
+    resolution: {integrity: sha512-QlKE7qn5qMnIGVGhXQlvYedvLtNJ9z0dmit5w8vPb8tKzW4Spk6M7N2kruprrDA8GBwHfeR5wmF+njfUm34qxg==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+      '@tiptap/pm': 3.27.1
+
+  '@tiptap/extension-image@3.26.1':
+    resolution: {integrity: sha512-IjoT+kRK4a1sTImvUz257yfk5l9kMxXxfxCfix5AUKdiWyn8SGUjJZapLICcZVY05UDqXmwsBvBK9lHkKX5ERg==}
+    peerDependencies:
+      '@tiptap/core': 3.26.1
+
+  '@tiptap/extension-italic@3.27.1':
+    resolution: {integrity: sha512-jGGeyn9uRUnNjSTHpbqhiGsp6KaYTSbV09jDXPJI9cDwfV9hpugLvpaCZd0BMBbhU1B1W6kOfX0BE15qX/HQfA==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extension-link@3.27.1':
+    resolution: {integrity: sha512-/2jBfsxBZUDGJmpZifqRQPz7f1E5qpS1BckTZ39TADzUJX+feKy7RJ3DtQ02+8y6SSMzvP9loGVjrk6zEMTk4g==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+      '@tiptap/pm': 3.27.1
+
+  '@tiptap/extension-list-item@3.27.1':
+    resolution: {integrity: sha512-zwRl01ETfCkWUvtvK5fw9bXtAajMPkvlkE3Cq6JvH3LF7XXJwDtNj5Tj7exacMpCaSZmlNc43vFb2rAYnrnwMA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.27.1
+
+  '@tiptap/extension-list-keymap@3.27.1':
+    resolution: {integrity: sha512-OIMZNlzPSO8WRd4ic73Fxckzl4N1tesjjLL2XApaNA/uMpO0LoF6WSRPAWv+Z24Wp92ARRJAnRP7iZoI5+Jxig==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.27.1
+
+  '@tiptap/extension-list@3.27.1':
+    resolution: {integrity: sha512-c2Upru7lj0/ZV/Ibww6cNz6sUS8m6Dp/9uygFhYcZOd3X8M0xBIEk42c6m6SQehkPziVA8QOgNJz7sMqsbz1OQ==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+      '@tiptap/pm': 3.27.1
+
+  '@tiptap/extension-ordered-list@3.27.1':
+    resolution: {integrity: sha512-GYrKqD//9nHJ2r80uXqbDMzRnFpGzbaEQRTSGaO/SH7DvXWFMow8evkOdjQ7PCQO07jNjJo75+A85Jwu3Ov3AA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.27.1
+
+  '@tiptap/extension-paragraph@3.27.1':
+    resolution: {integrity: sha512-7K7eo1gruOgAsnbK+GCV23AUVUI0cL1bTig8HaPneoFMVbig7vddk8jNLKBWO8TXVbG7TuHdnDN4F98vdtwh5Q==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extension-strike@3.27.1':
+    resolution: {integrity: sha512-Y3DW1jlSlCNCyMGHP3+3qBNNPS83wuFz4RTYGjZtvRRTCRh7apZme9XRWMq1rN5mJ2Cr7fKocA2/5Bs13KgN6Q==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extension-text@3.27.1':
+    resolution: {integrity: sha512-6ZwaZwSrDh+KFFv6V1J79oO37yPs7y1bFxvk1/9Ih2rn3Xr5AWz+eMS+n8RpH3djBVVAQpdIAeYQgcn+VCSsTg==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extension-underline@3.27.1':
+    resolution: {integrity: sha512-N889J4nXN/TPfVt8uF9N1A0SY82E90zwc1y26lqOcw6KWNLmQrlhMh/9OD4ikLDbekmFpOBq/UicpHf/6S8hbQ==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extensions@3.27.1':
+    resolution: {integrity: sha512-1Tdx9faw8k0/83V6X+xCDVhV8yElGt95JxeW3YMkKQJI56QdlPz0xOdJPlMiSGJKinPyVier+x9LJD/YZUZIaw==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+      '@tiptap/pm': 3.27.1
+
+  '@tiptap/pm@3.27.1':
+    resolution: {integrity: sha512-Ffjx+vimmBU7zH/KrpXzJid3+pziCe/VL2aexSTP63cyQwKQ65LkFkCKaIsSpFdQQuakVZBGWjCA5RoBV852pw==}
+
+  '@tiptap/starter-kit@3.27.1':
+    resolution: {integrity: sha512-vfxRsqW8rCc0k4pzo0ilU3wobVi2wqVj88VZI2SlgZlNnUAkrDGDIAph7CTa9k9fshV+O1ivpEgPC5yC046jow==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/alpinejs@3.13.11':
+    resolution: {integrity: sha512-3KhGkDixCPiLdL3Z/ok1GxHwLxEWqQOKJccgaQL01wc0EVM2tCTaqlC3NIedmxAXkVzt/V6VTM8qPgnOHKJ1MA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/jscodeshift@17.3.0':
+    resolution: {integrity: sha512-ogvGG8VQQqAQQ096uRh+d6tBHrYuZjsumHirKtvBa5qEyTMN3IQJ7apo+sw9lxaB/iKWIhbbLlF3zmAWk9XQIg==}
+
+  '@types/linkify-it@3.0.5':
+    resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@13.0.9':
+    resolution: {integrity: sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@1.0.5':
+    resolution: {integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/mdx@2.0.14':
+    resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@16.18.126':
+    resolution: {integrity: sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==}
+
+  '@types/node@24.13.2':
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
+
+  '@types/postcss-import@14.0.3':
+    resolution: {integrity: sha512-raZhRVTf6Vw5+QbmQ7LOHSDML71A5rj4+EqDzAbrZPfxfoGzFxMHRCq16VlddGIZpHELw0BG4G0YE2ANkdZiIQ==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@vitest/browser-playwright@4.1.8':
+    resolution: {integrity: sha512-SR7FqgegaexEg73xvf3ArtygXegagMdXnL0EZMpxrWvvhQxvicD/E8p0ib0J91riPRtQUViyh67Xjw3NqvyhVg==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.8
+
+  '@vitest/browser@4.1.8':
+    resolution: {integrity: sha512-u21VzX07HzlJYpFgkxmjEXar/tG2UqWGgyGG/46SrrPc7rSdCTPw5vuowopO9CIqF8UCUQzDFdbVnNpw6N0BfQ==}
+    peerDependencies:
+      vitest: 4.1.8
+
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
+  '@vue/reactivity@3.1.5':
+    resolution: {integrity: sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==}
+
+  '@vue/shared@3.1.5':
+    resolution: {integrity: sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==}
+
+  '@worker-tools/html-rewriter@0.1.0-pre.19':
+    resolution: {integrity: sha512-IUbEZwvSdp8vtaB1LAZ/sBRJGNycd9a8cbkqO05rMEPm5MC59Sb+wiGCWaaRXrwQLDAyWeod4QC/q0TuSUI5EA==}
+
+  '@worker-tools/resolvable-promise@0.2.0-pre.6':
+    resolution: {integrity: sha512-+5RcuruCLB/P3FYYb376RgyImXaq9BBQoOskUbgPyNK3O0AXPakrXUj1EELv+lcnUSdFws/ufdrrWODLJyoTmg==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  alpinejs@3.15.12:
+    resolution: {integrity: sha512-nJvPAQVNPdZZ0NrExJ/kzQco3ijR8LwvCOadQecllESiqT4NyZ/57sN9V2XyvhlBGAbmlKYgeWZvYdKq99ij/Q==}
+
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  arkregex@0.0.5:
+    resolution: {integrity: sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==}
+
+  arktype@2.2.0:
+    resolution: {integrity: sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
+  atomically@2.1.1:
+    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
+  autoprefixer@10.5.0:
+    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  baseline-browser-mapping@2.10.37:
+    resolution: {integrity: sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  better-auth@1.6.18:
+    resolution: {integrity: sha512-6jONqD0gNjE0S6ehhSZhZ7We0rBwjAzbqnQMJQg/zY0387M+agak7VsOAuE78r7Z0Qv7C/KBRKhHSuyJDQ4iLw==}
+    peerDependencies:
+      '@lynx-js/react': '*'
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@sveltejs/kit': ^2.0.0
+      '@tanstack/react-start': ^1.0.0
+      '@tanstack/solid-start': ^1.0.0
+      better-sqlite3: ^12.0.0
+      drizzle-kit: '>=0.31.4'
+      drizzle-orm: ^0.45.2
+      mongodb: ^6.0.0 || ^7.0.0
+      mysql2: ^3.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      pg: ^8.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      '@tanstack/react-start':
+        optional: true
+      '@tanstack/solid-start':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      next:
+        optional: true
+      pg:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vitest:
+        optional: true
+      vue:
+        optional: true
+
+  better-auth@1.6.21:
+    resolution: {integrity: sha512-qAX4pSjjl4pzg22vsunafm32zbIhn5K+blE5rz/xqevt7tahSLwPH73FPGmzEJ1xkX4nNNZ2THijNn675X7xAw==}
+    peerDependencies:
+      '@lynx-js/react': '*'
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@sveltejs/kit': ^2.0.0
+      '@tanstack/react-start': ^1.0.0
+      '@tanstack/solid-start': ^1.0.0
+      better-sqlite3: ^12.0.0
+      drizzle-kit: '>=0.31.4'
+      drizzle-orm: ^0.45.2
+      mongodb: ^6.0.0 || ^7.0.0
+      mysql2: ^3.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      pg: ^8.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      '@tanstack/react-start':
+        optional: true
+      '@tanstack/solid-start':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      next:
+        optional: true
+      pg:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vitest:
+        optional: true
+      vue:
+        optional: true
+
+  better-call@1.3.6:
+    resolution: {integrity: sha512-no1jI+h6Bkxs1NVBo4rONbVIzsPjZ8IUu7IHaJBiFwVX1XEQGN8KpHots5fSWmXe9nNyLuLIcgx6WEUcE6EDaA==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  better-call@1.3.7:
+    resolution: {integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  better-commits@1.24.0:
+    resolution: {integrity: sha512-Vkr/gLvNSLyfRmS4N/9EVc65vImcqNZe42DudlPBXsfNqW8RhYMAzuUjAgupunDpFloYkkoChkKQnQSuotcqkA==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
+
+  bun@1.3.14:
+    resolution: {integrity: sha512-aB6GVd42x1Y5ie1K16SF+oLGtgSkwX9hgoDdIW88pjvfTccU8F1vfpoOt34QLv0dZ1v3XimtaxPlZUG81Gx9Zg==}
+    cpu: [arm64, x64]
+    os: [darwin, linux, android, freebsd, win32]
+    hasBin: true
+
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
+  caniuse-api@3.0.0:
+    resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-truncate@4.0.0:
+    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
+    engines: {node: '>=18'}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
+  clone-deep@4.0.1:
+    resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
+    engines: {node: '>=6'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
+  configstore@8.0.0:
+    resolution: {integrity: sha512-U51WPZg+o6FDFhBCV6yYFEspGMCoHvCgJSGFw9AwsW2u75gYBPoDlYca5XfDs4TdMUu3/y0R6FFdvvgyH31mKQ==}
+    engines: {node: '>=20'}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  css-declaration-sorter@7.4.0:
+    resolution: {integrity: sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==}
+    engines: {node: ^14 || ^16 || >=18}
+    peerDependencies:
+      postcss: ^8.0.9
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-tree@2.2.1:
+    resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  cssnano-preset-default@7.0.17:
+    resolution: {integrity: sha512-11qO63A+czwguQFJCaTdICvbaxn0pJzz/XghLlv+OT7WyToDxAMR0Xb3/26/l0y0hQJywwNbj/SLSQlGBHE1OA==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  cssnano-utils@5.0.3:
+    resolution: {integrity: sha512-ynIREMICLxkxm7e9bCR9sh75s4Q5drICi0ua1yxo5jH2XPBqSKkl4dOh4EbFqtUmnTMhRffHgYL0EKKkMjtJTg==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  cssnano@7.1.9:
+    resolution: {integrity: sha512-uPR75+5Dk/WJ/YSPR1/YDHdwMM9c5FsaARljfKWgeCKLKOtJ0we21xy/RcCjn53fZnD/f6yYEIZ8pu18+GnbNQ==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  csso@5.0.5:
+    resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dot-prop@10.1.0:
+    resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
+    engines: {node: '>=20'}
+
+  drizzle-kit@1.0.0-rc.4-ca0f029:
+    resolution: {integrity: sha512-hM1K72ptIPOpJDScHo7cAF+K8A8Tr3q2yHvBJvOZWvLn2lN+G4RDUvG3rT3ohlSE2O3BN/s7g3e3JiQLStt8iQ==}
+    hasBin: true
+
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
+  electron-to-chromium@1.5.372:
+    resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
+
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  enhanced-resolve@5.21.6:
+    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
+    engines: {node: '>=10.13.0'}
+
+  enhanced-resolve@5.24.0:
+    resolution: {integrity: sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==}
+    engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  esast-util-from-estree@2.0.0:
+    resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
+
+  esast-util-from-js@2.0.1:
+    resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  estree-util-attach-comments@3.0.0:
+    resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
+
+  estree-util-build-jsx@3.0.1:
+    resolution: {integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-scope@1.0.0:
+    resolution: {integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==}
+
+  estree-util-to-js@2.0.0:
+    resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-cache-dir@2.1.0:
+    resolution: {integrity: sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==}
+    engines: {node: '>=6'}
+
+  find-up@3.0.0:
+    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
+    engines: {node: '>=6'}
+
+  flow-parser@0.318.0:
+    resolution: {integrity: sha512-66vPPqpjOcroUke2vbiyRNS87lbTi7ib80CM9lsn45qymGHPL4nrdY9FKo0TvtrFFqHQErfB/BJeqVkEnWeK/g==}
+    engines: {node: '>=0.4.0'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  ghtml@4.0.2:
+    resolution: {integrity: sha512-ymJljsiXUc6hrq2407EnkyCQ8dk5NVEvpAbB4fhnZ+oqP0u9Aq/YWsNkDh+Ew5lBz2uGqyLfzCBdE8J8g4NNgg==}
+    engines: {node: '>=18'}
+
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-to-estree@3.1.3:
+    resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-plain-object@2.0.4:
+    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+
+  is-safe-filename@0.1.1:
+    resolution: {integrity: sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==}
+    engines: {node: '>=20'}
+
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isobject@3.0.1:
+    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
+    engines: {node: '>=0.10.0'}
+
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsbi@4.3.2:
+    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
+
+  jscodeshift@17.3.0:
+    resolution: {integrity: sha512-LjFrGOIORqXBU+jwfC9nbkjmQfFldtMIoS6d9z2LG/lkmyNXsJAySPT+2SWXJEoE68/bCWcxKpXH37npftgmow==}
+    engines: {node: '>=16'}
+    hasBin: true
+    peerDependencies:
+      '@babel/preset-env': ^7.1.6
+    peerDependenciesMeta:
+      '@babel/preset-env':
+        optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+
+  kysely@0.29.2:
+    resolution: {integrity: sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==}
+    engines: {node: '>=22.0.0'}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+
+  linkifyjs@4.3.3:
+    resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
+
+  lint-staged@15.5.2:
+    resolution: {integrity: sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
+  listr2@8.3.3:
+    resolution: {integrity: sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==}
+    engines: {node: '>=18.0.0'}
+
+  lit-element@4.2.2:
+    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
+
+  lit-html@3.3.3:
+    resolution: {integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==}
+
+  lit@3.3.3:
+    resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
+
+  locate-path@3.0.0:
+    resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
+    engines: {node: '>=6'}
+
+  lodash.memoize@4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+
+  lodash.uniq@4.5.0:
+    resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
+
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  make-dir@2.1.0:
+    resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
+    engines: {node: '>=6'}
+
+  markdown-extensions@2.0.0:
+    resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
+    engines: {node: '>=16'}
+
+  markdown-it-task-lists@2.1.1:
+    resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
+
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
+    hasBin: true
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.0.28:
+    resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
+  mitata@1.0.34:
+    resolution: {integrity: sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==}
+
+  morphdom@2.7.8:
+    resolution: {integrity: sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg==}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanostores@1.3.0:
+    resolution: {integrity: sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-releases@2.0.47:
+    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+    engines: {node: '>=18'}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nypm@0.6.7:
+    resolution: {integrity: sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@2.3.0:
+    resolution: {integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
+  oxc-parser@0.124.0:
+    resolution: {integrity: sha512-h07SFj/tp2U3cf3+LFX6MmOguQiM9ahwpGs0ZK5CGhgL8p4kk24etrJKsEzhXAvo7mfvoKTZooZ5MLKAPRmJ1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-transform@0.124.0:
+    resolution: {integrity: sha512-uxVsQFZAaMv4cL3ijc1tx0WczUoBJBbwIFbtTf2QOdRww1s12Ib8dGc5Og63Fh4tmHt9ajYu+9BjxCRSL0b9/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxlint@1.69.0:
+    resolution: {integrity: sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@3.0.0:
+    resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
+    engines: {node: '>=6'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse-numeric-range@1.3.0:
+    resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  path-exists@3.0.0:
+    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
+    engines: {node: '>=4'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pidtree@0.6.1:
+    resolution: {integrity: sha512-e0F9AOF1JMrCfBsyJOwU9lNvQ0WtXTq0j/4jk0BQ5JSI9VAybPXmDpPRw/2FQ3e5d3ZFN1mLh7jW99m/jjaptw==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
+  pify@4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-dir@3.0.0:
+    resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}
+    engines: {node: '>=6'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
+
+  postcss-calc@10.1.1:
+    resolution: {integrity: sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==}
+    engines: {node: ^18.12 || ^20.9 || >=22.0}
+    peerDependencies:
+      postcss: ^8.4.38
+
+  postcss-colormin@7.0.10:
+    resolution: {integrity: sha512-yFr6JezOolHLta/buLE71VKPh2mXursp4saVe98/ol8ZnEWhL+racShqPKlvd/DKWLre/39B6HhcMXf7RZ3hxg==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-convert-values@7.0.12:
+    resolution: {integrity: sha512-xurKu5qqk4viR3Cp3p4xBR4KfnZm4w4ys6+UBwBmeuBSNkH7+DtLnYOYnOffgtE4yx8sH9S1VZ6RAAvROXzP2Q==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-discard-comments@7.0.8:
+    resolution: {integrity: sha512-CvvS5S9WrXblFXCEJ9nVo+4z+eA7zSC7Z88V1HEJuwlQhlFnYTIjg1xJY+BCUiG2bvICap2tXii4mP22BD108Q==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-discard-duplicates@7.0.4:
+    resolution: {integrity: sha512-VBNn1+EuMZkeGVVtz0gRfbNGtx9IFgAsAV+E2pHtXPrp4qfGBkhTIiAuE/wrb+Y6Pakg9NewAlfTpYIFAWODtw==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-discard-empty@7.0.3:
+    resolution: {integrity: sha512-M2pyjQCU+/7cMHVtL6bKTHjv0lZnPLMpicgr67Dlth7AbuV9gjVTtUqaRwn6Pp6BwSDspUzhz8SaUrRykJU5Dw==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-discard-overridden@7.0.3:
+    resolution: {integrity: sha512-aNovXo9UsZuRNLzHJtp13lHIvinDPfiXBPePpXkSjCbgp++iU2FqE+YxvjIsg6EdyPZsASFbfu+JcBFVsErXIQ==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-import@16.1.1:
+    resolution: {integrity: sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss-merge-longhand@7.0.7:
+    resolution: {integrity: sha512-b3mfYUxR388u5Pt0HPcVIUtUDn/k15UfTY9M+ORW+meCR6JLNxoZffiYvXyOYQoRYQNZyX/UFkMCM/mNHxe1qA==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-merge-rules@7.0.11:
+    resolution: {integrity: sha512-SJUPM18g2BmPhf8BVlbwqWz4aK3pLu6u6xjfwEzra7xL6IBR10sUaiB++EzqcVfadPHrKBSMlNdP+XieykhI+Q==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-minify-font-values@7.0.3:
+    resolution: {integrity: sha512-yilG/VOaNI74IylQvAQQxm3/wZVBkXyYUqNUAdxqwtbWUXPsbK1q8Ms0mL83v+f8YicgcyfYCRZtWACUdYajpA==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-minify-gradients@7.0.5:
+    resolution: {integrity: sha512-YraROyQRg3BI1+Hg8E05B/JPdnTm8EDSVu4P2BxdM+CRiOyfmou809+chGIqo6fQqwjPGQ947nbGncSjmTU1WQ==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-minify-params@7.0.9:
+    resolution: {integrity: sha512-R8itbB8BhlpoYyBm1ou0dD+vJnQ3F6adQipR4UnkCHUwlo+S9WXJaDRg1RHjC8YVAtIdrQzSWvJl40HnGDTKjA==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-minify-selectors@7.1.2:
+    resolution: {integrity: sha512-aQtrEWKwqafNlExcKHQvPGsXR2+vlUqqJtf5XsCQcgsSb5PL4wlujWBYDJuWsP4UnQX1YHDHU8qRlD+1PzTQ+Q==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
+  postcss-nested@7.0.2:
+    resolution: {integrity: sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
+  postcss-normalize-charset@7.0.3:
+    resolution: {integrity: sha512-NoBfZu8PR4c2NlmjvrqQTzCzLY79hwcSRgNQ3ZiNK0ABzf9kYKloE/jNj+/8GQY1wsm8pRRgANk6ydLH8cwo0Q==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-normalize-display-values@7.0.3:
+    resolution: {integrity: sha512-ldsCX0QIt05pKIOobZtVQ48wXJecr+czw4+e1/YjVhLMqslShgpVxgPtI2CefURR8oyVoYaU/l829MMwExDMLw==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-normalize-positions@7.0.4:
+    resolution: {integrity: sha512-VEvlpeGd3Ju1Hqa/oN4jaP3+ms4laYwkEL9N9u+B6k54PZjXbW1n6wI+aVprf1BQXlCYpS5+1pl/7/vHiKgARg==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-normalize-repeat-style@7.0.4:
+    resolution: {integrity: sha512-6mPKlY/8cSaDHxX502wERADarJsccwlky6yIrOapHH2ZgfoKAV94SbiTKfKEs4EEpdazuc3J72WsqeYk7hp9+Q==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-normalize-string@7.0.3:
+    resolution: {integrity: sha512-HnEQPUchi1eznmDKEYrKUTqrprEq97SrpUYClgUkv7V2zRODD9DFoUsYU+m9ZOetmD5ku7fEMZB/lwy8IT6xVQ==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-normalize-timing-functions@7.0.3:
+    resolution: {integrity: sha512-zmEzHdvpZBZu0OKlbJSfgASQvaayyAoVuWtvyr34IJ/LyS+DaOKvvR3EvFJ9RWWtNIx+CMvO125OVophaxNYew==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-normalize-unicode@7.0.9:
+    resolution: {integrity: sha512-DRAdWfeh/TjmhLJsw91vdiWCnUod9iwvM7xyS02/nF/sLsCR3A8l3pztrSUrWG8DSBqfX7yEk9FM0USaVJ2mSg==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-normalize-url@7.0.3:
+    resolution: {integrity: sha512-CL93wmloq5qsffmFv+bw24MIRbmhHrp53qoh1LDAb/5TtjWEXI/np4xcP/Gw9oWCb2XyWnqHYLDUwiKRoJBA1Q==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-normalize-whitespace@7.0.3:
+    resolution: {integrity: sha512-FdHjjn+Ht5Z2ZRjNOmeCbNq6lq09sUYKpmlF/Aq0XjVNSLTL6fmHlA/3swN2wP2caY9GV/tjSDcIIyS7aN7W0A==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-ordered-values@7.0.4:
+    resolution: {integrity: sha512-nubSi49hDHQk4E8KIj+IbLY8Bg+8OcSUEhgyolgM+atnOvXjV7EjaR6bac4YGZoFyPa9mWoAF3EaYbWdFkKqVg==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-reduce-initial@7.0.9:
+    resolution: {integrity: sha512-ztTNPdIxXTxtBcG03E9u8v44M4ElXbMIRT7pf2onlquGula0Y83nKKxqM22FA/hMgkfCjN7ohevkVlaNwI8iOQ==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-reduce-transforms@7.0.3:
+    resolution: {integrity: sha512-FXsnN9ZwcZTT8Yf8cAHA8qIGUXcX6WfLd9JoYhrdDfmvsVhhfqkkv7m4AC3rwFOfz+GzkUa87OCKF9dUcicd+g==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-selector-parser@6.1.4:
+    resolution: {integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==}
+    engines: {node: '>=4'}
+
+  postcss-selector-parser@7.1.4:
+    resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
+    engines: {node: '>=4'}
+
+  postcss-simple-vars@7.0.1:
+    resolution: {integrity: sha512-5GLLXaS8qmzHMOjVxqkk1TZPf1jMqesiI7qLhnlyERalG0sMbHIbJqrcnrpmZdKCLglHnRHoEBB61RtGTsj++A==}
+    engines: {node: '>=14.0'}
+    peerDependencies:
+      postcss: ^8.2.1
+
+  postcss-svgo@7.1.3:
+    resolution: {integrity: sha512-2QfoFOYMcj8lwcVEf9WeTlkVIAm7u2QvOEhMzkQU3KUhhGX/l8hVV9EtjMv4iq3E9iI3OeeMN0YoMLbGusuigw==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >= 18}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-unique-selectors@7.0.7:
+    resolution: {integrity: sha512-d+sCkaRnSefghOUdH8CMJZV9yUQhj2ojpe8Nw/lA+LV1UOfeleGkLTl6XdCFFSai9UJ+DJPb69FFuqthXYsY8w==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  prosemirror-changeset@2.4.1:
+    resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-dropcursor@1.8.2:
+    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-markdown@1.13.4:
+    resolution: {integrity: sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==}
+
+  prosemirror-model@1.25.8:
+    resolution: {integrity: sha512-BswA4BLSFEiORV6Vjj/yZBXDbos1zTEnhyeSSgT8psGFhstQS7UJ8/WOLiDos9Byaee27+tml0/DuMNxYR84zg==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
+
+  prosemirror-view@1.41.9:
+    resolution: {integrity: sha512-clTunTX+eaLbr87L1V1QPheRlEQJyTlL3gXe9x3jQIk3rL0RVWxviDGz8tFaydwIVm+hKhYCyr+R/zBtWr9s6A==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-aria-components@1.18.0:
+    resolution: {integrity: sha512-FhRQjuDkH4WhgFv+O2sYTzK3JzdZTGpBeaqfRlfTo+DcSZzD8elJEkytHe7SDpcexVKeire8NVd7OruZHfCVoA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-aria@3.49.0:
+    resolution: {integrity: sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-stately@3.47.0:
+    resolution: {integrity: sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
+
+  recma-build-jsx@1.0.0:
+    resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
+
+  recma-jsx@1.0.1:
+    resolution: {integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  recma-parse@1.0.0:
+    resolution: {integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==}
+
+  recma-stringify@1.0.0:
+    resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
+  regex-recursion@5.1.1:
+    resolution: {integrity: sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@5.1.1:
+    resolution: {integrity: sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  rehype-parse@9.0.1:
+    resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
+
+  rehype-pretty-code@0.14.3:
+    resolution: {integrity: sha512-Cz692FeYusTjT5cfFWLc4r7JhgC3/JlJptgUh4iffBxWxUnWW1oqbWFi7jGCeq00DYUm8yzoTnvpocaYa5x82g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      shiki: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-recma@1.0.0:
+    resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
+  rehype@13.0.2:
+    resolution: {integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rolldown@1.0.0-rc.12:
+    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.1.1:
+    resolution: {integrity: sha512-IN750c0p+s3jqJIsFLRZrQazmbAB1kkQDTtQjSt/gbS2ywLhlv4R5Shazer0FZKmuo/BsO3/w2UoYnUjuOZqHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
+
+  rou3@0.7.12:
+    resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  shallow-clone@3.0.1:
+    resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
+    engines: {node: '>=8'}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  shiki@1.29.2:
+    resolution: {integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==}
+
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  slice-ansi@5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
+
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  stylehacks@7.0.11:
+    resolution: {integrity: sha512-iODNfhXVLqc5LADs+Y6Oh5wJuK5ZcHbVng8aiK3y9pjMQdc5hLrBW0eFU6FtnpNrE6PoEg/MmFTU4waotj5WNg==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  svgo@4.0.1:
+    resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
+  tailwindcss@3.4.19:
+    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  tailwindcss@4.3.1:
+    resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tiptap-markdown@0.9.0:
+    resolution: {integrity: sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.0.1
+
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  type-fest@5.7.0:
+    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
+    engines: {node: '>=20'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  valibot@1.4.1:
+    resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@8.0.4:
+    resolution: {integrity: sha512-baBr4jUVSLJ0RPyZ2nK0zS2+W8hNHbM4hEzfvllukmRPVS3xDG5ATTNtbRXrKIOE2b8/FsPWJAOnuIxcs7g3cw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  write-file-atomic@5.0.1:
+    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xdg-basedir@5.1.0:
+    resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
+    engines: {node: '>=12'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-    '@alloc/quick-lru@5.2.0': {}
-
-    '@ark/schema@0.56.0':
-        dependencies:
-            '@ark/util': 0.56.0
-
-    '@ark/util@0.56.0': {}
-
-    '@babel/code-frame@7.29.7':
-        dependencies:
-            '@babel/helper-validator-identifier': 7.29.7
-            js-tokens: 4.0.0
-            picocolors: 1.1.1
-
-    '@babel/compat-data@7.29.7': {}
-
-    '@babel/core@7.29.7':
-        dependencies:
-            '@babel/code-frame': 7.29.7
-            '@babel/generator': 7.29.7
-            '@babel/helper-compilation-targets': 7.29.7
-            '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
-            '@babel/helpers': 7.29.7
-            '@babel/parser': 7.29.7
-            '@babel/template': 7.29.7
-            '@babel/traverse': 7.29.7
-            '@babel/types': 7.29.7
-            '@jridgewell/remapping': 2.3.5
-            convert-source-map: 2.0.0
-            debug: 4.4.3
-            gensync: 1.0.0-beta.2
-            json5: 2.2.3
-            semver: 6.3.1
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/generator@7.29.7':
-        dependencies:
-            '@babel/parser': 7.29.7
-            '@babel/types': 7.29.7
-            '@jridgewell/gen-mapping': 0.3.13
-            '@jridgewell/trace-mapping': 0.3.31
-            jsesc: 3.1.0
-
-    '@babel/helper-annotate-as-pure@7.29.7':
-        dependencies:
-            '@babel/types': 7.29.7
-
-    '@babel/helper-compilation-targets@7.29.7':
-        dependencies:
-            '@babel/compat-data': 7.29.7
-            '@babel/helper-validator-option': 7.29.7
-            browserslist: 4.28.2
-            lru-cache: 5.1.1
-            semver: 6.3.1
-
-    '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-annotate-as-pure': 7.29.7
-            '@babel/helper-member-expression-to-functions': 7.29.7
-            '@babel/helper-optimise-call-expression': 7.29.7
-            '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
-            '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-            '@babel/traverse': 7.29.7
-            semver: 6.3.1
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/helper-globals@7.29.7': {}
-
-    '@babel/helper-member-expression-to-functions@7.29.7':
-        dependencies:
-            '@babel/traverse': 7.29.7
-            '@babel/types': 7.29.7
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/helper-module-imports@7.29.7':
-        dependencies:
-            '@babel/traverse': 7.29.7
-            '@babel/types': 7.29.7
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-module-imports': 7.29.7
-            '@babel/helper-validator-identifier': 7.29.7
-            '@babel/traverse': 7.29.7
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/helper-optimise-call-expression@7.29.7':
-        dependencies:
-            '@babel/types': 7.29.7
-
-    '@babel/helper-plugin-utils@7.29.7': {}
-
-    '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-member-expression-to-functions': 7.29.7
-            '@babel/helper-optimise-call-expression': 7.29.7
-            '@babel/traverse': 7.29.7
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
-        dependencies:
-            '@babel/traverse': 7.29.7
-            '@babel/types': 7.29.7
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/helper-string-parser@7.29.7': {}
-
-    '@babel/helper-validator-identifier@7.29.7': {}
-
-    '@babel/helper-validator-option@7.29.7': {}
-
-    '@babel/helpers@7.29.7':
-        dependencies:
-            '@babel/template': 7.29.7
-            '@babel/types': 7.29.7
-
-    '@babel/parser@7.29.7':
-        dependencies:
-            '@babel/types': 7.29.7
-
-    '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-plugin-utils': 7.29.7
-
-    '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-plugin-utils': 7.29.7
-
-    '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-plugin-utils': 7.29.7
-
-    '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
-            '@babel/helper-plugin-utils': 7.29.7
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/plugin-transform-flow-strip-types@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-plugin-utils': 7.29.7
-            '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
-
-    '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
-            '@babel/helper-plugin-utils': 7.29.7
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-plugin-utils': 7.29.7
-
-    '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-plugin-utils': 7.29.7
-            '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
-            '@babel/helper-plugin-utils': 7.29.7
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-annotate-as-pure': 7.29.7
-            '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
-            '@babel/helper-plugin-utils': 7.29.7
-            '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-            '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/preset-flow@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-plugin-utils': 7.29.7
-            '@babel/helper-validator-option': 7.29.7
-            '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7)
-
-    '@babel/preset-typescript@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/helper-plugin-utils': 7.29.7
-            '@babel/helper-validator-option': 7.29.7
-            '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-            '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
-            '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/register@7.29.7(@babel/core@7.29.7)':
-        dependencies:
-            '@babel/core': 7.29.7
-            clone-deep: 4.0.1
-            find-cache-dir: 2.1.0
-            make-dir: 2.1.0
-            pirates: 4.0.7
-            source-map-support: 0.5.21
-
-    '@babel/runtime@7.29.7': {}
-
-    '@babel/template@7.29.7':
-        dependencies:
-            '@babel/code-frame': 7.29.7
-            '@babel/parser': 7.29.7
-            '@babel/types': 7.29.7
-
-    '@babel/traverse@7.29.7':
-        dependencies:
-            '@babel/code-frame': 7.29.7
-            '@babel/generator': 7.29.7
-            '@babel/helper-globals': 7.29.7
-            '@babel/parser': 7.29.7
-            '@babel/template': 7.29.7
-            '@babel/types': 7.29.7
-            debug: 4.4.3
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/types@7.29.7':
-        dependencies:
-            '@babel/helper-string-parser': 7.29.7
-            '@babel/helper-validator-identifier': 7.29.7
-
-    '@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
-        dependencies:
-            '@better-auth/utils': 0.4.1
-            '@better-fetch/fetch': 1.3.0
-            '@opentelemetry/semantic-conventions': 1.41.1
-            '@standard-schema/spec': 1.1.0
-            better-call: 1.3.6(zod@4.4.3)
-            jose: 6.2.3
-            kysely: 0.29.2
-            nanostores: 1.3.0
-            zod: 4.4.3
-
-    '@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
-        dependencies:
-            '@better-auth/utils': 0.4.2
-            '@better-fetch/fetch': 1.3.1
-            '@opentelemetry/semantic-conventions': 1.41.1
-            '@standard-schema/spec': 1.1.0
-            better-call: 1.3.6(zod@4.4.3)
-            jose: 6.2.3
-            kysely: 0.29.2
-            nanostores: 1.3.0
-            zod: 4.4.3
-
-    '@better-auth/drizzle-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))':
-        dependencies:
-            '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/utils': 0.4.1
-        optionalDependencies:
-            drizzle-orm: 0.45.2(bun-types@1.3.14)(kysely@0.29.2)
-
-    '@better-auth/drizzle-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))':
-        dependencies:
-            '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/utils': 0.4.2
-        optionalDependencies:
-            drizzle-orm: 0.45.2(bun-types@1.3.14)(kysely@0.29.2)
-
-    '@better-auth/kysely-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.29.2)':
-        dependencies:
-            '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/utils': 0.4.1
-        optionalDependencies:
-            kysely: 0.29.2
-
-    '@better-auth/kysely-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
-        dependencies:
-            '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/utils': 0.4.2
-        optionalDependencies:
-            kysely: 0.29.2
-
-    '@better-auth/memory-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)':
-        dependencies:
-            '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/utils': 0.4.1
-
-    '@better-auth/memory-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
-        dependencies:
-            '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/utils': 0.4.2
-
-    '@better-auth/mongo-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)':
-        dependencies:
-            '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/utils': 0.4.1
-
-    '@better-auth/mongo-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
-        dependencies:
-            '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/utils': 0.4.2
-
-    '@better-auth/prisma-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)':
-        dependencies:
-            '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/utils': 0.4.1
-
-    '@better-auth/prisma-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
-        dependencies:
-            '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/utils': 0.4.2
-
-    '@better-auth/telemetry@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)':
-        dependencies:
-            '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/utils': 0.4.1
-            '@better-fetch/fetch': 1.3.0
-
-    '@better-auth/telemetry@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
-        dependencies:
-            '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/utils': 0.4.2
-            '@better-fetch/fetch': 1.3.1
-
-    '@better-auth/utils@0.4.1':
-        dependencies:
-            '@noble/hashes': 2.2.0
-
-    '@better-auth/utils@0.4.2':
-        dependencies:
-            '@noble/hashes': 2.2.0
-
-    '@better-fetch/fetch@1.3.0': {}
-
-    '@better-fetch/fetch@1.3.1': {}
-
-    '@blazediff/core@1.9.1': {}
-
-    '@bomb.sh/args@0.3.1': {}
-
-    '@clack/core@1.4.1':
-        dependencies:
-            fast-wrap-ansi: 0.2.2
-            sisteransi: 1.0.5
-
-    '@clack/prompts@1.5.1':
-        dependencies:
-            '@clack/core': 1.4.1
-            fast-string-width: 3.0.2
-            fast-wrap-ansi: 0.2.2
-            sisteransi: 1.0.5
-
-    '@colordx/core@5.4.3': {}
-
-    '@drizzle-team/brocli@0.11.0': {}
-
-    '@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3)':
-        dependencies:
-            typescript: 5.9.3
-
-    '@ecopages/logger@0.2.3(typescript@5.9.3)':
-        dependencies:
-            typescript: 5.9.3
-
-    '@ecopages/radiant@0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))':
-        dependencies:
-            '@ecopages/jsx': 0.3.0-alpha.25(typescript@5.9.3)
-            '@ecopages/signals': 0.3.0-alpha.25(typescript@5.9.3)
-
-    '@ecopages/scripts-injector@0.1.5(typescript@5.9.3)':
-        dependencies:
-            typescript: 5.9.3
-
-    '@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3)':
-        dependencies:
-            typescript: 5.9.3
-
-    '@emnapi/core@1.10.0':
-        dependencies:
-            '@emnapi/wasi-threads': 1.2.1
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/core@1.11.0':
-        dependencies:
-            '@emnapi/wasi-threads': 1.2.2
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/runtime@1.10.0':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/runtime@1.11.0':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/runtime@1.11.1':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/wasi-threads@1.2.1':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/wasi-threads@1.2.2':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    '@esbuild/aix-ppc64@0.25.12':
-        optional: true
-
-    '@esbuild/aix-ppc64@0.28.1':
-        optional: true
-
-    '@esbuild/android-arm64@0.25.12':
-        optional: true
-
-    '@esbuild/android-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/android-arm@0.25.12':
-        optional: true
-
-    '@esbuild/android-arm@0.28.1':
-        optional: true
-
-    '@esbuild/android-x64@0.25.12':
-        optional: true
-
-    '@esbuild/android-x64@0.28.1':
-        optional: true
-
-    '@esbuild/darwin-arm64@0.25.12':
-        optional: true
-
-    '@esbuild/darwin-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/darwin-x64@0.25.12':
-        optional: true
-
-    '@esbuild/darwin-x64@0.28.1':
-        optional: true
-
-    '@esbuild/freebsd-arm64@0.25.12':
-        optional: true
-
-    '@esbuild/freebsd-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/freebsd-x64@0.25.12':
-        optional: true
-
-    '@esbuild/freebsd-x64@0.28.1':
-        optional: true
-
-    '@esbuild/linux-arm64@0.25.12':
-        optional: true
-
-    '@esbuild/linux-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/linux-arm@0.25.12':
-        optional: true
-
-    '@esbuild/linux-arm@0.28.1':
-        optional: true
-
-    '@esbuild/linux-ia32@0.25.12':
-        optional: true
-
-    '@esbuild/linux-ia32@0.28.1':
-        optional: true
-
-    '@esbuild/linux-loong64@0.25.12':
-        optional: true
-
-    '@esbuild/linux-loong64@0.28.1':
-        optional: true
-
-    '@esbuild/linux-mips64el@0.25.12':
-        optional: true
-
-    '@esbuild/linux-mips64el@0.28.1':
-        optional: true
-
-    '@esbuild/linux-ppc64@0.25.12':
-        optional: true
-
-    '@esbuild/linux-ppc64@0.28.1':
-        optional: true
-
-    '@esbuild/linux-riscv64@0.25.12':
-        optional: true
-
-    '@esbuild/linux-riscv64@0.28.1':
-        optional: true
-
-    '@esbuild/linux-s390x@0.25.12':
-        optional: true
-
-    '@esbuild/linux-s390x@0.28.1':
-        optional: true
-
-    '@esbuild/linux-x64@0.25.12':
-        optional: true
-
-    '@esbuild/linux-x64@0.28.1':
-        optional: true
-
-    '@esbuild/netbsd-arm64@0.25.12':
-        optional: true
-
-    '@esbuild/netbsd-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/netbsd-x64@0.25.12':
-        optional: true
-
-    '@esbuild/netbsd-x64@0.28.1':
-        optional: true
-
-    '@esbuild/openbsd-arm64@0.25.12':
-        optional: true
-
-    '@esbuild/openbsd-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/openbsd-x64@0.25.12':
-        optional: true
-
-    '@esbuild/openbsd-x64@0.28.1':
-        optional: true
-
-    '@esbuild/openharmony-arm64@0.25.12':
-        optional: true
-
-    '@esbuild/openharmony-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/sunos-x64@0.25.12':
-        optional: true
-
-    '@esbuild/sunos-x64@0.28.1':
-        optional: true
-
-    '@esbuild/win32-arm64@0.25.12':
-        optional: true
-
-    '@esbuild/win32-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/win32-ia32@0.25.12':
-        optional: true
-
-    '@esbuild/win32-ia32@0.28.1':
-        optional: true
-
-    '@esbuild/win32-x64@0.25.12':
-        optional: true
-
-    '@esbuild/win32-x64@0.28.1':
-        optional: true
-
-    '@faker-js/faker@10.4.0': {}
-
-    '@faker-js/faker@9.7.0': {}
-
-    '@fontsource-variable/jetbrains-mono@5.2.8': {}
-
-    '@img/colour@1.1.0': {}
-
-    '@img/sharp-darwin-arm64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-darwin-arm64': 1.2.4
-        optional: true
-
-    '@img/sharp-darwin-x64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-darwin-x64': 1.2.4
-        optional: true
-
-    '@img/sharp-libvips-darwin-arm64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-darwin-x64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linux-arm64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linux-arm@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linux-ppc64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linux-riscv64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linux-s390x@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linux-x64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-        optional: true
-
-    '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-        optional: true
-
-    '@img/sharp-linux-arm64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linux-arm64': 1.2.4
-        optional: true
-
-    '@img/sharp-linux-arm@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linux-arm': 1.2.4
-        optional: true
-
-    '@img/sharp-linux-ppc64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linux-ppc64': 1.2.4
-        optional: true
-
-    '@img/sharp-linux-riscv64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linux-riscv64': 1.2.4
-        optional: true
-
-    '@img/sharp-linux-s390x@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linux-s390x': 1.2.4
-        optional: true
-
-    '@img/sharp-linux-x64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linux-x64': 1.2.4
-        optional: true
-
-    '@img/sharp-linuxmusl-arm64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-        optional: true
-
-    '@img/sharp-linuxmusl-x64@0.34.5':
-        optionalDependencies:
-            '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-        optional: true
-
-    '@img/sharp-wasm32@0.34.5':
-        dependencies:
-            '@emnapi/runtime': 1.11.1
-        optional: true
-
-    '@img/sharp-win32-arm64@0.34.5':
-        optional: true
-
-    '@img/sharp-win32-ia32@0.34.5':
-        optional: true
-
-    '@img/sharp-win32-x64@0.34.5':
-        optional: true
-
-    '@internationalized/date@3.12.2':
-        dependencies:
-            '@swc/helpers': 0.5.23
-
-    '@internationalized/number@3.6.7':
-        dependencies:
-            '@swc/helpers': 0.5.23
-
-    '@internationalized/string@3.2.9':
-        dependencies:
-            '@swc/helpers': 0.5.23
-
-    '@jridgewell/gen-mapping@0.3.13':
-        dependencies:
-            '@jridgewell/sourcemap-codec': 1.5.5
-            '@jridgewell/trace-mapping': 0.3.31
-
-    '@jridgewell/remapping@2.3.5':
-        dependencies:
-            '@jridgewell/gen-mapping': 0.3.13
-            '@jridgewell/trace-mapping': 0.3.31
-
-    '@jridgewell/resolve-uri@3.1.2': {}
-
-    '@jridgewell/sourcemap-codec@1.5.5': {}
-
-    '@jridgewell/trace-mapping@0.3.31':
-        dependencies:
-            '@jridgewell/resolve-uri': 3.1.2
-            '@jridgewell/sourcemap-codec': 1.5.5
-
-    '@js-temporal/polyfill@0.5.1':
-        dependencies:
-            jsbi: 4.3.2
-
-    '@kitajs/html@4.2.13':
-        dependencies:
-            csstype: 3.2.3
-
-    '@kitajs/ts-html-plugin@4.1.4(@kitajs/html@4.2.13)(typescript@5.9.3)':
-        dependencies:
-            '@kitajs/html': 4.2.13
-            chalk: 5.6.2
-            tslib: 2.8.1
-            typescript: 5.9.3
-            yargs: 18.0.0
-
-    '@lit-labs/ssr-client@1.1.8':
-        dependencies:
-            '@lit/reactive-element': 2.1.2
-            lit: 3.3.3
-            lit-html: 3.3.3
-
-    '@lit-labs/ssr-dom-shim@1.6.0': {}
-
-    '@lit-labs/ssr@3.3.1':
-        dependencies:
-            '@lit-labs/ssr-client': 1.1.8
-            '@lit-labs/ssr-dom-shim': 1.6.0
-            '@lit/reactive-element': 2.1.2
-            '@parse5/tools': 0.3.0
-            '@types/node': 16.18.126
-            enhanced-resolve: 5.24.0
-            lit: 3.3.3
-            lit-element: 4.2.2
-            lit-html: 3.3.3
-            node-fetch: 3.3.2
-            parse5: 7.3.0
-
-    '@lit/reactive-element@2.1.2':
-        dependencies:
-            '@lit-labs/ssr-dom-shim': 1.6.0
-
-    '@mdx-js/mdx@3.1.1':
-        dependencies:
-            '@types/estree': 1.0.9
-            '@types/estree-jsx': 1.0.5
-            '@types/hast': 3.0.4
-            '@types/mdx': 2.0.14
-            acorn: 8.17.0
-            collapse-white-space: 2.1.0
-            devlop: 1.1.0
-            estree-util-is-identifier-name: 3.0.0
-            estree-util-scope: 1.0.0
-            estree-walker: 3.0.3
-            hast-util-to-jsx-runtime: 2.3.6
-            markdown-extensions: 2.0.0
-            recma-build-jsx: 1.0.0
-            recma-jsx: 1.0.1(acorn@8.17.0)
-            recma-stringify: 1.0.0
-            rehype-recma: 1.0.0
-            remark-mdx: 3.1.1
-            remark-parse: 11.0.0
-            remark-rehype: 11.1.2
-            source-map: 0.7.6
-            unified: 11.0.5
-            unist-util-position-from-estree: 2.0.0
-            unist-util-stringify-position: 4.0.0
-            unist-util-visit: 5.1.0
-            vfile: 6.0.3
-        transitivePeerDependencies:
-            - supports-color
-
-    '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-        dependencies:
-            '@emnapi/core': 1.10.0
-            '@emnapi/runtime': 1.10.0
-            '@tybys/wasm-util': 0.10.2
-        optional: true
-
-    '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
-        dependencies:
-            '@emnapi/core': 1.11.0
-            '@emnapi/runtime': 1.11.0
-            '@tybys/wasm-util': 0.10.2
-        optional: true
-
-    '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)':
-        dependencies:
-            '@emnapi/core': 1.11.0
-            '@emnapi/runtime': 1.11.1
-            '@tybys/wasm-util': 0.10.2
-        optional: true
-
-    '@noble/ciphers@2.2.0': {}
-
-    '@noble/hashes@2.2.0': {}
-
-    '@nodelib/fs.scandir@2.1.5':
-        dependencies:
-            '@nodelib/fs.stat': 2.0.5
-            run-parallel: 1.2.0
-
-    '@nodelib/fs.stat@2.0.5': {}
-
-    '@nodelib/fs.walk@1.2.8':
-        dependencies:
-            '@nodelib/fs.scandir': 2.1.5
-            fastq: 1.20.1
-
-    '@opentelemetry/semantic-conventions@1.41.1': {}
-
-    '@oven/bun-darwin-aarch64@1.3.14':
-        optional: true
-
-    '@oven/bun-darwin-x64-baseline@1.3.14':
-        optional: true
-
-    '@oven/bun-darwin-x64@1.3.14':
-        optional: true
-
-    '@oven/bun-freebsd-aarch64@1.3.14':
-        optional: true
-
-    '@oven/bun-freebsd-x64@1.3.14':
-        optional: true
-
-    '@oven/bun-linux-aarch64-android@1.3.14':
-        optional: true
-
-    '@oven/bun-linux-aarch64-musl@1.3.14':
-        optional: true
-
-    '@oven/bun-linux-aarch64@1.3.14':
-        optional: true
-
-    '@oven/bun-linux-x64-android@1.3.14':
-        optional: true
-
-    '@oven/bun-linux-x64-baseline@1.3.14':
-        optional: true
-
-    '@oven/bun-linux-x64-musl-baseline@1.3.14':
-        optional: true
-
-    '@oven/bun-linux-x64-musl@1.3.14':
-        optional: true
-
-    '@oven/bun-linux-x64@1.3.14':
-        optional: true
-
-    '@oven/bun-windows-aarch64@1.3.14':
-        optional: true
-
-    '@oven/bun-windows-x64-baseline@1.3.14':
-        optional: true
-
-    '@oven/bun-windows-x64@1.3.14':
-        optional: true
-
-    '@oxc-parser/binding-android-arm-eabi@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-android-arm64@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-darwin-arm64@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-darwin-x64@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-freebsd-x64@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-arm-gnueabihf@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-arm-musleabihf@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-arm64-gnu@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-arm64-musl@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-ppc64-gnu@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-riscv64-gnu@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-riscv64-musl@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-s390x-gnu@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-x64-gnu@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-x64-musl@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-openharmony-arm64@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-wasm32-wasi@0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)':
-        dependencies:
-            '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
-        transitivePeerDependencies:
-            - '@emnapi/core'
-            - '@emnapi/runtime'
-        optional: true
-
-    '@oxc-parser/binding-win32-arm64-msvc@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-win32-ia32-msvc@0.124.0':
-        optional: true
-
-    '@oxc-parser/binding-win32-x64-msvc@0.124.0':
-        optional: true
-
-    '@oxc-project/runtime@0.134.0': {}
-
-    '@oxc-project/types@0.122.0': {}
-
-    '@oxc-project/types@0.124.0': {}
-
-    '@oxc-project/types@0.133.0': {}
-
-    '@oxc-project/types@0.135.0': {}
-
-    '@oxc-transform/binding-android-arm-eabi@0.124.0':
-        optional: true
-
-    '@oxc-transform/binding-android-arm64@0.124.0':
-        optional: true
-
-    '@oxc-transform/binding-darwin-arm64@0.124.0':
-        optional: true
-
-    '@oxc-transform/binding-darwin-x64@0.124.0':
-        optional: true
-
-    '@oxc-transform/binding-freebsd-x64@0.124.0':
-        optional: true
-
-    '@oxc-transform/binding-linux-arm-gnueabihf@0.124.0':
-        optional: true
-
-    '@oxc-transform/binding-linux-arm-musleabihf@0.124.0':
-        optional: true
-
-    '@oxc-transform/binding-linux-arm64-gnu@0.124.0':
-        optional: true
-
-    '@oxc-transform/binding-linux-arm64-musl@0.124.0':
-        optional: true
-
-    '@oxc-transform/binding-linux-ppc64-gnu@0.124.0':
-        optional: true
-
-    '@oxc-transform/binding-linux-riscv64-gnu@0.124.0':
-        optional: true
 
-    '@oxc-transform/binding-linux-riscv64-musl@0.124.0':
-        optional: true
-
-    '@oxc-transform/binding-linux-s390x-gnu@0.124.0':
-        optional: true
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@ark/schema@0.56.0':
+    dependencies:
+      '@ark/util': 0.56.0
+
+  '@ark/util@0.56.0': {}
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-flow-strip-types@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
+
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-flow@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7)
+
+  '@babel/preset-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/register@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      clone-deep: 4.0.1
+      find-cache-dir: 2.1.0
+      make-dir: 2.1.0
+      pirates: 4.0.7
+      source-map-support: 0.5.21
+
+  '@babel/runtime@7.29.7': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
+    dependencies:
+      '@better-auth/utils': 0.4.1
+      '@better-fetch/fetch': 1.3.0
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.6(zod@4.4.3)
+      jose: 6.2.3
+      kysely: 0.29.2
+      nanostores: 1.3.0
+      zod: 4.4.3
+
+  '@better-auth/core@1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.7(zod@4.4.3)
+      jose: 6.2.3
+      kysely: 0.29.2
+      nanostores: 1.3.0
+      zod: 4.4.3
+
+  '@better-auth/drizzle-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))':
+    dependencies:
+      '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.1
+    optionalDependencies:
+      drizzle-orm: 0.45.2(bun-types@1.3.14)(kysely@0.29.2)
+
+  '@better-auth/drizzle-adapter@1.6.21(@better-auth/core@1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))':
+    dependencies:
+      '@better-auth/core': 1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      drizzle-orm: 0.45.2(bun-types@1.3.14)(kysely@0.29.2)
+
+  '@better-auth/kysely-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.29.2)':
+    dependencies:
+      '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.1
+    optionalDependencies:
+      kysely: 0.29.2
+
+  '@better-auth/kysely-adapter@1.6.21(@better-auth/core@1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
+    dependencies:
+      '@better-auth/core': 1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      kysely: 0.29.2
+
+  '@better-auth/memory-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)':
+    dependencies:
+      '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.1
+
+  '@better-auth/memory-adapter@1.6.21(@better-auth/core@1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)':
+    dependencies:
+      '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.1
+
+  '@better-auth/mongo-adapter@1.6.21(@better-auth/core@1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/prisma-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)':
+    dependencies:
+      '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.1
+
+  '@better-auth/prisma-adapter@1.6.21(@better-auth/core@1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/telemetry@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)':
+    dependencies:
+      '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.1
+      '@better-fetch/fetch': 1.3.0
+
+  '@better-auth/telemetry@1.6.21(@better-auth/core@1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+    dependencies:
+      '@better-auth/core': 1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.1':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@better-auth/utils@0.4.2':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@better-fetch/fetch@1.3.0': {}
+
+  '@better-fetch/fetch@1.3.1': {}
+
+  '@blazediff/core@1.9.1': {}
+
+  '@bomb.sh/args@0.3.1': {}
+
+  '@clack/core@1.4.1':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.5.1':
+    dependencies:
+      '@clack/core': 1.4.1
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@colordx/core@5.4.3': {}
+
+  '@drizzle-team/brocli@0.11.0': {}
+
+  '@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@ecopages/logger@0.2.3(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@ecopages/radiant@0.3.0-alpha.25(@ecopages/jsx@0.3.0-alpha.25(typescript@5.9.3))(@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3))':
+    dependencies:
+      '@ecopages/jsx': 0.3.0-alpha.25(typescript@5.9.3)
+      '@ecopages/signals': 0.3.0-alpha.25(typescript@5.9.3)
+
+  '@ecopages/scripts-injector@0.1.5(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@ecopages/signals@0.3.0-alpha.25(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/core@1.11.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@faker-js/faker@10.4.0': {}
+
+  '@faker-js/faker@9.7.0': {}
+
+  '@fontsource-variable/jetbrains-mono@5.2.8': {}
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@internationalized/date@3.12.2':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/number@3.6.7':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/string@3.2.9':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-temporal/polyfill@0.5.1':
+    dependencies:
+      jsbi: 4.3.2
+
+  '@kitajs/html@4.2.13':
+    dependencies:
+      csstype: 3.2.3
+
+  '@kitajs/ts-html-plugin@4.1.4(@kitajs/html@4.2.13)(typescript@5.9.3)':
+    dependencies:
+      '@kitajs/html': 4.2.13
+      chalk: 5.6.2
+      tslib: 2.8.1
+      typescript: 5.9.3
+      yargs: 18.0.0
+
+  '@lit-labs/ssr-client@1.1.8':
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit: 3.3.3
+      lit-html: 3.3.3
+
+  '@lit-labs/ssr-dom-shim@1.6.0': {}
+
+  '@lit-labs/ssr@3.3.1':
+    dependencies:
+      '@lit-labs/ssr-client': 1.1.8
+      '@lit-labs/ssr-dom-shim': 1.6.0
+      '@lit/reactive-element': 2.1.2
+      '@parse5/tools': 0.3.0
+      '@types/node': 16.18.126
+      enhanced-resolve: 5.24.0
+      lit: 3.3.3
+      lit-element: 4.2.2
+      lit-html: 3.3.3
+      node-fetch: 3.3.2
+      parse5: 7.3.0
+
+  '@lit/reactive-element@2.1.2':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
+
+  '@mdx-js/mdx@3.1.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdx': 2.0.14
+      acorn: 8.17.0
+      collapse-white-space: 2.1.0
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-util-scope: 1.0.0
+      estree-walker: 3.0.3
+      hast-util-to-jsx-runtime: 2.3.6
+      markdown-extensions: 2.0.0
+      recma-build-jsx: 1.0.0
+      recma-jsx: 1.0.1(acorn@8.17.0)
+      recma-stringify: 1.0.0
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      source-map: 0.7.6
+      unified: 11.0.5
+      unist-util-position-from-estree: 2.0.0
+      unist-util-stringify-position: 4.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
+    dependencies:
+      '@emnapi/core': 1.11.0
+      '@emnapi/runtime': 1.11.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.0
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@noble/ciphers@2.2.0': {}
+
+  '@noble/hashes@2.2.0': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
+  '@oven/bun-darwin-aarch64@1.3.14':
+    optional: true
+
+  '@oven/bun-darwin-x64-baseline@1.3.14':
+    optional: true
+
+  '@oven/bun-darwin-x64@1.3.14':
+    optional: true
+
+  '@oven/bun-freebsd-aarch64@1.3.14':
+    optional: true
+
+  '@oven/bun-freebsd-x64@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-aarch64-android@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-aarch64-musl@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-aarch64@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-x64-android@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-x64-baseline@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-x64-musl-baseline@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-x64-musl@1.3.14':
+    optional: true
+
+  '@oven/bun-linux-x64@1.3.14':
+    optional: true
+
+  '@oven/bun-windows-aarch64@1.3.14':
+    optional: true
+
+  '@oven/bun-windows-x64-baseline@1.3.14':
+    optional: true
+
+  '@oven/bun-windows-x64@1.3.14':
+    optional: true
+
+  '@oxc-parser/binding-android-arm-eabi@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.124.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.124.0':
+    optional: true
+
+  '@oxc-project/runtime@0.134.0': {}
+
+  '@oxc-project/types@0.122.0': {}
+
+  '@oxc-project/types@0.124.0': {}
+
+  '@oxc-project/types@0.133.0': {}
+
+  '@oxc-project/types@0.135.0': {}
+
+  '@oxc-transform/binding-android-arm-eabi@0.124.0':
+    optional: true
+
+  '@oxc-transform/binding-android-arm64@0.124.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-arm64@0.124.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-x64@0.124.0':
+    optional: true
+
+  '@oxc-transform/binding-freebsd-x64@0.124.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.124.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.124.0':
+    optional: true
 
-    '@oxc-transform/binding-linux-x64-gnu@0.124.0':
-        optional: true
+  '@oxc-transform/binding-linux-arm64-gnu@0.124.0':
+    optional: true
 
-    '@oxc-transform/binding-linux-x64-musl@0.124.0':
-        optional: true
+  '@oxc-transform/binding-linux-arm64-musl@0.124.0':
+    optional: true
 
-    '@oxc-transform/binding-openharmony-arm64@0.124.0':
-        optional: true
+  '@oxc-transform/binding-linux-ppc64-gnu@0.124.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.124.0':
+    optional: true
 
-    '@oxc-transform/binding-wasm32-wasi@0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)':
-        dependencies:
-            '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
-        transitivePeerDependencies:
-            - '@emnapi/core'
-            - '@emnapi/runtime'
-        optional: true
+  '@oxc-transform/binding-linux-riscv64-musl@0.124.0':
+    optional: true
 
-    '@oxc-transform/binding-win32-arm64-msvc@0.124.0':
-        optional: true
+  '@oxc-transform/binding-linux-s390x-gnu@0.124.0':
+    optional: true
 
-    '@oxc-transform/binding-win32-ia32-msvc@0.124.0':
-        optional: true
+  '@oxc-transform/binding-linux-x64-gnu@0.124.0':
+    optional: true
 
-    '@oxc-transform/binding-win32-x64-msvc@0.124.0':
-        optional: true
+  '@oxc-transform/binding-linux-x64-musl@0.124.0':
+    optional: true
 
-    '@oxlint/binding-android-arm-eabi@1.69.0':
-        optional: true
+  '@oxc-transform/binding-openharmony-arm64@0.124.0':
+    optional: true
 
-    '@oxlint/binding-android-arm64@1.69.0':
-        optional: true
+  '@oxc-transform/binding-wasm32-wasi@0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
 
-    '@oxlint/binding-darwin-arm64@1.69.0':
-        optional: true
+  '@oxc-transform/binding-win32-arm64-msvc@0.124.0':
+    optional: true
 
-    '@oxlint/binding-darwin-x64@1.69.0':
-        optional: true
+  '@oxc-transform/binding-win32-ia32-msvc@0.124.0':
+    optional: true
 
-    '@oxlint/binding-freebsd-x64@1.69.0':
-        optional: true
+  '@oxc-transform/binding-win32-x64-msvc@0.124.0':
+    optional: true
 
-    '@oxlint/binding-linux-arm-gnueabihf@1.69.0':
-        optional: true
+  '@oxlint/binding-android-arm-eabi@1.69.0':
+    optional: true
 
-    '@oxlint/binding-linux-arm-musleabihf@1.69.0':
-        optional: true
+  '@oxlint/binding-android-arm64@1.69.0':
+    optional: true
 
-    '@oxlint/binding-linux-arm64-gnu@1.69.0':
-        optional: true
+  '@oxlint/binding-darwin-arm64@1.69.0':
+    optional: true
 
-    '@oxlint/binding-linux-arm64-musl@1.69.0':
-        optional: true
+  '@oxlint/binding-darwin-x64@1.69.0':
+    optional: true
 
-    '@oxlint/binding-linux-ppc64-gnu@1.69.0':
-        optional: true
+  '@oxlint/binding-freebsd-x64@1.69.0':
+    optional: true
 
-    '@oxlint/binding-linux-riscv64-gnu@1.69.0':
-        optional: true
+  '@oxlint/binding-linux-arm-gnueabihf@1.69.0':
+    optional: true
 
-    '@oxlint/binding-linux-riscv64-musl@1.69.0':
-        optional: true
+  '@oxlint/binding-linux-arm-musleabihf@1.69.0':
+    optional: true
 
-    '@oxlint/binding-linux-s390x-gnu@1.69.0':
-        optional: true
+  '@oxlint/binding-linux-arm64-gnu@1.69.0':
+    optional: true
 
-    '@oxlint/binding-linux-x64-gnu@1.69.0':
-        optional: true
+  '@oxlint/binding-linux-arm64-musl@1.69.0':
+    optional: true
 
-    '@oxlint/binding-linux-x64-musl@1.69.0':
-        optional: true
+  '@oxlint/binding-linux-ppc64-gnu@1.69.0':
+    optional: true
 
-    '@oxlint/binding-openharmony-arm64@1.69.0':
-        optional: true
+  '@oxlint/binding-linux-riscv64-gnu@1.69.0':
+    optional: true
 
-    '@oxlint/binding-win32-arm64-msvc@1.69.0':
-        optional: true
+  '@oxlint/binding-linux-riscv64-musl@1.69.0':
+    optional: true
 
-    '@oxlint/binding-win32-ia32-msvc@1.69.0':
-        optional: true
+  '@oxlint/binding-linux-s390x-gnu@1.69.0':
+    optional: true
 
-    '@oxlint/binding-win32-x64-msvc@1.69.0':
-        optional: true
+  '@oxlint/binding-linux-x64-gnu@1.69.0':
+    optional: true
 
-    '@parse5/tools@0.3.0':
-        dependencies:
-            parse5: 7.3.0
+  '@oxlint/binding-linux-x64-musl@1.69.0':
+    optional: true
 
-    '@playwright/test@1.60.0':
-        dependencies:
-            playwright: 1.60.0
+  '@oxlint/binding-openharmony-arm64@1.69.0':
+    optional: true
 
-    '@polka/url@1.0.0-next.29': {}
+  '@oxlint/binding-win32-arm64-msvc@1.69.0':
+    optional: true
 
-    '@react-types/shared@3.35.0(react@19.2.7)':
-        dependencies:
-            react: 19.2.7
+  '@oxlint/binding-win32-ia32-msvc@1.69.0':
+    optional: true
 
-    '@rehype-pretty/transformers@0.13.2': {}
+  '@oxlint/binding-win32-x64-msvc@1.69.0':
+    optional: true
 
-    '@rolldown/binding-android-arm64@1.0.0-rc.12':
-        optional: true
+  '@parse5/tools@0.3.0':
+    dependencies:
+      parse5: 7.3.0
 
-    '@rolldown/binding-android-arm64@1.0.3':
-        optional: true
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
-    '@rolldown/binding-android-arm64@1.1.1':
-        optional: true
+  '@polka/url@1.0.0-next.29': {}
 
-    '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
-        optional: true
+  '@react-types/shared@3.35.0(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
 
-    '@rolldown/binding-darwin-arm64@1.0.3':
-        optional: true
+  '@rehype-pretty/transformers@0.13.2': {}
 
-    '@rolldown/binding-darwin-arm64@1.1.1':
-        optional: true
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    optional: true
 
-    '@rolldown/binding-darwin-x64@1.0.0-rc.12':
-        optional: true
+  '@rolldown/binding-android-arm64@1.0.3':
+    optional: true
 
-    '@rolldown/binding-darwin-x64@1.0.3':
-        optional: true
+  '@rolldown/binding-android-arm64@1.1.1':
+    optional: true
 
-    '@rolldown/binding-darwin-x64@1.1.1':
-        optional: true
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    optional: true
 
-    '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
-        optional: true
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    optional: true
 
-    '@rolldown/binding-freebsd-x64@1.0.3':
-        optional: true
+  '@rolldown/binding-darwin-arm64@1.1.1':
+    optional: true
 
-    '@rolldown/binding-freebsd-x64@1.1.1':
-        optional: true
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    optional: true
 
-    '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
-        optional: true
+  '@rolldown/binding-darwin-x64@1.0.3':
+    optional: true
 
-    '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
-        optional: true
+  '@rolldown/binding-darwin-x64@1.1.1':
+    optional: true
 
-    '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
-        optional: true
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    optional: true
 
-    '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
-        optional: true
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    optional: true
 
-    '@rolldown/binding-linux-arm64-gnu@1.0.3':
-        optional: true
+  '@rolldown/binding-freebsd-x64@1.1.1':
+    optional: true
 
-    '@rolldown/binding-linux-arm64-gnu@1.1.1':
-        optional: true
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    optional: true
 
-    '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
-        optional: true
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    optional: true
 
-    '@rolldown/binding-linux-arm64-musl@1.0.3':
-        optional: true
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
+    optional: true
 
-    '@rolldown/binding-linux-arm64-musl@1.1.1':
-        optional: true
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    optional: true
 
-    '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
-        optional: true
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    optional: true
 
-    '@rolldown/binding-linux-ppc64-gnu@1.0.3':
-        optional: true
+  '@rolldown/binding-linux-arm64-gnu@1.1.1':
+    optional: true
 
-    '@rolldown/binding-linux-ppc64-gnu@1.1.1':
-        optional: true
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    optional: true
 
-    '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
-        optional: true
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    optional: true
 
-    '@rolldown/binding-linux-s390x-gnu@1.0.3':
-        optional: true
+  '@rolldown/binding-linux-arm64-musl@1.1.1':
+    optional: true
 
-    '@rolldown/binding-linux-s390x-gnu@1.1.1':
-        optional: true
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    optional: true
 
-    '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
-        optional: true
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    optional: true
 
-    '@rolldown/binding-linux-x64-gnu@1.0.3':
-        optional: true
+  '@rolldown/binding-linux-ppc64-gnu@1.1.1':
+    optional: true
 
-    '@rolldown/binding-linux-x64-gnu@1.1.1':
-        optional: true
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    optional: true
 
-    '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
-        optional: true
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    optional: true
 
-    '@rolldown/binding-linux-x64-musl@1.0.3':
-        optional: true
+  '@rolldown/binding-linux-s390x-gnu@1.1.1':
+    optional: true
 
-    '@rolldown/binding-linux-x64-musl@1.1.1':
-        optional: true
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    optional: true
 
-    '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
-        optional: true
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    optional: true
 
-    '@rolldown/binding-openharmony-arm64@1.0.3':
-        optional: true
+  '@rolldown/binding-linux-x64-gnu@1.1.1':
+    optional: true
 
-    '@rolldown/binding-openharmony-arm64@1.1.1':
-        optional: true
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    optional: true
 
-    '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)':
-        dependencies:
-            '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
-        transitivePeerDependencies:
-            - '@emnapi/core'
-            - '@emnapi/runtime'
-        optional: true
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    optional: true
 
-    '@rolldown/binding-wasm32-wasi@1.0.3':
-        dependencies:
-            '@emnapi/core': 1.10.0
-            '@emnapi/runtime': 1.10.0
-            '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-        optional: true
+  '@rolldown/binding-linux-x64-musl@1.1.1':
+    optional: true
 
-    '@rolldown/binding-wasm32-wasi@1.1.1':
-        dependencies:
-            '@emnapi/core': 1.11.0
-            '@emnapi/runtime': 1.11.0
-            '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
-        optional: true
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    optional: true
 
-    '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
-        optional: true
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    optional: true
 
-    '@rolldown/binding-win32-arm64-msvc@1.0.3':
-        optional: true
+  '@rolldown/binding-openharmony-arm64@1.1.1':
+    optional: true
 
-    '@rolldown/binding-win32-arm64-msvc@1.1.1':
-        optional: true
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
 
-    '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
-        optional: true
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
 
-    '@rolldown/binding-win32-x64-msvc@1.0.3':
-        optional: true
+  '@rolldown/binding-wasm32-wasi@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.11.0
+      '@emnapi/runtime': 1.11.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
+    optional: true
 
-    '@rolldown/binding-win32-x64-msvc@1.1.1':
-        optional: true
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    optional: true
 
-    '@rolldown/pluginutils@1.0.0-rc.12': {}
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    optional: true
 
-    '@rolldown/pluginutils@1.0.1': {}
+  '@rolldown/binding-win32-arm64-msvc@1.1.1':
+    optional: true
 
-    '@shikijs/core@1.29.2':
-        dependencies:
-            '@shikijs/engine-javascript': 1.29.2
-            '@shikijs/engine-oniguruma': 1.29.2
-            '@shikijs/types': 1.29.2
-            '@shikijs/vscode-textmate': 10.0.2
-            '@types/hast': 3.0.4
-            hast-util-to-html: 9.0.5
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    optional: true
 
-    '@shikijs/core@3.23.0':
-        dependencies:
-            '@shikijs/types': 3.23.0
-            '@shikijs/vscode-textmate': 10.0.2
-            '@types/hast': 3.0.4
-            hast-util-to-html: 9.0.5
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    optional: true
 
-    '@shikijs/engine-javascript@1.29.2':
-        dependencies:
-            '@shikijs/types': 1.29.2
-            '@shikijs/vscode-textmate': 10.0.2
-            oniguruma-to-es: 2.3.0
+  '@rolldown/binding-win32-x64-msvc@1.1.1':
+    optional: true
 
-    '@shikijs/engine-javascript@3.23.0':
-        dependencies:
-            '@shikijs/types': 3.23.0
-            '@shikijs/vscode-textmate': 10.0.2
-            oniguruma-to-es: 4.3.6
+  '@rolldown/pluginutils@1.0.0-rc.12': {}
 
-    '@shikijs/engine-oniguruma@1.29.2':
-        dependencies:
-            '@shikijs/types': 1.29.2
-            '@shikijs/vscode-textmate': 10.0.2
+  '@rolldown/pluginutils@1.0.1': {}
 
-    '@shikijs/engine-oniguruma@3.23.0':
-        dependencies:
-            '@shikijs/types': 3.23.0
-            '@shikijs/vscode-textmate': 10.0.2
+  '@shikijs/core@1.29.2':
+    dependencies:
+      '@shikijs/engine-javascript': 1.29.2
+      '@shikijs/engine-oniguruma': 1.29.2
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
 
-    '@shikijs/langs@1.29.2':
-        dependencies:
-            '@shikijs/types': 1.29.2
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
 
-    '@shikijs/langs@3.23.0':
-        dependencies:
-            '@shikijs/types': 3.23.0
+  '@shikijs/engine-javascript@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 2.3.0
 
-    '@shikijs/themes@1.29.2':
-        dependencies:
-            '@shikijs/types': 1.29.2
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
 
-    '@shikijs/themes@3.23.0':
-        dependencies:
-            '@shikijs/types': 3.23.0
+  '@shikijs/engine-oniguruma@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
 
-    '@shikijs/types@1.29.2':
-        dependencies:
-            '@shikijs/vscode-textmate': 10.0.2
-            '@types/hast': 3.0.4
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
 
-    '@shikijs/types@3.23.0':
-        dependencies:
-            '@shikijs/vscode-textmate': 10.0.2
-            '@types/hast': 3.0.4
+  '@shikijs/langs@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
 
-    '@shikijs/vscode-textmate@10.0.2': {}
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
 
-    '@standard-schema/spec@1.1.0': {}
+  '@shikijs/themes@1.29.2':
+    dependencies:
+      '@shikijs/types': 1.29.2
 
-    '@stardazed/streams-compression@1.0.0':
-        dependencies:
-            '@stardazed/zlib': 1.0.1
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
 
-    '@stardazed/zlib@1.0.1': {}
+  '@shikijs/types@1.29.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
-    '@swc/helpers@0.5.23':
-        dependencies:
-            tslib: 2.8.1
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
-    '@tailwindcss/node@4.3.1':
-        dependencies:
-            '@jridgewell/remapping': 2.3.5
-            enhanced-resolve: 5.21.6
-            jiti: 2.7.0
-            lightningcss: 1.32.0
-            magic-string: 0.30.21
-            source-map-js: 1.2.1
-            tailwindcss: 4.3.1
+  '@shikijs/vscode-textmate@10.0.2': {}
 
-    '@tailwindcss/oxide-android-arm64@4.3.1':
-        optional: true
+  '@standard-schema/spec@1.1.0': {}
 
-    '@tailwindcss/oxide-darwin-arm64@4.3.1':
-        optional: true
+  '@stardazed/streams-compression@1.0.0':
+    dependencies:
+      '@stardazed/zlib': 1.0.1
 
-    '@tailwindcss/oxide-darwin-x64@4.3.1':
-        optional: true
+  '@stardazed/zlib@1.0.1': {}
 
-    '@tailwindcss/oxide-freebsd-x64@4.3.1':
-        optional: true
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
 
-    '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
-        optional: true
+  '@tailwindcss/node@4.3.1':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.1
 
-    '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
-        optional: true
+  '@tailwindcss/oxide-android-arm64@4.3.1':
+    optional: true
 
-    '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
-        optional: true
+  '@tailwindcss/oxide-darwin-arm64@4.3.1':
+    optional: true
 
-    '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
-        optional: true
+  '@tailwindcss/oxide-darwin-x64@4.3.1':
+    optional: true
 
-    '@tailwindcss/oxide-linux-x64-musl@4.3.1':
-        optional: true
+  '@tailwindcss/oxide-freebsd-x64@4.3.1':
+    optional: true
 
-    '@tailwindcss/oxide-wasm32-wasi@4.3.1':
-        optional: true
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
+    optional: true
 
-    '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
-        optional: true
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
+    optional: true
 
-    '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
-        optional: true
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
+    optional: true
 
-    '@tailwindcss/oxide@4.3.1':
-        optionalDependencies:
-            '@tailwindcss/oxide-android-arm64': 4.3.1
-            '@tailwindcss/oxide-darwin-arm64': 4.3.1
-            '@tailwindcss/oxide-darwin-x64': 4.3.1
-            '@tailwindcss/oxide-freebsd-x64': 4.3.1
-            '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.1
-            '@tailwindcss/oxide-linux-arm64-gnu': 4.3.1
-            '@tailwindcss/oxide-linux-arm64-musl': 4.3.1
-            '@tailwindcss/oxide-linux-x64-gnu': 4.3.1
-            '@tailwindcss/oxide-linux-x64-musl': 4.3.1
-            '@tailwindcss/oxide-wasm32-wasi': 4.3.1
-            '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
-            '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
+    optional: true
 
-    '@tailwindcss/postcss@4.3.1':
-        dependencies:
-            '@alloc/quick-lru': 5.2.0
-            '@tailwindcss/node': 4.3.1
-            '@tailwindcss/oxide': 4.3.1
-            postcss: 8.5.15
-            tailwindcss: 4.3.1
+  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
+    optional: true
 
-    '@tanstack/react-table@8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-        dependencies:
-            '@tanstack/table-core': 8.21.3
-            react: 19.2.7
-            react-dom: 19.2.7(react@19.2.7)
+  '@tailwindcss/oxide-wasm32-wasi@4.3.1':
+    optional: true
 
-    '@tanstack/table-core@8.21.3': {}
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
+    optional: true
 
-    '@testing-library/dom@10.4.1':
-        dependencies:
-            '@babel/code-frame': 7.29.7
-            '@babel/runtime': 7.29.7
-            '@types/aria-query': 5.0.4
-            aria-query: 5.3.0
-            dom-accessibility-api: 0.5.16
-            lz-string: 1.5.0
-            picocolors: 1.1.1
-            pretty-format: 27.5.1
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
+    optional: true
 
-    '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-        dependencies:
-            '@babel/runtime': 7.29.7
-            '@testing-library/dom': 10.4.1
-            react: 19.2.7
-            react-dom: 19.2.7(react@19.2.7)
-        optionalDependencies:
-            '@types/react': 19.2.17
-            '@types/react-dom': 19.2.3(@types/react@19.2.17)
+  '@tailwindcss/oxide@4.3.1':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.1
+      '@tailwindcss/oxide-darwin-arm64': 4.3.1
+      '@tailwindcss/oxide-darwin-x64': 4.3.1
+      '@tailwindcss/oxide-freebsd-x64': 4.3.1
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.1
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.1
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.1
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.1
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.1
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.1
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-    '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
-        dependencies:
-            '@testing-library/dom': 10.4.1
+  '@tailwindcss/postcss@4.3.1':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.3.1
+      '@tailwindcss/oxide': 4.3.1
+      postcss: 8.5.15
+      tailwindcss: 4.3.1
 
-    '@tiptap/core@3.27.1(@tiptap/pm@3.27.1)':
-        dependencies:
-            '@tiptap/pm': 3.27.1
+  '@tanstack/react-table@8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
-    '@tiptap/extension-blockquote@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-bold@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-bullet-list@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-code-block@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-            '@tiptap/pm': 3.27.1
-
-    '@tiptap/extension-code@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-document@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-dropcursor@3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-gapcursor@3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-hard-break@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-heading@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-horizontal-rule@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-            '@tiptap/pm': 3.27.1
-
-    '@tiptap/extension-image@3.26.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-italic@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-link@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-            '@tiptap/pm': 3.27.1
-            linkifyjs: 4.3.3
-
-    '@tiptap/extension-list-item@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-list-keymap@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-            '@tiptap/pm': 3.27.1
-
-    '@tiptap/extension-ordered-list@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-paragraph@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-strike@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-text@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-    '@tiptap/extension-underline@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-    '@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-            '@tiptap/pm': 3.27.1
-
-    '@tiptap/pm@3.27.1':
-        dependencies:
-            prosemirror-changeset: 2.4.1
-            prosemirror-commands: 1.7.1
-            prosemirror-dropcursor: 1.8.2
-            prosemirror-gapcursor: 1.4.1
-            prosemirror-history: 1.5.0
-            prosemirror-inputrules: 1.5.1
-            prosemirror-keymap: 1.2.3
-            prosemirror-model: 1.25.8
-            prosemirror-schema-list: 1.5.1
-            prosemirror-state: 1.4.4
-            prosemirror-tables: 1.8.5
-            prosemirror-transform: 1.12.0
-            prosemirror-view: 1.41.9
-
-    '@tiptap/starter-kit@3.27.1':
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-            '@tiptap/extension-blockquote': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-            '@tiptap/extension-bold': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-            '@tiptap/extension-bullet-list': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-            '@tiptap/extension-code': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-            '@tiptap/extension-code-block': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-            '@tiptap/extension-document': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-            '@tiptap/extension-dropcursor': 3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-            '@tiptap/extension-gapcursor': 3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-            '@tiptap/extension-hard-break': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-            '@tiptap/extension-heading': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-            '@tiptap/extension-horizontal-rule': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-            '@tiptap/extension-italic': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-            '@tiptap/extension-link': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-            '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-            '@tiptap/extension-list-item': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-            '@tiptap/extension-list-keymap': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-            '@tiptap/extension-ordered-list': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-            '@tiptap/extension-paragraph': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-            '@tiptap/extension-strike': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-            '@tiptap/extension-text': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-            '@tiptap/extension-underline': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-            '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-            '@tiptap/pm': 3.27.1
-
-    '@tybys/wasm-util@0.10.2':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    '@types/alpinejs@3.13.11': {}
-
-    '@types/aria-query@5.0.4': {}
-
-    '@types/bun@1.3.14':
-        dependencies:
-            bun-types: 1.3.14
-
-    '@types/chai@5.2.3':
-        dependencies:
-            '@types/deep-eql': 4.0.2
-            assertion-error: 2.0.1
-
-    '@types/debug@4.1.13':
-        dependencies:
-            '@types/ms': 2.1.0
-
-    '@types/deep-eql@4.0.2': {}
-
-    '@types/estree-jsx@1.0.5':
-        dependencies:
-            '@types/estree': 1.0.9
-
-    '@types/estree@1.0.9': {}
-
-    '@types/hast@3.0.4':
-        dependencies:
-            '@types/unist': 3.0.3
-
-    '@types/jscodeshift@17.3.0':
-        dependencies:
-            ast-types: 0.16.1
-            recast: 0.23.11
-
-    '@types/linkify-it@3.0.5': {}
-
-    '@types/linkify-it@5.0.0': {}
-
-    '@types/markdown-it@13.0.9':
-        dependencies:
-            '@types/linkify-it': 3.0.5
-            '@types/mdurl': 1.0.5
-
-    '@types/markdown-it@14.1.2':
-        dependencies:
-            '@types/linkify-it': 5.0.0
-            '@types/mdurl': 2.0.0
-
-    '@types/mdast@4.0.4':
-        dependencies:
-            '@types/unist': 3.0.3
-
-    '@types/mdurl@1.0.5': {}
-
-    '@types/mdurl@2.0.0': {}
-
-    '@types/mdx@2.0.14': {}
-
-    '@types/ms@2.1.0': {}
-
-    '@types/node@16.18.126': {}
-
-    '@types/node@24.13.2':
-        dependencies:
-            undici-types: 7.18.2
-
-    '@types/postcss-import@14.0.3':
-        dependencies:
-            postcss: 8.5.15
-
-    '@types/react-dom@19.2.3(@types/react@19.2.17)':
-        dependencies:
-            '@types/react': 19.2.17
-
-    '@types/react@19.2.17':
-        dependencies:
-            csstype: 3.2.3
-
-    '@types/trusted-types@2.0.7': {}
-
-    '@types/unist@2.0.11': {}
-
-    '@types/unist@3.0.3': {}
-
-    '@types/ws@8.18.1':
-        dependencies:
-            '@types/node': 24.13.2
-
-    '@ungap/structured-clone@1.3.1': {}
-
-    '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)':
-        dependencies:
-            '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
-            '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-            playwright: 1.60.0
-            tinyrainbow: 3.1.0
-            vitest: 4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-        transitivePeerDependencies:
-            - bufferutil
-            - msw
-            - utf-8-validate
-            - vite
-
-    '@vitest/browser@4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)':
-        dependencies:
-            '@blazediff/core': 1.9.1
-            '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-            '@vitest/utils': 4.1.8
-            magic-string: 0.30.21
-            pngjs: 7.0.0
-            sirv: 3.0.2
-            tinyrainbow: 3.1.0
-            vitest: 4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-            ws: 8.21.0
-        transitivePeerDependencies:
-            - bufferutil
-            - msw
-            - utf-8-validate
-            - vite
-
-    '@vitest/expect@4.1.8':
-        dependencies:
-            '@standard-schema/spec': 1.1.0
-            '@types/chai': 5.2.3
-            '@vitest/spy': 4.1.8
-            '@vitest/utils': 4.1.8
-            chai: 6.2.2
-            tinyrainbow: 3.1.0
-
-    '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
-        dependencies:
-            '@vitest/spy': 4.1.8
-            estree-walker: 3.0.3
-            magic-string: 0.30.21
-        optionalDependencies:
-            vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-
-    '@vitest/pretty-format@4.1.8':
-        dependencies:
-            tinyrainbow: 3.1.0
-
-    '@vitest/runner@4.1.8':
-        dependencies:
-            '@vitest/utils': 4.1.8
-            pathe: 2.0.3
-
-    '@vitest/snapshot@4.1.8':
-        dependencies:
-            '@vitest/pretty-format': 4.1.8
-            '@vitest/utils': 4.1.8
-            magic-string: 0.30.21
-            pathe: 2.0.3
-
-    '@vitest/spy@4.1.8': {}
-
-    '@vitest/utils@4.1.8':
-        dependencies:
-            '@vitest/pretty-format': 4.1.8
-            convert-source-map: 2.0.0
-            tinyrainbow: 3.1.0
-
-    '@vue/reactivity@3.1.5':
-        dependencies:
-            '@vue/shared': 3.1.5
-
-    '@vue/shared@3.1.5': {}
-
-    '@worker-tools/html-rewriter@0.1.0-pre.19':
-        dependencies:
-            '@stardazed/streams-compression': 1.0.0
-            '@worker-tools/resolvable-promise': 0.2.0-pre.6
-
-    '@worker-tools/resolvable-promise@0.2.0-pre.6': {}
-
-    acorn-jsx@5.3.2(acorn@8.17.0):
-        dependencies:
-            acorn: 8.17.0
-
-    acorn@8.17.0: {}
-
-    alpinejs@3.15.12:
-        dependencies:
-            '@vue/reactivity': 3.1.5
-
-    ansi-escapes@7.3.0:
-        dependencies:
-            environment: 1.1.0
-
-    ansi-regex@5.0.1: {}
-
-    ansi-regex@6.2.2: {}
-
-    ansi-styles@5.2.0: {}
-
-    ansi-styles@6.2.3: {}
-
-    any-promise@1.3.0: {}
-
-    anymatch@3.1.3:
-        dependencies:
-            normalize-path: 3.0.0
-            picomatch: 2.3.2
-
-    arg@5.0.2: {}
-
-    argparse@2.0.1: {}
-
-    aria-hidden@1.2.6:
-        dependencies:
-            tslib: 2.8.1
-
-    aria-query@5.3.0:
-        dependencies:
-            dequal: 2.0.3
-
-    arkregex@0.0.5:
-        dependencies:
-            '@ark/util': 0.56.0
-
-    arktype@2.2.0:
-        dependencies:
-            '@ark/schema': 0.56.0
-            '@ark/util': 0.56.0
-            arkregex: 0.0.5
-
-    assertion-error@2.0.1: {}
-
-    ast-types@0.16.1:
-        dependencies:
-            tslib: 2.8.1
-
-    astring@1.9.0: {}
-
-    atomically@2.1.1:
-        dependencies:
-            stubborn-fs: 2.0.0
-            when-exit: 2.1.5
-
-    autoprefixer@10.5.0(postcss@8.5.15):
-        dependencies:
-            browserslist: 4.28.2
-            caniuse-lite: 1.0.30001799
-            fraction.js: 5.3.4
-            picocolors: 1.1.1
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    bail@2.0.2: {}
-
-    baseline-browser-mapping@2.10.37: {}
-
-    better-auth@1.6.18(drizzle-kit@1.0.0-rc.4-ca0f029)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8):
-        dependencies:
-            '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/drizzle-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))
-            '@better-auth/kysely-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.29.2)
-            '@better-auth/memory-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
-            '@better-auth/mongo-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
-            '@better-auth/prisma-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
-            '@better-auth/telemetry': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)
-            '@better-auth/utils': 0.4.1
-            '@better-fetch/fetch': 1.3.0
-            '@noble/ciphers': 2.2.0
-            '@noble/hashes': 2.2.0
-            better-call: 1.3.6(zod@4.4.3)
-            defu: 6.1.7
-            jose: 6.2.3
-            kysely: 0.29.2
-            nanostores: 1.3.0
-            zod: 4.4.3
-        optionalDependencies:
-            drizzle-kit: 1.0.0-rc.4-ca0f029
-            drizzle-orm: 0.45.2(bun-types@1.3.14)(kysely@0.29.2)
-            react: 19.2.7
-            react-dom: 19.2.7(react@19.2.7)
-            vitest: 4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-        transitivePeerDependencies:
-            - '@cloudflare/workers-types'
-            - '@opentelemetry/api'
-
-    better-auth@1.6.20(drizzle-kit@1.0.0-rc.4-ca0f029)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8):
-        dependencies:
-            '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-            '@better-auth/drizzle-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))
-            '@better-auth/kysely-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
-            '@better-auth/memory-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-            '@better-auth/mongo-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-            '@better-auth/prisma-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-            '@better-auth/telemetry': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
-            '@better-auth/utils': 0.4.2
-            '@better-fetch/fetch': 1.3.1
-            '@noble/ciphers': 2.2.0
-            '@noble/hashes': 2.2.0
-            better-call: 1.3.6(zod@4.4.3)
-            defu: 6.1.7
-            jose: 6.2.3
-            kysely: 0.29.2
-            nanostores: 1.3.0
-            zod: 4.4.3
-        optionalDependencies:
-            drizzle-kit: 1.0.0-rc.4-ca0f029
-            drizzle-orm: 0.45.2(bun-types@1.3.14)(kysely@0.29.2)
-            react: 19.2.7
-            react-dom: 19.2.7(react@19.2.7)
-            vitest: 4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-        transitivePeerDependencies:
-            - '@cloudflare/workers-types'
-            - '@opentelemetry/api'
-
-    better-call@1.3.6(zod@4.4.3):
-        dependencies:
-            '@better-auth/utils': 0.4.1
-            '@better-fetch/fetch': 1.3.0
-            rou3: 0.7.12
-            set-cookie-parser: 3.1.0
-        optionalDependencies:
-            zod: 4.4.3
-
-    better-commits@1.24.0(typescript@5.9.3):
-        dependencies:
-            '@bomb.sh/args': 0.3.1
-            '@clack/core': 1.4.1
-            '@clack/prompts': 1.5.1
-            configstore: 8.0.0
-            jsonc-parser: 3.3.1
-            picocolors: 1.1.1
-            valibot: 1.4.1(typescript@5.9.3)
-        transitivePeerDependencies:
-            - typescript
-
-    binary-extensions@2.3.0: {}
-
-    boolbase@1.0.0: {}
-
-    braces@3.0.3:
-        dependencies:
-            fill-range: 7.1.1
-
-    browserslist@4.28.2:
-        dependencies:
-            baseline-browser-mapping: 2.10.37
-            caniuse-lite: 1.0.30001799
-            electron-to-chromium: 1.5.372
-            node-releases: 2.0.47
-            update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
-    buffer-from@1.1.2: {}
-
-    bun-types@1.3.14:
-        dependencies:
-            '@types/node': 24.13.2
-
-    bun@1.3.14:
-        optionalDependencies:
-            '@oven/bun-darwin-aarch64': 1.3.14
-            '@oven/bun-darwin-x64': 1.3.14
-            '@oven/bun-darwin-x64-baseline': 1.3.14
-            '@oven/bun-freebsd-aarch64': 1.3.14
-            '@oven/bun-freebsd-x64': 1.3.14
-            '@oven/bun-linux-aarch64': 1.3.14
-            '@oven/bun-linux-aarch64-android': 1.3.14
-            '@oven/bun-linux-aarch64-musl': 1.3.14
-            '@oven/bun-linux-x64': 1.3.14
-            '@oven/bun-linux-x64-android': 1.3.14
-            '@oven/bun-linux-x64-baseline': 1.3.14
-            '@oven/bun-linux-x64-musl': 1.3.14
-            '@oven/bun-linux-x64-musl-baseline': 1.3.14
-            '@oven/bun-windows-aarch64': 1.3.14
-            '@oven/bun-windows-x64': 1.3.14
-            '@oven/bun-windows-x64-baseline': 1.3.14
-
-    camelcase-css@2.0.1: {}
-
-    caniuse-api@3.0.0:
-        dependencies:
-            browserslist: 4.28.2
-            caniuse-lite: 1.0.30001799
-            lodash.memoize: 4.1.2
-            lodash.uniq: 4.5.0
-
-    caniuse-lite@1.0.30001799: {}
-
-    ccount@2.0.1: {}
-
-    chai@6.2.2: {}
-
-    chalk@5.6.2: {}
-
-    character-entities-html4@2.1.0: {}
-
-    character-entities-legacy@3.0.0: {}
-
-    character-entities@2.0.2: {}
-
-    character-reference-invalid@2.0.1: {}
-
-    chokidar@3.6.0:
-        dependencies:
-            anymatch: 3.1.3
-            braces: 3.0.3
-            glob-parent: 5.1.2
-            is-binary-path: 2.1.0
-            is-glob: 4.0.3
-            normalize-path: 3.0.0
-            readdirp: 3.6.0
-        optionalDependencies:
-            fsevents: 2.3.3
-
-    chokidar@5.0.0:
-        dependencies:
-            readdirp: 5.0.0
-
-    citty@0.1.6:
-        dependencies:
-            consola: 3.4.2
-
-    citty@0.2.2: {}
-
-    cli-cursor@5.0.0:
-        dependencies:
-            restore-cursor: 5.1.0
-
-    cli-truncate@4.0.0:
-        dependencies:
-            slice-ansi: 5.0.0
-            string-width: 7.2.0
-
-    client-only@0.0.1: {}
-
-    cliui@9.0.1:
-        dependencies:
-            string-width: 7.2.0
-            strip-ansi: 7.2.0
-            wrap-ansi: 9.0.2
-
-    clone-deep@4.0.1:
-        dependencies:
-            is-plain-object: 2.0.4
-            kind-of: 6.0.3
-            shallow-clone: 3.0.1
-
-    clsx@2.1.1: {}
-
-    collapse-white-space@2.1.0: {}
-
-    colorette@2.0.20: {}
-
-    comma-separated-tokens@2.0.3: {}
-
-    commander@11.1.0: {}
-
-    commander@13.1.0: {}
-
-    commander@4.1.1: {}
-
-    commondir@1.0.1: {}
-
-    configstore@8.0.0:
-        dependencies:
-            atomically: 2.1.1
-            dot-prop: 10.1.0
-            graceful-fs: 4.2.11
-            is-safe-filename: 0.1.1
-            xdg-basedir: 5.1.0
-
-    consola@3.4.2: {}
-
-    convert-source-map@2.0.0: {}
-
-    cross-spawn@7.0.6:
-        dependencies:
-            path-key: 3.1.1
-            shebang-command: 2.0.0
-            which: 2.0.2
-
-    css-declaration-sorter@7.4.0(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-
-    css-select@5.2.2:
-        dependencies:
-            boolbase: 1.0.0
-            css-what: 6.2.2
-            domhandler: 5.0.3
-            domutils: 3.2.2
-            nth-check: 2.1.1
-
-    css-tree@2.2.1:
-        dependencies:
-            mdn-data: 2.0.28
-            source-map-js: 1.2.1
-
-    css-tree@3.2.1:
-        dependencies:
-            mdn-data: 2.27.1
-            source-map-js: 1.2.1
-
-    css-what@6.2.2: {}
-
-    cssesc@3.0.0: {}
-
-    cssnano-preset-default@7.0.17(postcss@8.5.15):
-        dependencies:
-            browserslist: 4.28.2
-            css-declaration-sorter: 7.4.0(postcss@8.5.15)
-            cssnano-utils: 5.0.3(postcss@8.5.15)
-            postcss: 8.5.15
-            postcss-calc: 10.1.1(postcss@8.5.15)
-            postcss-colormin: 7.0.10(postcss@8.5.15)
-            postcss-convert-values: 7.0.12(postcss@8.5.15)
-            postcss-discard-comments: 7.0.8(postcss@8.5.15)
-            postcss-discard-duplicates: 7.0.4(postcss@8.5.15)
-            postcss-discard-empty: 7.0.3(postcss@8.5.15)
-            postcss-discard-overridden: 7.0.3(postcss@8.5.15)
-            postcss-merge-longhand: 7.0.7(postcss@8.5.15)
-            postcss-merge-rules: 7.0.11(postcss@8.5.15)
-            postcss-minify-font-values: 7.0.3(postcss@8.5.15)
-            postcss-minify-gradients: 7.0.5(postcss@8.5.15)
-            postcss-minify-params: 7.0.9(postcss@8.5.15)
-            postcss-minify-selectors: 7.1.2(postcss@8.5.15)
-            postcss-normalize-charset: 7.0.3(postcss@8.5.15)
-            postcss-normalize-display-values: 7.0.3(postcss@8.5.15)
-            postcss-normalize-positions: 7.0.4(postcss@8.5.15)
-            postcss-normalize-repeat-style: 7.0.4(postcss@8.5.15)
-            postcss-normalize-string: 7.0.3(postcss@8.5.15)
-            postcss-normalize-timing-functions: 7.0.3(postcss@8.5.15)
-            postcss-normalize-unicode: 7.0.9(postcss@8.5.15)
-            postcss-normalize-url: 7.0.3(postcss@8.5.15)
-            postcss-normalize-whitespace: 7.0.3(postcss@8.5.15)
-            postcss-ordered-values: 7.0.4(postcss@8.5.15)
-            postcss-reduce-initial: 7.0.9(postcss@8.5.15)
-            postcss-reduce-transforms: 7.0.3(postcss@8.5.15)
-            postcss-svgo: 7.1.3(postcss@8.5.15)
-            postcss-unique-selectors: 7.0.7(postcss@8.5.15)
-
-    cssnano-utils@5.0.3(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-
-    cssnano@7.1.9(postcss@8.5.15):
-        dependencies:
-            cssnano-preset-default: 7.0.17(postcss@8.5.15)
-            lilconfig: 3.1.3
-            postcss: 8.5.15
-
-    csso@5.0.5:
-        dependencies:
-            css-tree: 2.2.1
-
-    csstype@3.2.3: {}
-
-    data-uri-to-buffer@4.0.1: {}
-
-    debug@4.4.3:
-        dependencies:
-            ms: 2.1.3
-
-    decode-named-character-reference@1.3.0:
-        dependencies:
-            character-entities: 2.0.2
-
-    defu@6.1.7: {}
-
-    dequal@2.0.3: {}
-
-    detect-libc@2.1.2: {}
-
-    devlop@1.1.0:
-        dependencies:
-            dequal: 2.0.3
-
-    didyoumean@1.2.2: {}
-
-    dlv@1.1.3: {}
-
-    dom-accessibility-api@0.5.16: {}
-
-    dom-serializer@2.0.0:
-        dependencies:
-            domelementtype: 2.3.0
-            domhandler: 5.0.3
-            entities: 4.5.0
-
-    domelementtype@2.3.0: {}
-
-    domhandler@5.0.3:
-        dependencies:
-            domelementtype: 2.3.0
-
-    domutils@3.2.2:
-        dependencies:
-            dom-serializer: 2.0.0
-            domelementtype: 2.3.0
-            domhandler: 5.0.3
-
-    dot-prop@10.1.0:
-        dependencies:
-            type-fest: 5.7.0
-
-    drizzle-kit@1.0.0-rc.4-ca0f029:
-        dependencies:
-            '@drizzle-team/brocli': 0.11.0
-            '@js-temporal/polyfill': 0.5.1
-            esbuild: 0.25.12
-            get-tsconfig: 4.14.0
-            jiti: 2.7.0
-
-    drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2):
-        optionalDependencies:
-            bun-types: 1.3.14
-            kysely: 0.29.2
-
-    electron-to-chromium@1.5.372: {}
-
-    emoji-regex-xs@1.0.0: {}
-
-    emoji-regex@10.6.0: {}
-
-    enhanced-resolve@5.21.6:
-        dependencies:
-            graceful-fs: 4.2.11
-            tapable: 2.3.3
-
-    enhanced-resolve@5.24.0:
-        dependencies:
-            graceful-fs: 4.2.11
-            tapable: 2.3.3
-
-    entities@4.5.0: {}
-
-    entities@6.0.1: {}
-
-    environment@1.1.0: {}
-
-    es-errors@1.3.0: {}
-
-    es-module-lexer@2.1.0: {}
-
-    esast-util-from-estree@2.0.0:
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            devlop: 1.1.0
-            estree-util-visit: 2.0.0
-            unist-util-position-from-estree: 2.0.0
-
-    esast-util-from-js@2.0.1:
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            acorn: 8.17.0
-            esast-util-from-estree: 2.0.0
-            vfile-message: 4.0.3
-
-    esbuild@0.25.12:
-        optionalDependencies:
-            '@esbuild/aix-ppc64': 0.25.12
-            '@esbuild/android-arm': 0.25.12
-            '@esbuild/android-arm64': 0.25.12
-            '@esbuild/android-x64': 0.25.12
-            '@esbuild/darwin-arm64': 0.25.12
-            '@esbuild/darwin-x64': 0.25.12
-            '@esbuild/freebsd-arm64': 0.25.12
-            '@esbuild/freebsd-x64': 0.25.12
-            '@esbuild/linux-arm': 0.25.12
-            '@esbuild/linux-arm64': 0.25.12
-            '@esbuild/linux-ia32': 0.25.12
-            '@esbuild/linux-loong64': 0.25.12
-            '@esbuild/linux-mips64el': 0.25.12
-            '@esbuild/linux-ppc64': 0.25.12
-            '@esbuild/linux-riscv64': 0.25.12
-            '@esbuild/linux-s390x': 0.25.12
-            '@esbuild/linux-x64': 0.25.12
-            '@esbuild/netbsd-arm64': 0.25.12
-            '@esbuild/netbsd-x64': 0.25.12
-            '@esbuild/openbsd-arm64': 0.25.12
-            '@esbuild/openbsd-x64': 0.25.12
-            '@esbuild/openharmony-arm64': 0.25.12
-            '@esbuild/sunos-x64': 0.25.12
-            '@esbuild/win32-arm64': 0.25.12
-            '@esbuild/win32-ia32': 0.25.12
-            '@esbuild/win32-x64': 0.25.12
-
-    esbuild@0.28.1:
-        optionalDependencies:
-            '@esbuild/aix-ppc64': 0.28.1
-            '@esbuild/android-arm': 0.28.1
-            '@esbuild/android-arm64': 0.28.1
-            '@esbuild/android-x64': 0.28.1
-            '@esbuild/darwin-arm64': 0.28.1
-            '@esbuild/darwin-x64': 0.28.1
-            '@esbuild/freebsd-arm64': 0.28.1
-            '@esbuild/freebsd-x64': 0.28.1
-            '@esbuild/linux-arm': 0.28.1
-            '@esbuild/linux-arm64': 0.28.1
-            '@esbuild/linux-ia32': 0.28.1
-            '@esbuild/linux-loong64': 0.28.1
-            '@esbuild/linux-mips64el': 0.28.1
-            '@esbuild/linux-ppc64': 0.28.1
-            '@esbuild/linux-riscv64': 0.28.1
-            '@esbuild/linux-s390x': 0.28.1
-            '@esbuild/linux-x64': 0.28.1
-            '@esbuild/netbsd-arm64': 0.28.1
-            '@esbuild/netbsd-x64': 0.28.1
-            '@esbuild/openbsd-arm64': 0.28.1
-            '@esbuild/openbsd-x64': 0.28.1
-            '@esbuild/openharmony-arm64': 0.28.1
-            '@esbuild/sunos-x64': 0.28.1
-            '@esbuild/win32-arm64': 0.28.1
-            '@esbuild/win32-ia32': 0.28.1
-            '@esbuild/win32-x64': 0.28.1
-
-    escalade@3.2.0: {}
-
-    escape-string-regexp@5.0.0: {}
-
-    esprima@4.0.1: {}
-
-    estree-util-attach-comments@3.0.0:
-        dependencies:
-            '@types/estree': 1.0.9
-
-    estree-util-build-jsx@3.0.1:
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            devlop: 1.1.0
-            estree-util-is-identifier-name: 3.0.0
-            estree-walker: 3.0.3
-
-    estree-util-is-identifier-name@3.0.0: {}
-
-    estree-util-scope@1.0.0:
-        dependencies:
-            '@types/estree': 1.0.9
-            devlop: 1.1.0
-
-    estree-util-to-js@2.0.0:
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            astring: 1.9.0
-            source-map: 0.7.6
-
-    estree-util-visit@2.0.0:
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            '@types/unist': 3.0.3
-
-    estree-walker@3.0.3:
-        dependencies:
-            '@types/estree': 1.0.9
-
-    eventemitter3@5.0.4: {}
-
-    execa@8.0.1:
-        dependencies:
-            cross-spawn: 7.0.6
-            get-stream: 8.0.1
-            human-signals: 5.0.0
-            is-stream: 3.0.0
-            merge-stream: 2.0.0
-            npm-run-path: 5.3.0
-            onetime: 6.0.0
-            signal-exit: 4.1.0
-            strip-final-newline: 3.0.0
-
-    expect-type@1.3.0: {}
-
-    extend@3.0.2: {}
-
-    fast-glob@3.3.3:
-        dependencies:
-            '@nodelib/fs.stat': 2.0.5
-            '@nodelib/fs.walk': 1.2.8
-            glob-parent: 5.1.2
-            merge2: 1.4.1
-            micromatch: 4.0.8
-
-    fast-string-truncated-width@3.0.3: {}
-
-    fast-string-width@3.0.2:
-        dependencies:
-            fast-string-truncated-width: 3.0.3
-
-    fast-wrap-ansi@0.2.2:
-        dependencies:
-            fast-string-width: 3.0.2
-
-    fastq@1.20.1:
-        dependencies:
-            reusify: 1.1.0
-
-    fdir@6.5.0(picomatch@4.0.4):
-        optionalDependencies:
-            picomatch: 4.0.4
-
-    fetch-blob@3.2.0:
-        dependencies:
-            node-domexception: 1.0.0
-            web-streams-polyfill: 3.3.3
-
-    fill-range@7.1.1:
-        dependencies:
-            to-regex-range: 5.0.1
-
-    find-cache-dir@2.1.0:
-        dependencies:
-            commondir: 1.0.1
-            make-dir: 2.1.0
-            pkg-dir: 3.0.0
-
-    find-up@3.0.0:
-        dependencies:
-            locate-path: 3.0.0
-
-    flow-parser@0.318.0: {}
-
-    formdata-polyfill@4.0.10:
-        dependencies:
-            fetch-blob: 3.2.0
-
-    fraction.js@5.3.4: {}
-
-    fsevents@2.3.2:
-        optional: true
-
-    fsevents@2.3.3:
-        optional: true
-
-    function-bind@1.1.2: {}
-
-    gensync@1.0.0-beta.2: {}
-
-    get-caller-file@2.0.5: {}
-
-    get-east-asian-width@1.6.0: {}
-
-    get-stream@8.0.1: {}
-
-    get-tsconfig@4.14.0:
-        dependencies:
-            resolve-pkg-maps: 1.0.0
-
-    ghtml@4.0.2: {}
-
-    giget@2.0.0:
-        dependencies:
-            citty: 0.1.6
-            consola: 3.4.2
-            defu: 6.1.7
-            node-fetch-native: 1.6.7
-            nypm: 0.6.7
-            pathe: 2.0.3
-
-    glob-parent@5.1.2:
-        dependencies:
-            is-glob: 4.0.3
-
-    glob-parent@6.0.2:
-        dependencies:
-            is-glob: 4.0.3
-
-    graceful-fs@4.2.11: {}
-
-    hasown@2.0.4:
-        dependencies:
-            function-bind: 1.1.2
-
-    hast-util-from-html@2.0.3:
-        dependencies:
-            '@types/hast': 3.0.4
-            devlop: 1.1.0
-            hast-util-from-parse5: 8.0.3
-            parse5: 7.3.0
-            vfile: 6.0.3
-            vfile-message: 4.0.3
-
-    hast-util-from-parse5@8.0.3:
-        dependencies:
-            '@types/hast': 3.0.4
-            '@types/unist': 3.0.3
-            devlop: 1.1.0
-            hastscript: 9.0.1
-            property-information: 7.2.0
-            vfile: 6.0.3
-            vfile-location: 5.0.3
-            web-namespaces: 2.0.1
-
-    hast-util-parse-selector@4.0.0:
-        dependencies:
-            '@types/hast': 3.0.4
-
-    hast-util-raw@9.1.0:
-        dependencies:
-            '@types/hast': 3.0.4
-            '@types/unist': 3.0.3
-            '@ungap/structured-clone': 1.3.1
-            hast-util-from-parse5: 8.0.3
-            hast-util-to-parse5: 8.0.1
-            html-void-elements: 3.0.0
-            mdast-util-to-hast: 13.2.1
-            parse5: 7.3.0
-            unist-util-position: 5.0.0
-            unist-util-visit: 5.1.0
-            vfile: 6.0.3
-            web-namespaces: 2.0.1
-            zwitch: 2.0.4
-
-    hast-util-to-estree@3.1.3:
-        dependencies:
-            '@types/estree': 1.0.9
-            '@types/estree-jsx': 1.0.5
-            '@types/hast': 3.0.4
-            comma-separated-tokens: 2.0.3
-            devlop: 1.1.0
-            estree-util-attach-comments: 3.0.0
-            estree-util-is-identifier-name: 3.0.0
-            hast-util-whitespace: 3.0.0
-            mdast-util-mdx-expression: 2.0.1
-            mdast-util-mdx-jsx: 3.2.0
-            mdast-util-mdxjs-esm: 2.0.1
-            property-information: 7.2.0
-            space-separated-tokens: 2.0.2
-            style-to-js: 1.1.21
-            unist-util-position: 5.0.0
-            zwitch: 2.0.4
-        transitivePeerDependencies:
-            - supports-color
-
-    hast-util-to-html@9.0.5:
-        dependencies:
-            '@types/hast': 3.0.4
-            '@types/unist': 3.0.3
-            ccount: 2.0.1
-            comma-separated-tokens: 2.0.3
-            hast-util-whitespace: 3.0.0
-            html-void-elements: 3.0.0
-            mdast-util-to-hast: 13.2.1
-            property-information: 7.2.0
-            space-separated-tokens: 2.0.2
-            stringify-entities: 4.0.4
-            zwitch: 2.0.4
-
-    hast-util-to-jsx-runtime@2.3.6:
-        dependencies:
-            '@types/estree': 1.0.9
-            '@types/hast': 3.0.4
-            '@types/unist': 3.0.3
-            comma-separated-tokens: 2.0.3
-            devlop: 1.1.0
-            estree-util-is-identifier-name: 3.0.0
-            hast-util-whitespace: 3.0.0
-            mdast-util-mdx-expression: 2.0.1
-            mdast-util-mdx-jsx: 3.2.0
-            mdast-util-mdxjs-esm: 2.0.1
-            property-information: 7.2.0
-            space-separated-tokens: 2.0.2
-            style-to-js: 1.1.21
-            unist-util-position: 5.0.0
-            vfile-message: 4.0.3
-        transitivePeerDependencies:
-            - supports-color
-
-    hast-util-to-parse5@8.0.1:
-        dependencies:
-            '@types/hast': 3.0.4
-            comma-separated-tokens: 2.0.3
-            devlop: 1.1.0
-            property-information: 7.2.0
-            space-separated-tokens: 2.0.2
-            web-namespaces: 2.0.1
-            zwitch: 2.0.4
-
-    hast-util-to-string@3.0.1:
-        dependencies:
-            '@types/hast': 3.0.4
-
-    hast-util-whitespace@3.0.0:
-        dependencies:
-            '@types/hast': 3.0.4
-
-    hastscript@9.0.1:
-        dependencies:
-            '@types/hast': 3.0.4
-            comma-separated-tokens: 2.0.3
-            hast-util-parse-selector: 4.0.0
-            property-information: 7.2.0
-            space-separated-tokens: 2.0.2
-
-    html-void-elements@3.0.0: {}
-
-    human-signals@5.0.0: {}
-
-    husky@9.1.7: {}
-
-    imurmurhash@0.1.4: {}
-
-    inline-style-parser@0.2.7: {}
-
-    is-alphabetical@2.0.1: {}
-
-    is-alphanumerical@2.0.1:
-        dependencies:
-            is-alphabetical: 2.0.1
-            is-decimal: 2.0.1
-
-    is-binary-path@2.1.0:
-        dependencies:
-            binary-extensions: 2.3.0
-
-    is-core-module@2.16.2:
-        dependencies:
-            hasown: 2.0.4
-
-    is-decimal@2.0.1: {}
-
-    is-extglob@2.1.1: {}
-
-    is-fullwidth-code-point@4.0.0: {}
-
-    is-fullwidth-code-point@5.1.0:
-        dependencies:
-            get-east-asian-width: 1.6.0
-
-    is-glob@4.0.3:
-        dependencies:
-            is-extglob: 2.1.1
-
-    is-hexadecimal@2.0.1: {}
-
-    is-number@7.0.0: {}
-
-    is-plain-obj@4.1.0: {}
-
-    is-plain-object@2.0.4:
-        dependencies:
-            isobject: 3.0.1
-
-    is-safe-filename@0.1.1: {}
-
-    is-stream@3.0.0: {}
-
-    isexe@2.0.0: {}
-
-    isobject@3.0.1: {}
-
-    jiti@1.21.7: {}
-
-    jiti@2.7.0: {}
-
-    jose@6.2.3: {}
-
-    js-tokens@4.0.0: {}
-
-    jsbi@4.3.2: {}
-
-    jscodeshift@17.3.0:
-        dependencies:
-            '@babel/core': 7.29.7
-            '@babel/parser': 7.29.7
-            '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
-            '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
-            '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
-            '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)
-            '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7)
-            '@babel/preset-flow': 7.29.7(@babel/core@7.29.7)
-            '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
-            '@babel/register': 7.29.7(@babel/core@7.29.7)
-            flow-parser: 0.318.0
-            graceful-fs: 4.2.11
-            micromatch: 4.0.8
-            neo-async: 2.6.2
-            picocolors: 1.1.1
-            recast: 0.23.11
-            tmp: 0.2.7
-            write-file-atomic: 5.0.1
-        transitivePeerDependencies:
-            - supports-color
-
-    jsesc@3.1.0: {}
-
-    json5@2.2.3: {}
-
-    jsonc-parser@3.3.1: {}
-
-    kind-of@6.0.3: {}
-
-    kysely@0.29.2: {}
-
-    lightningcss-android-arm64@1.32.0:
-        optional: true
-
-    lightningcss-darwin-arm64@1.32.0:
-        optional: true
-
-    lightningcss-darwin-x64@1.32.0:
-        optional: true
-
-    lightningcss-freebsd-x64@1.32.0:
-        optional: true
-
-    lightningcss-linux-arm-gnueabihf@1.32.0:
-        optional: true
-
-    lightningcss-linux-arm64-gnu@1.32.0:
-        optional: true
-
-    lightningcss-linux-arm64-musl@1.32.0:
-        optional: true
-
-    lightningcss-linux-x64-gnu@1.32.0:
-        optional: true
-
-    lightningcss-linux-x64-musl@1.32.0:
-        optional: true
-
-    lightningcss-win32-arm64-msvc@1.32.0:
-        optional: true
-
-    lightningcss-win32-x64-msvc@1.32.0:
-        optional: true
-
-    lightningcss@1.32.0:
-        dependencies:
-            detect-libc: 2.1.2
-        optionalDependencies:
-            lightningcss-android-arm64: 1.32.0
-            lightningcss-darwin-arm64: 1.32.0
-            lightningcss-darwin-x64: 1.32.0
-            lightningcss-freebsd-x64: 1.32.0
-            lightningcss-linux-arm-gnueabihf: 1.32.0
-            lightningcss-linux-arm64-gnu: 1.32.0
-            lightningcss-linux-arm64-musl: 1.32.0
-            lightningcss-linux-x64-gnu: 1.32.0
-            lightningcss-linux-x64-musl: 1.32.0
-            lightningcss-win32-arm64-msvc: 1.32.0
-            lightningcss-win32-x64-msvc: 1.32.0
-
-    lilconfig@3.1.3: {}
-
-    lines-and-columns@1.2.4: {}
-
-    linkify-it@5.0.1:
-        dependencies:
-            uc.micro: 2.1.0
-
-    linkifyjs@4.3.3: {}
-
-    lint-staged@15.5.2:
-        dependencies:
-            chalk: 5.6.2
-            commander: 13.1.0
-            debug: 4.4.3
-            execa: 8.0.1
-            lilconfig: 3.1.3
-            listr2: 8.3.3
-            micromatch: 4.0.8
-            pidtree: 0.6.1
-            string-argv: 0.3.2
-            yaml: 2.9.0
-        transitivePeerDependencies:
-            - supports-color
-
-    listr2@8.3.3:
-        dependencies:
-            cli-truncate: 4.0.0
-            colorette: 2.0.20
-            eventemitter3: 5.0.4
-            log-update: 6.1.0
-            rfdc: 1.4.1
-            wrap-ansi: 9.0.2
-
-    lit-element@4.2.2:
-        dependencies:
-            '@lit-labs/ssr-dom-shim': 1.6.0
-            '@lit/reactive-element': 2.1.2
-            lit-html: 3.3.3
-
-    lit-html@3.3.3:
-        dependencies:
-            '@types/trusted-types': 2.0.7
-
-    lit@3.3.3:
-        dependencies:
-            '@lit/reactive-element': 2.1.2
-            lit-element: 4.2.2
-            lit-html: 3.3.3
-
-    locate-path@3.0.0:
-        dependencies:
-            p-locate: 3.0.0
-            path-exists: 3.0.0
-
-    lodash.memoize@4.1.2: {}
-
-    lodash.uniq@4.5.0: {}
-
-    log-update@6.1.0:
-        dependencies:
-            ansi-escapes: 7.3.0
-            cli-cursor: 5.0.0
-            slice-ansi: 7.1.2
-            strip-ansi: 7.2.0
-            wrap-ansi: 9.0.2
-
-    longest-streak@3.1.0: {}
-
-    lru-cache@5.1.1:
-        dependencies:
-            yallist: 3.1.1
-
-    lz-string@1.5.0: {}
-
-    magic-string@0.30.21:
-        dependencies:
-            '@jridgewell/sourcemap-codec': 1.5.5
-
-    make-dir@2.1.0:
-        dependencies:
-            pify: 4.0.1
-            semver: 5.7.2
-
-    markdown-extensions@2.0.0: {}
-
-    markdown-it-task-lists@2.1.1: {}
-
-    markdown-it@14.2.0:
-        dependencies:
-            argparse: 2.0.1
-            entities: 4.5.0
-            linkify-it: 5.0.1
-            mdurl: 2.0.0
-            punycode.js: 2.3.1
-            uc.micro: 2.1.0
-
-    markdown-table@3.0.4: {}
-
-    mdast-util-find-and-replace@3.0.2:
-        dependencies:
-            '@types/mdast': 4.0.4
-            escape-string-regexp: 5.0.0
-            unist-util-is: 6.0.1
-            unist-util-visit-parents: 6.0.2
-
-    mdast-util-from-markdown@2.0.3:
-        dependencies:
-            '@types/mdast': 4.0.4
-            '@types/unist': 3.0.3
-            decode-named-character-reference: 1.3.0
-            devlop: 1.1.0
-            mdast-util-to-string: 4.0.0
-            micromark: 4.0.2
-            micromark-util-decode-numeric-character-reference: 2.0.2
-            micromark-util-decode-string: 2.0.1
-            micromark-util-normalize-identifier: 2.0.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-            unist-util-stringify-position: 4.0.0
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-gfm-autolink-literal@2.0.1:
-        dependencies:
-            '@types/mdast': 4.0.4
-            ccount: 2.0.1
-            devlop: 1.1.0
-            mdast-util-find-and-replace: 3.0.2
-            micromark-util-character: 2.1.1
-
-    mdast-util-gfm-footnote@2.1.0:
-        dependencies:
-            '@types/mdast': 4.0.4
-            devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.3
-            mdast-util-to-markdown: 2.1.2
-            micromark-util-normalize-identifier: 2.0.1
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-gfm-strikethrough@2.0.0:
-        dependencies:
-            '@types/mdast': 4.0.4
-            mdast-util-from-markdown: 2.0.3
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-gfm-table@2.0.0:
-        dependencies:
-            '@types/mdast': 4.0.4
-            devlop: 1.1.0
-            markdown-table: 3.0.4
-            mdast-util-from-markdown: 2.0.3
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-gfm-task-list-item@2.0.0:
-        dependencies:
-            '@types/mdast': 4.0.4
-            devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.3
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-gfm@3.1.0:
-        dependencies:
-            mdast-util-from-markdown: 2.0.3
-            mdast-util-gfm-autolink-literal: 2.0.1
-            mdast-util-gfm-footnote: 2.1.0
-            mdast-util-gfm-strikethrough: 2.0.0
-            mdast-util-gfm-table: 2.0.0
-            mdast-util-gfm-task-list-item: 2.0.0
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-mdx-expression@2.0.1:
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            '@types/hast': 3.0.4
-            '@types/mdast': 4.0.4
-            devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.3
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-mdx-jsx@3.2.0:
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            '@types/hast': 3.0.4
-            '@types/mdast': 4.0.4
-            '@types/unist': 3.0.3
-            ccount: 2.0.1
-            devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.3
-            mdast-util-to-markdown: 2.1.2
-            parse-entities: 4.0.2
-            stringify-entities: 4.0.4
-            unist-util-stringify-position: 4.0.0
-            vfile-message: 4.0.3
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-mdx@3.0.0:
-        dependencies:
-            mdast-util-from-markdown: 2.0.3
-            mdast-util-mdx-expression: 2.0.1
-            mdast-util-mdx-jsx: 3.2.0
-            mdast-util-mdxjs-esm: 2.0.1
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-mdxjs-esm@2.0.1:
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            '@types/hast': 3.0.4
-            '@types/mdast': 4.0.4
-            devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.3
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-phrasing@4.1.0:
-        dependencies:
-            '@types/mdast': 4.0.4
-            unist-util-is: 6.0.1
-
-    mdast-util-to-hast@13.2.1:
-        dependencies:
-            '@types/hast': 3.0.4
-            '@types/mdast': 4.0.4
-            '@ungap/structured-clone': 1.3.1
-            devlop: 1.1.0
-            micromark-util-sanitize-uri: 2.0.1
-            trim-lines: 3.0.1
-            unist-util-position: 5.0.0
-            unist-util-visit: 5.1.0
-            vfile: 6.0.3
-
-    mdast-util-to-markdown@2.1.2:
-        dependencies:
-            '@types/mdast': 4.0.4
-            '@types/unist': 3.0.3
-            longest-streak: 3.1.0
-            mdast-util-phrasing: 4.1.0
-            mdast-util-to-string: 4.0.0
-            micromark-util-classify-character: 2.0.1
-            micromark-util-decode-string: 2.0.1
-            unist-util-visit: 5.1.0
-            zwitch: 2.0.4
-
-    mdast-util-to-string@4.0.0:
-        dependencies:
-            '@types/mdast': 4.0.4
-
-    mdn-data@2.0.28: {}
-
-    mdn-data@2.27.1: {}
-
-    mdurl@2.0.0: {}
-
-    merge-stream@2.0.0: {}
-
-    merge2@1.4.1: {}
-
-    micromark-core-commonmark@2.0.3:
-        dependencies:
-            decode-named-character-reference: 1.3.0
-            devlop: 1.1.0
-            micromark-factory-destination: 2.0.1
-            micromark-factory-label: 2.0.1
-            micromark-factory-space: 2.0.1
-            micromark-factory-title: 2.0.1
-            micromark-factory-whitespace: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-chunked: 2.0.1
-            micromark-util-classify-character: 2.0.1
-            micromark-util-html-tag-name: 2.0.1
-            micromark-util-normalize-identifier: 2.0.1
-            micromark-util-resolve-all: 2.0.1
-            micromark-util-subtokenize: 2.1.0
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm-autolink-literal@2.1.0:
-        dependencies:
-            micromark-util-character: 2.1.1
-            micromark-util-sanitize-uri: 2.0.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm-footnote@2.1.0:
-        dependencies:
-            devlop: 1.1.0
-            micromark-core-commonmark: 2.0.3
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-normalize-identifier: 2.0.1
-            micromark-util-sanitize-uri: 2.0.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm-strikethrough@2.1.0:
-        dependencies:
-            devlop: 1.1.0
-            micromark-util-chunked: 2.0.1
-            micromark-util-classify-character: 2.0.1
-            micromark-util-resolve-all: 2.0.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm-table@2.1.1:
-        dependencies:
-            devlop: 1.1.0
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm-tagfilter@2.0.0:
-        dependencies:
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm-task-list-item@2.1.0:
-        dependencies:
-            devlop: 1.1.0
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm@3.0.0:
-        dependencies:
-            micromark-extension-gfm-autolink-literal: 2.1.0
-            micromark-extension-gfm-footnote: 2.1.0
-            micromark-extension-gfm-strikethrough: 2.1.0
-            micromark-extension-gfm-table: 2.1.1
-            micromark-extension-gfm-tagfilter: 2.0.0
-            micromark-extension-gfm-task-list-item: 2.1.0
-            micromark-util-combine-extensions: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-mdx-expression@3.0.1:
-        dependencies:
-            '@types/estree': 1.0.9
-            devlop: 1.1.0
-            micromark-factory-mdx-expression: 2.0.3
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-events-to-acorn: 2.0.3
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-mdx-jsx@3.0.2:
-        dependencies:
-            '@types/estree': 1.0.9
-            devlop: 1.1.0
-            estree-util-is-identifier-name: 3.0.0
-            micromark-factory-mdx-expression: 2.0.3
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-events-to-acorn: 2.0.3
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-            vfile-message: 4.0.3
-
-    micromark-extension-mdx-md@2.0.0:
-        dependencies:
-            micromark-util-types: 2.0.2
-
-    micromark-extension-mdxjs-esm@3.0.0:
-        dependencies:
-            '@types/estree': 1.0.9
-            devlop: 1.1.0
-            micromark-core-commonmark: 2.0.3
-            micromark-util-character: 2.1.1
-            micromark-util-events-to-acorn: 2.0.3
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-            unist-util-position-from-estree: 2.0.0
-            vfile-message: 4.0.3
-
-    micromark-extension-mdxjs@3.0.0:
-        dependencies:
-            acorn: 8.17.0
-            acorn-jsx: 5.3.2(acorn@8.17.0)
-            micromark-extension-mdx-expression: 3.0.1
-            micromark-extension-mdx-jsx: 3.0.2
-            micromark-extension-mdx-md: 2.0.0
-            micromark-extension-mdxjs-esm: 3.0.0
-            micromark-util-combine-extensions: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-factory-destination@2.0.1:
-        dependencies:
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-factory-label@2.0.1:
-        dependencies:
-            devlop: 1.1.0
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-factory-mdx-expression@2.0.3:
-        dependencies:
-            '@types/estree': 1.0.9
-            devlop: 1.1.0
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-events-to-acorn: 2.0.3
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-            unist-util-position-from-estree: 2.0.0
-            vfile-message: 4.0.3
-
-    micromark-factory-space@2.0.1:
-        dependencies:
-            micromark-util-character: 2.1.1
-            micromark-util-types: 2.0.2
-
-    micromark-factory-title@2.0.1:
-        dependencies:
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-factory-whitespace@2.0.1:
-        dependencies:
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-util-character@2.1.1:
-        dependencies:
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-util-chunked@2.0.1:
-        dependencies:
-            micromark-util-symbol: 2.0.1
-
-    micromark-util-classify-character@2.0.1:
-        dependencies:
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-util-combine-extensions@2.0.1:
-        dependencies:
-            micromark-util-chunked: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-util-decode-numeric-character-reference@2.0.2:
-        dependencies:
-            micromark-util-symbol: 2.0.1
-
-    micromark-util-decode-string@2.0.1:
-        dependencies:
-            decode-named-character-reference: 1.3.0
-            micromark-util-character: 2.1.1
-            micromark-util-decode-numeric-character-reference: 2.0.2
-            micromark-util-symbol: 2.0.1
-
-    micromark-util-encode@2.0.1: {}
-
-    micromark-util-events-to-acorn@2.0.3:
-        dependencies:
-            '@types/estree': 1.0.9
-            '@types/unist': 3.0.3
-            devlop: 1.1.0
-            estree-util-visit: 2.0.0
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-            vfile-message: 4.0.3
-
-    micromark-util-html-tag-name@2.0.1: {}
-
-    micromark-util-normalize-identifier@2.0.1:
-        dependencies:
-            micromark-util-symbol: 2.0.1
-
-    micromark-util-resolve-all@2.0.1:
-        dependencies:
-            micromark-util-types: 2.0.2
-
-    micromark-util-sanitize-uri@2.0.1:
-        dependencies:
-            micromark-util-character: 2.1.1
-            micromark-util-encode: 2.0.1
-            micromark-util-symbol: 2.0.1
-
-    micromark-util-subtokenize@2.1.0:
-        dependencies:
-            devlop: 1.1.0
-            micromark-util-chunked: 2.0.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-util-symbol@2.0.1: {}
-
-    micromark-util-types@2.0.2: {}
-
-    micromark@4.0.2:
-        dependencies:
-            '@types/debug': 4.1.13
-            debug: 4.4.3
-            decode-named-character-reference: 1.3.0
-            devlop: 1.1.0
-            micromark-core-commonmark: 2.0.3
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-chunked: 2.0.1
-            micromark-util-combine-extensions: 2.0.1
-            micromark-util-decode-numeric-character-reference: 2.0.2
-            micromark-util-encode: 2.0.1
-            micromark-util-normalize-identifier: 2.0.1
-            micromark-util-resolve-all: 2.0.1
-            micromark-util-sanitize-uri: 2.0.1
-            micromark-util-subtokenize: 2.1.0
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-        transitivePeerDependencies:
-            - supports-color
-
-    micromatch@4.0.8:
-        dependencies:
-            braces: 3.0.3
-            picomatch: 2.3.2
-
-    mimic-fn@4.0.0: {}
-
-    mimic-function@5.0.1: {}
-
-    mitata@1.0.34: {}
-
-    morphdom@2.7.8: {}
-
-    mrmime@2.0.1: {}
-
-    ms@2.1.3: {}
-
-    mz@2.7.0:
-        dependencies:
-            any-promise: 1.3.0
-            object-assign: 4.1.1
-            thenify-all: 1.6.0
-
-    nanoid@3.3.12: {}
-
-    nanostores@1.3.0: {}
-
-    neo-async@2.6.2: {}
-
-    node-domexception@1.0.0: {}
-
-    node-fetch-native@1.6.7: {}
-
-    node-fetch@3.3.2:
-        dependencies:
-            data-uri-to-buffer: 4.0.1
-            fetch-blob: 3.2.0
-            formdata-polyfill: 4.0.10
-
-    node-releases@2.0.47: {}
-
-    normalize-path@3.0.0: {}
-
-    npm-run-path@5.3.0:
-        dependencies:
-            path-key: 4.0.0
-
-    nth-check@2.1.1:
-        dependencies:
-            boolbase: 1.0.0
-
-    nypm@0.6.7:
-        dependencies:
-            citty: 0.2.2
-            pathe: 2.0.3
-            tinyexec: 1.2.4
-
-    object-assign@4.1.1: {}
-
-    object-hash@3.0.0: {}
-
-    obug@2.1.3: {}
-
-    onetime@6.0.0:
-        dependencies:
-            mimic-fn: 4.0.0
-
-    onetime@7.0.0:
-        dependencies:
-            mimic-function: 5.0.1
-
-    oniguruma-parser@0.12.2: {}
-
-    oniguruma-to-es@2.3.0:
-        dependencies:
-            emoji-regex-xs: 1.0.0
-            regex: 5.1.1
-            regex-recursion: 5.1.1
-
-    oniguruma-to-es@4.3.6:
-        dependencies:
-            oniguruma-parser: 0.12.2
-            regex: 6.1.0
-            regex-recursion: 6.0.2
-
-    orderedmap@2.1.1: {}
-
-    oxc-parser@0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1):
-        dependencies:
-            '@oxc-project/types': 0.124.0
-        optionalDependencies:
-            '@oxc-parser/binding-android-arm-eabi': 0.124.0
-            '@oxc-parser/binding-android-arm64': 0.124.0
-            '@oxc-parser/binding-darwin-arm64': 0.124.0
-            '@oxc-parser/binding-darwin-x64': 0.124.0
-            '@oxc-parser/binding-freebsd-x64': 0.124.0
-            '@oxc-parser/binding-linux-arm-gnueabihf': 0.124.0
-            '@oxc-parser/binding-linux-arm-musleabihf': 0.124.0
-            '@oxc-parser/binding-linux-arm64-gnu': 0.124.0
-            '@oxc-parser/binding-linux-arm64-musl': 0.124.0
-            '@oxc-parser/binding-linux-ppc64-gnu': 0.124.0
-            '@oxc-parser/binding-linux-riscv64-gnu': 0.124.0
-            '@oxc-parser/binding-linux-riscv64-musl': 0.124.0
-            '@oxc-parser/binding-linux-s390x-gnu': 0.124.0
-            '@oxc-parser/binding-linux-x64-gnu': 0.124.0
-            '@oxc-parser/binding-linux-x64-musl': 0.124.0
-            '@oxc-parser/binding-openharmony-arm64': 0.124.0
-            '@oxc-parser/binding-wasm32-wasi': 0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
-            '@oxc-parser/binding-win32-arm64-msvc': 0.124.0
-            '@oxc-parser/binding-win32-ia32-msvc': 0.124.0
-            '@oxc-parser/binding-win32-x64-msvc': 0.124.0
-        transitivePeerDependencies:
-            - '@emnapi/core'
-            - '@emnapi/runtime'
-
-    oxc-transform@0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1):
-        optionalDependencies:
-            '@oxc-transform/binding-android-arm-eabi': 0.124.0
-            '@oxc-transform/binding-android-arm64': 0.124.0
-            '@oxc-transform/binding-darwin-arm64': 0.124.0
-            '@oxc-transform/binding-darwin-x64': 0.124.0
-            '@oxc-transform/binding-freebsd-x64': 0.124.0
-            '@oxc-transform/binding-linux-arm-gnueabihf': 0.124.0
-            '@oxc-transform/binding-linux-arm-musleabihf': 0.124.0
-            '@oxc-transform/binding-linux-arm64-gnu': 0.124.0
-            '@oxc-transform/binding-linux-arm64-musl': 0.124.0
-            '@oxc-transform/binding-linux-ppc64-gnu': 0.124.0
-            '@oxc-transform/binding-linux-riscv64-gnu': 0.124.0
-            '@oxc-transform/binding-linux-riscv64-musl': 0.124.0
-            '@oxc-transform/binding-linux-s390x-gnu': 0.124.0
-            '@oxc-transform/binding-linux-x64-gnu': 0.124.0
-            '@oxc-transform/binding-linux-x64-musl': 0.124.0
-            '@oxc-transform/binding-openharmony-arm64': 0.124.0
-            '@oxc-transform/binding-wasm32-wasi': 0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
-            '@oxc-transform/binding-win32-arm64-msvc': 0.124.0
-            '@oxc-transform/binding-win32-ia32-msvc': 0.124.0
-            '@oxc-transform/binding-win32-x64-msvc': 0.124.0
-        transitivePeerDependencies:
-            - '@emnapi/core'
-            - '@emnapi/runtime'
-
-    oxlint@1.69.0:
-        optionalDependencies:
-            '@oxlint/binding-android-arm-eabi': 1.69.0
-            '@oxlint/binding-android-arm64': 1.69.0
-            '@oxlint/binding-darwin-arm64': 1.69.0
-            '@oxlint/binding-darwin-x64': 1.69.0
-            '@oxlint/binding-freebsd-x64': 1.69.0
-            '@oxlint/binding-linux-arm-gnueabihf': 1.69.0
-            '@oxlint/binding-linux-arm-musleabihf': 1.69.0
-            '@oxlint/binding-linux-arm64-gnu': 1.69.0
-            '@oxlint/binding-linux-arm64-musl': 1.69.0
-            '@oxlint/binding-linux-ppc64-gnu': 1.69.0
-            '@oxlint/binding-linux-riscv64-gnu': 1.69.0
-            '@oxlint/binding-linux-riscv64-musl': 1.69.0
-            '@oxlint/binding-linux-s390x-gnu': 1.69.0
-            '@oxlint/binding-linux-x64-gnu': 1.69.0
-            '@oxlint/binding-linux-x64-musl': 1.69.0
-            '@oxlint/binding-openharmony-arm64': 1.69.0
-            '@oxlint/binding-win32-arm64-msvc': 1.69.0
-            '@oxlint/binding-win32-ia32-msvc': 1.69.0
-            '@oxlint/binding-win32-x64-msvc': 1.69.0
-
-    p-limit@2.3.0:
-        dependencies:
-            p-try: 2.2.0
-
-    p-locate@3.0.0:
-        dependencies:
-            p-limit: 2.3.0
-
-    p-try@2.2.0: {}
-
-    parse-entities@4.0.2:
-        dependencies:
-            '@types/unist': 2.0.11
-            character-entities-legacy: 3.0.0
-            character-reference-invalid: 2.0.1
-            decode-named-character-reference: 1.3.0
-            is-alphanumerical: 2.0.1
-            is-decimal: 2.0.1
-            is-hexadecimal: 2.0.1
-
-    parse-numeric-range@1.3.0: {}
-
-    parse5@7.3.0:
-        dependencies:
-            entities: 6.0.1
-
-    path-exists@3.0.0: {}
-
-    path-key@3.1.1: {}
-
-    path-key@4.0.0: {}
-
-    path-parse@1.0.7: {}
-
-    pathe@2.0.3: {}
-
-    picocolors@1.1.1: {}
-
-    picomatch@2.3.2: {}
-
-    picomatch@4.0.4: {}
-
-    pidtree@0.6.1: {}
-
-    pify@2.3.0: {}
-
-    pify@4.0.1: {}
-
-    pirates@4.0.7: {}
-
-    pkg-dir@3.0.0:
-        dependencies:
-            find-up: 3.0.0
-
-    playwright-core@1.60.0: {}
-
-    playwright@1.60.0:
-        dependencies:
-            playwright-core: 1.60.0
-        optionalDependencies:
-            fsevents: 2.3.2
-
-    pngjs@7.0.0: {}
-
-    postcss-calc@10.1.1(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-selector-parser: 7.1.4
-            postcss-value-parser: 4.2.0
-
-    postcss-colormin@7.0.10(postcss@8.5.15):
-        dependencies:
-            '@colordx/core': 5.4.3
-            browserslist: 4.28.2
-            caniuse-api: 3.0.0
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-convert-values@7.0.12(postcss@8.5.15):
-        dependencies:
-            browserslist: 4.28.2
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-discard-comments@7.0.8(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-selector-parser: 7.1.4
-
-    postcss-discard-duplicates@7.0.4(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-
-    postcss-discard-empty@7.0.3(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-
-    postcss-discard-overridden@7.0.3(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-
-    postcss-import@15.1.0(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-            read-cache: 1.0.0
-            resolve: 1.22.12
-
-    postcss-import@16.1.1(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-            read-cache: 1.0.0
-            resolve: 1.22.12
-
-    postcss-js@4.1.0(postcss@8.5.15):
-        dependencies:
-            camelcase-css: 2.0.1
-            postcss: 8.5.15
-
-    postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.9.0):
-        dependencies:
-            lilconfig: 3.1.3
-        optionalDependencies:
-            jiti: 1.21.7
-            postcss: 8.5.15
-            tsx: 4.22.4
-            yaml: 2.9.0
-
-    postcss-merge-longhand@7.0.7(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-            stylehacks: 7.0.11(postcss@8.5.15)
-
-    postcss-merge-rules@7.0.11(postcss@8.5.15):
-        dependencies:
-            browserslist: 4.28.2
-            caniuse-api: 3.0.0
-            cssnano-utils: 5.0.3(postcss@8.5.15)
-            postcss: 8.5.15
-            postcss-selector-parser: 7.1.4
-
-    postcss-minify-font-values@7.0.3(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-minify-gradients@7.0.5(postcss@8.5.15):
-        dependencies:
-            '@colordx/core': 5.4.3
-            cssnano-utils: 5.0.3(postcss@8.5.15)
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-minify-params@7.0.9(postcss@8.5.15):
-        dependencies:
-            browserslist: 4.28.2
-            cssnano-utils: 5.0.3(postcss@8.5.15)
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-minify-selectors@7.1.2(postcss@8.5.15):
-        dependencies:
-            browserslist: 4.28.2
-            caniuse-api: 3.0.0
-            cssesc: 3.0.0
-            postcss: 8.5.15
-            postcss-selector-parser: 7.1.4
-
-    postcss-nested@6.2.0(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-selector-parser: 6.1.4
-
-    postcss-nested@7.0.2(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-selector-parser: 7.1.4
-
-    postcss-normalize-charset@7.0.3(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-
-    postcss-normalize-display-values@7.0.3(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-positions@7.0.4(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-repeat-style@7.0.4(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-string@7.0.3(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-timing-functions@7.0.3(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-unicode@7.0.9(postcss@8.5.15):
-        dependencies:
-            browserslist: 4.28.2
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-url@7.0.3(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-whitespace@7.0.3(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-ordered-values@7.0.4(postcss@8.5.15):
-        dependencies:
-            cssnano-utils: 5.0.3(postcss@8.5.15)
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-reduce-initial@7.0.9(postcss@8.5.15):
-        dependencies:
-            browserslist: 4.28.2
-            caniuse-api: 3.0.0
-            postcss: 8.5.15
-
-    postcss-reduce-transforms@7.0.3(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-
-    postcss-selector-parser@6.1.4:
-        dependencies:
-            cssesc: 3.0.0
-            util-deprecate: 1.0.2
-
-    postcss-selector-parser@7.1.4:
-        dependencies:
-            cssesc: 3.0.0
-            util-deprecate: 1.0.2
-
-    postcss-simple-vars@7.0.1(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-
-    postcss-svgo@7.1.3(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-value-parser: 4.2.0
-            svgo: 4.0.1
-
-    postcss-unique-selectors@7.0.7(postcss@8.5.15):
-        dependencies:
-            postcss: 8.5.15
-            postcss-selector-parser: 7.1.4
-
-    postcss-value-parser@4.2.0: {}
-
-    postcss@8.5.15:
-        dependencies:
-            nanoid: 3.3.12
-            picocolors: 1.1.1
-            source-map-js: 1.2.1
-
-    prettier@3.8.4: {}
-
-    pretty-format@27.5.1:
-        dependencies:
-            ansi-regex: 5.0.1
-            ansi-styles: 5.2.0
-            react-is: 17.0.2
-
-    property-information@7.2.0: {}
-
-    prosemirror-changeset@2.4.1:
-        dependencies:
-            prosemirror-transform: 1.12.0
-
-    prosemirror-commands@1.7.1:
-        dependencies:
-            prosemirror-model: 1.25.8
-            prosemirror-state: 1.4.4
-            prosemirror-transform: 1.12.0
-
-    prosemirror-dropcursor@1.8.2:
-        dependencies:
-            prosemirror-state: 1.4.4
-            prosemirror-transform: 1.12.0
-            prosemirror-view: 1.41.9
-
-    prosemirror-gapcursor@1.4.1:
-        dependencies:
-            prosemirror-keymap: 1.2.3
-            prosemirror-model: 1.25.8
-            prosemirror-state: 1.4.4
-            prosemirror-view: 1.41.9
-
-    prosemirror-history@1.5.0:
-        dependencies:
-            prosemirror-state: 1.4.4
-            prosemirror-transform: 1.12.0
-            prosemirror-view: 1.41.9
-            rope-sequence: 1.3.4
-
-    prosemirror-inputrules@1.5.1:
-        dependencies:
-            prosemirror-state: 1.4.4
-            prosemirror-transform: 1.12.0
-
-    prosemirror-keymap@1.2.3:
-        dependencies:
-            prosemirror-state: 1.4.4
-            w3c-keyname: 2.2.8
-
-    prosemirror-markdown@1.13.4:
-        dependencies:
-            '@types/markdown-it': 14.1.2
-            markdown-it: 14.2.0
-            prosemirror-model: 1.25.8
-
-    prosemirror-model@1.25.8:
-        dependencies:
-            orderedmap: 2.1.1
-
-    prosemirror-schema-list@1.5.1:
-        dependencies:
-            prosemirror-model: 1.25.8
-            prosemirror-state: 1.4.4
-            prosemirror-transform: 1.12.0
-
-    prosemirror-state@1.4.4:
-        dependencies:
-            prosemirror-model: 1.25.8
-            prosemirror-transform: 1.12.0
-            prosemirror-view: 1.41.9
-
-    prosemirror-tables@1.8.5:
-        dependencies:
-            prosemirror-keymap: 1.2.3
-            prosemirror-model: 1.25.8
-            prosemirror-state: 1.4.4
-            prosemirror-transform: 1.12.0
-            prosemirror-view: 1.41.9
-
-    prosemirror-transform@1.12.0:
-        dependencies:
-            prosemirror-model: 1.25.8
-
-    prosemirror-view@1.41.9:
-        dependencies:
-            prosemirror-model: 1.25.8
-            prosemirror-state: 1.4.4
-            prosemirror-transform: 1.12.0
-
-    punycode.js@2.3.1: {}
-
-    queue-microtask@1.2.3: {}
-
-    react-aria-components@1.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-        dependencies:
-            '@internationalized/date': 3.12.2
-            '@react-types/shared': 3.35.0(react@19.2.7)
-            '@swc/helpers': 0.5.23
-            client-only: 0.0.1
-            react: 19.2.7
-            react-aria: 3.49.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-            react-dom: 19.2.7(react@19.2.7)
-            react-stately: 3.47.0(react@19.2.7)
-
-    react-aria@3.49.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-        dependencies:
-            '@internationalized/date': 3.12.2
-            '@internationalized/number': 3.6.7
-            '@internationalized/string': 3.2.9
-            '@react-types/shared': 3.35.0(react@19.2.7)
-            '@swc/helpers': 0.5.23
-            aria-hidden: 1.2.6
-            clsx: 2.1.1
-            react: 19.2.7
-            react-dom: 19.2.7(react@19.2.7)
-            react-stately: 3.47.0(react@19.2.7)
-            use-sync-external-store: 1.6.0(react@19.2.7)
-
-    react-dom@19.2.7(react@19.2.7):
-        dependencies:
-            react: 19.2.7
-            scheduler: 0.27.0
-
-    react-is@17.0.2: {}
-
-    react-stately@3.47.0(react@19.2.7):
-        dependencies:
-            '@internationalized/date': 3.12.2
-            '@internationalized/number': 3.6.7
-            '@internationalized/string': 3.2.9
-            '@react-types/shared': 3.35.0(react@19.2.7)
-            '@swc/helpers': 0.5.23
-            react: 19.2.7
-            use-sync-external-store: 1.6.0(react@19.2.7)
-
-    react@19.2.7: {}
-
-    read-cache@1.0.0:
-        dependencies:
-            pify: 2.3.0
-
-    readdirp@3.6.0:
-        dependencies:
-            picomatch: 2.3.2
-
-    readdirp@5.0.0: {}
-
-    recast@0.23.11:
-        dependencies:
-            ast-types: 0.16.1
-            esprima: 4.0.1
-            source-map: 0.6.1
-            tiny-invariant: 1.3.3
-            tslib: 2.8.1
-
-    recma-build-jsx@1.0.0:
-        dependencies:
-            '@types/estree': 1.0.9
-            estree-util-build-jsx: 3.0.1
-            vfile: 6.0.3
-
-    recma-jsx@1.0.1(acorn@8.17.0):
-        dependencies:
-            acorn: 8.17.0
-            acorn-jsx: 5.3.2(acorn@8.17.0)
-            estree-util-to-js: 2.0.0
-            recma-parse: 1.0.0
-            recma-stringify: 1.0.0
-            unified: 11.0.5
-
-    recma-parse@1.0.0:
-        dependencies:
-            '@types/estree': 1.0.9
-            esast-util-from-js: 2.0.1
-            unified: 11.0.5
-            vfile: 6.0.3
-
-    recma-stringify@1.0.0:
-        dependencies:
-            '@types/estree': 1.0.9
-            estree-util-to-js: 2.0.0
-            unified: 11.0.5
-            vfile: 6.0.3
-
-    regex-recursion@5.1.1:
-        dependencies:
-            regex: 5.1.1
-            regex-utilities: 2.3.0
-
-    regex-recursion@6.0.2:
-        dependencies:
-            regex-utilities: 2.3.0
-
-    regex-utilities@2.3.0: {}
-
-    regex@5.1.1:
-        dependencies:
-            regex-utilities: 2.3.0
-
-    regex@6.1.0:
-        dependencies:
-            regex-utilities: 2.3.0
-
-    rehype-parse@9.0.1:
-        dependencies:
-            '@types/hast': 3.0.4
-            hast-util-from-html: 2.0.3
-            unified: 11.0.5
-
-    rehype-pretty-code@0.14.3(shiki@3.23.0):
-        dependencies:
-            '@types/hast': 3.0.4
-            hast-util-to-string: 3.0.1
-            parse-numeric-range: 1.3.0
-            rehype-parse: 9.0.1
-            shiki: 3.23.0
-            unified: 11.0.5
-            unist-util-visit: 5.1.0
-
-    rehype-raw@7.0.0:
-        dependencies:
-            '@types/hast': 3.0.4
-            hast-util-raw: 9.1.0
-            vfile: 6.0.3
-
-    rehype-recma@1.0.0:
-        dependencies:
-            '@types/estree': 1.0.9
-            '@types/hast': 3.0.4
-            hast-util-to-estree: 3.1.3
-        transitivePeerDependencies:
-            - supports-color
-
-    rehype-stringify@10.0.1:
-        dependencies:
-            '@types/hast': 3.0.4
-            hast-util-to-html: 9.0.5
-            unified: 11.0.5
-
-    rehype@13.0.2:
-        dependencies:
-            '@types/hast': 3.0.4
-            rehype-parse: 9.0.1
-            rehype-stringify: 10.0.1
-            unified: 11.0.5
-
-    remark-gfm@4.0.1:
-        dependencies:
-            '@types/mdast': 4.0.4
-            mdast-util-gfm: 3.1.0
-            micromark-extension-gfm: 3.0.0
-            remark-parse: 11.0.0
-            remark-stringify: 11.0.0
-            unified: 11.0.5
-        transitivePeerDependencies:
-            - supports-color
-
-    remark-mdx@3.1.1:
-        dependencies:
-            mdast-util-mdx: 3.0.0
-            micromark-extension-mdxjs: 3.0.0
-        transitivePeerDependencies:
-            - supports-color
-
-    remark-parse@11.0.0:
-        dependencies:
-            '@types/mdast': 4.0.4
-            mdast-util-from-markdown: 2.0.3
-            micromark-util-types: 2.0.2
-            unified: 11.0.5
-        transitivePeerDependencies:
-            - supports-color
-
-    remark-rehype@11.1.2:
-        dependencies:
-            '@types/hast': 3.0.4
-            '@types/mdast': 4.0.4
-            mdast-util-to-hast: 13.2.1
-            unified: 11.0.5
-            vfile: 6.0.3
-
-    remark-stringify@11.0.0:
-        dependencies:
-            '@types/mdast': 4.0.4
-            mdast-util-to-markdown: 2.1.2
-            unified: 11.0.5
-
-    resolve-pkg-maps@1.0.0: {}
-
-    resolve@1.22.12:
-        dependencies:
-            es-errors: 1.3.0
-            is-core-module: 2.16.2
-            path-parse: 1.0.7
-            supports-preserve-symlinks-flag: 1.0.0
-
-    restore-cursor@5.1.0:
-        dependencies:
-            onetime: 7.0.0
-            signal-exit: 4.1.0
-
-    reusify@1.1.0: {}
-
-    rfdc@1.4.1: {}
-
-    rolldown@1.0.0-rc.12(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1):
-        dependencies:
-            '@oxc-project/types': 0.122.0
-            '@rolldown/pluginutils': 1.0.0-rc.12
-        optionalDependencies:
-            '@rolldown/binding-android-arm64': 1.0.0-rc.12
-            '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
-            '@rolldown/binding-darwin-x64': 1.0.0-rc.12
-            '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
-            '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
-            '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
-            '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
-            '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
-            '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
-            '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
-            '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
-            '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-            '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
-            '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
-            '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
-        transitivePeerDependencies:
-            - '@emnapi/core'
-            - '@emnapi/runtime'
-
-    rolldown@1.0.3:
-        dependencies:
-            '@oxc-project/types': 0.133.0
-            '@rolldown/pluginutils': 1.0.1
-        optionalDependencies:
-            '@rolldown/binding-android-arm64': 1.0.3
-            '@rolldown/binding-darwin-arm64': 1.0.3
-            '@rolldown/binding-darwin-x64': 1.0.3
-            '@rolldown/binding-freebsd-x64': 1.0.3
-            '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
-            '@rolldown/binding-linux-arm64-gnu': 1.0.3
-            '@rolldown/binding-linux-arm64-musl': 1.0.3
-            '@rolldown/binding-linux-ppc64-gnu': 1.0.3
-            '@rolldown/binding-linux-s390x-gnu': 1.0.3
-            '@rolldown/binding-linux-x64-gnu': 1.0.3
-            '@rolldown/binding-linux-x64-musl': 1.0.3
-            '@rolldown/binding-openharmony-arm64': 1.0.3
-            '@rolldown/binding-wasm32-wasi': 1.0.3
-            '@rolldown/binding-win32-arm64-msvc': 1.0.3
-            '@rolldown/binding-win32-x64-msvc': 1.0.3
-
-    rolldown@1.1.1:
-        dependencies:
-            '@oxc-project/types': 0.135.0
-            '@rolldown/pluginutils': 1.0.1
-        optionalDependencies:
-            '@rolldown/binding-android-arm64': 1.1.1
-            '@rolldown/binding-darwin-arm64': 1.1.1
-            '@rolldown/binding-darwin-x64': 1.1.1
-            '@rolldown/binding-freebsd-x64': 1.1.1
-            '@rolldown/binding-linux-arm-gnueabihf': 1.1.1
-            '@rolldown/binding-linux-arm64-gnu': 1.1.1
-            '@rolldown/binding-linux-arm64-musl': 1.1.1
-            '@rolldown/binding-linux-ppc64-gnu': 1.1.1
-            '@rolldown/binding-linux-s390x-gnu': 1.1.1
-            '@rolldown/binding-linux-x64-gnu': 1.1.1
-            '@rolldown/binding-linux-x64-musl': 1.1.1
-            '@rolldown/binding-openharmony-arm64': 1.1.1
-            '@rolldown/binding-wasm32-wasi': 1.1.1
-            '@rolldown/binding-win32-arm64-msvc': 1.1.1
-            '@rolldown/binding-win32-x64-msvc': 1.1.1
-
-    rope-sequence@1.3.4: {}
-
-    rou3@0.7.12: {}
-
-    run-parallel@1.2.0:
-        dependencies:
-            queue-microtask: 1.2.3
-
-    sax@1.6.0: {}
-
-    scheduler@0.27.0: {}
-
-    semver@5.7.2: {}
-
-    semver@6.3.1: {}
-
-    semver@7.8.4: {}
-
-    set-cookie-parser@3.1.0: {}
-
-    shallow-clone@3.0.1:
-        dependencies:
-            kind-of: 6.0.3
-
-    sharp@0.34.5:
-        dependencies:
-            '@img/colour': 1.1.0
-            detect-libc: 2.1.2
-            semver: 7.8.4
-        optionalDependencies:
-            '@img/sharp-darwin-arm64': 0.34.5
-            '@img/sharp-darwin-x64': 0.34.5
-            '@img/sharp-libvips-darwin-arm64': 1.2.4
-            '@img/sharp-libvips-darwin-x64': 1.2.4
-            '@img/sharp-libvips-linux-arm': 1.2.4
-            '@img/sharp-libvips-linux-arm64': 1.2.4
-            '@img/sharp-libvips-linux-ppc64': 1.2.4
-            '@img/sharp-libvips-linux-riscv64': 1.2.4
-            '@img/sharp-libvips-linux-s390x': 1.2.4
-            '@img/sharp-libvips-linux-x64': 1.2.4
-            '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-            '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-            '@img/sharp-linux-arm': 0.34.5
-            '@img/sharp-linux-arm64': 0.34.5
-            '@img/sharp-linux-ppc64': 0.34.5
-            '@img/sharp-linux-riscv64': 0.34.5
-            '@img/sharp-linux-s390x': 0.34.5
-            '@img/sharp-linux-x64': 0.34.5
-            '@img/sharp-linuxmusl-arm64': 0.34.5
-            '@img/sharp-linuxmusl-x64': 0.34.5
-            '@img/sharp-wasm32': 0.34.5
-            '@img/sharp-win32-arm64': 0.34.5
-            '@img/sharp-win32-ia32': 0.34.5
-            '@img/sharp-win32-x64': 0.34.5
-
-    shebang-command@2.0.0:
-        dependencies:
-            shebang-regex: 3.0.0
-
-    shebang-regex@3.0.0: {}
-
-    shiki@1.29.2:
-        dependencies:
-            '@shikijs/core': 1.29.2
-            '@shikijs/engine-javascript': 1.29.2
-            '@shikijs/engine-oniguruma': 1.29.2
-            '@shikijs/langs': 1.29.2
-            '@shikijs/themes': 1.29.2
-            '@shikijs/types': 1.29.2
-            '@shikijs/vscode-textmate': 10.0.2
-            '@types/hast': 3.0.4
-
-    shiki@3.23.0:
-        dependencies:
-            '@shikijs/core': 3.23.0
-            '@shikijs/engine-javascript': 3.23.0
-            '@shikijs/engine-oniguruma': 3.23.0
-            '@shikijs/langs': 3.23.0
-            '@shikijs/themes': 3.23.0
-            '@shikijs/types': 3.23.0
-            '@shikijs/vscode-textmate': 10.0.2
-            '@types/hast': 3.0.4
-
-    siginfo@2.0.0: {}
-
-    signal-exit@4.1.0: {}
-
-    sirv@3.0.2:
-        dependencies:
-            '@polka/url': 1.0.0-next.29
-            mrmime: 2.0.1
-            totalist: 3.0.1
-
-    sisteransi@1.0.5: {}
-
-    slice-ansi@5.0.0:
-        dependencies:
-            ansi-styles: 6.2.3
-            is-fullwidth-code-point: 4.0.0
-
-    slice-ansi@7.1.2:
-        dependencies:
-            ansi-styles: 6.2.3
-            is-fullwidth-code-point: 5.1.0
-
-    source-map-js@1.2.1: {}
-
-    source-map-support@0.5.21:
-        dependencies:
-            buffer-from: 1.1.2
-            source-map: 0.6.1
-
-    source-map@0.6.1: {}
-
-    source-map@0.7.6: {}
-
-    space-separated-tokens@2.0.2: {}
-
-    stackback@0.0.2: {}
-
-    std-env@4.1.0: {}
-
-    string-argv@0.3.2: {}
-
-    string-width@7.2.0:
-        dependencies:
-            emoji-regex: 10.6.0
-            get-east-asian-width: 1.6.0
-            strip-ansi: 7.2.0
-
-    stringify-entities@4.0.4:
-        dependencies:
-            character-entities-html4: 2.1.0
-            character-entities-legacy: 3.0.0
-
-    strip-ansi@7.2.0:
-        dependencies:
-            ansi-regex: 6.2.2
-
-    strip-final-newline@3.0.0: {}
-
-    stubborn-fs@2.0.0:
-        dependencies:
-            stubborn-utils: 1.0.2
-
-    stubborn-utils@1.0.2: {}
-
-    style-to-js@1.1.21:
-        dependencies:
-            style-to-object: 1.0.14
-
-    style-to-object@1.0.14:
-        dependencies:
-            inline-style-parser: 0.2.7
-
-    stylehacks@7.0.11(postcss@8.5.15):
-        dependencies:
-            browserslist: 4.28.2
-            postcss: 8.5.15
-            postcss-selector-parser: 7.1.4
-
-    sucrase@3.35.1:
-        dependencies:
-            '@jridgewell/gen-mapping': 0.3.13
-            commander: 4.1.1
-            lines-and-columns: 1.2.4
-            mz: 2.7.0
-            pirates: 4.0.7
-            tinyglobby: 0.2.17
-            ts-interface-checker: 0.1.13
-
-    supports-preserve-symlinks-flag@1.0.0: {}
-
-    svgo@4.0.1:
-        dependencies:
-            commander: 11.1.0
-            css-select: 5.2.2
-            css-tree: 3.2.1
-            css-what: 6.2.2
-            csso: 5.0.5
-            picocolors: 1.1.1
-            sax: 1.6.0
-
-    tagged-tag@1.0.0: {}
-
-    tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.9.0):
-        dependencies:
-            '@alloc/quick-lru': 5.2.0
-            arg: 5.0.2
-            chokidar: 3.6.0
-            didyoumean: 1.2.2
-            dlv: 1.1.3
-            fast-glob: 3.3.3
-            glob-parent: 6.0.2
-            is-glob: 4.0.3
-            jiti: 1.21.7
-            lilconfig: 3.1.3
-            micromatch: 4.0.8
-            normalize-path: 3.0.0
-            object-hash: 3.0.0
-            picocolors: 1.1.1
-            postcss: 8.5.15
-            postcss-import: 15.1.0(postcss@8.5.15)
-            postcss-js: 4.1.0(postcss@8.5.15)
-            postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.9.0)
-            postcss-nested: 6.2.0(postcss@8.5.15)
-            postcss-selector-parser: 6.1.4
-            resolve: 1.22.12
-            sucrase: 3.35.1
-        transitivePeerDependencies:
-            - tsx
-            - yaml
-
-    tailwindcss@4.3.1: {}
-
-    tapable@2.3.3: {}
-
-    thenify-all@1.6.0:
-        dependencies:
-            thenify: 3.3.1
-
-    thenify@3.3.1:
-        dependencies:
-            any-promise: 1.3.0
-
-    tiny-invariant@1.3.3: {}
-
-    tinybench@2.9.0: {}
-
-    tinyexec@1.2.4: {}
-
-    tinyglobby@0.2.17:
-        dependencies:
-            fdir: 6.5.0(picomatch@4.0.4)
-            picomatch: 4.0.4
-
-    tinyrainbow@3.1.0: {}
-
-    tiptap-markdown@0.9.0(@tiptap/core@3.27.1(@tiptap/pm@3.27.1)):
-        dependencies:
-            '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-            '@types/markdown-it': 13.0.9
-            markdown-it: 14.2.0
-            markdown-it-task-lists: 2.1.1
-            prosemirror-markdown: 1.13.4
-
-    tmp@0.2.7: {}
-
-    to-regex-range@5.0.1:
-        dependencies:
-            is-number: 7.0.0
-
-    totalist@3.0.1: {}
-
-    trim-lines@3.0.1: {}
-
-    trough@2.2.0: {}
-
-    ts-interface-checker@0.1.13: {}
-
-    tslib@2.8.1: {}
-
-    tsx@4.22.4:
-        dependencies:
-            esbuild: 0.28.1
-        optionalDependencies:
-            fsevents: 2.3.3
-
-    type-fest@5.7.0:
-        dependencies:
-            tagged-tag: 1.0.0
-
-    typescript@5.9.3: {}
-
-    uc.micro@2.1.0: {}
-
-    undici-types@7.18.2: {}
-
-    unified@11.0.5:
-        dependencies:
-            '@types/unist': 3.0.3
-            bail: 2.0.2
-            devlop: 1.1.0
-            extend: 3.0.2
-            is-plain-obj: 4.1.0
-            trough: 2.2.0
-            vfile: 6.0.3
-
-    unist-util-is@6.0.1:
-        dependencies:
-            '@types/unist': 3.0.3
-
-    unist-util-position-from-estree@2.0.0:
-        dependencies:
-            '@types/unist': 3.0.3
-
-    unist-util-position@5.0.0:
-        dependencies:
-            '@types/unist': 3.0.3
-
-    unist-util-stringify-position@4.0.0:
-        dependencies:
-            '@types/unist': 3.0.3
-
-    unist-util-visit-parents@6.0.2:
-        dependencies:
-            '@types/unist': 3.0.3
-            unist-util-is: 6.0.1
-
-    unist-util-visit@5.1.0:
-        dependencies:
-            '@types/unist': 3.0.3
-            unist-util-is: 6.0.1
-            unist-util-visit-parents: 6.0.2
-
-    update-browserslist-db@1.2.3(browserslist@4.28.2):
-        dependencies:
-            browserslist: 4.28.2
-            escalade: 3.2.0
-            picocolors: 1.1.1
-
-    use-sync-external-store@1.6.0(react@19.2.7):
-        dependencies:
-            react: 19.2.7
-
-    util-deprecate@1.0.2: {}
-
-    valibot@1.4.1(typescript@5.9.3):
-        optionalDependencies:
-            typescript: 5.9.3
-
-    vfile-location@5.0.3:
-        dependencies:
-            '@types/unist': 3.0.3
-            vfile: 6.0.3
-
-    vfile-message@4.0.3:
-        dependencies:
-            '@types/unist': 3.0.3
-            unist-util-stringify-position: 4.0.0
-
-    vfile@6.0.3:
-        dependencies:
-            '@types/unist': 3.0.3
-            vfile-message: 4.0.3
-
-    vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
-        dependencies:
-            lightningcss: 1.32.0
-            picomatch: 4.0.4
-            postcss: 8.5.15
-            rolldown: 1.0.3
-            tinyglobby: 0.2.17
-        optionalDependencies:
-            '@types/node': 24.13.2
-            esbuild: 0.28.1
-            fsevents: 2.3.3
-            jiti: 2.7.0
-            tsx: 4.22.4
-            yaml: 2.9.0
-
-    vite@8.0.4(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
-        dependencies:
-            lightningcss: 1.32.0
-            picomatch: 4.0.4
-            postcss: 8.5.15
-            rolldown: 1.0.0-rc.12(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
-            tinyglobby: 0.2.17
-        optionalDependencies:
-            '@types/node': 24.13.2
-            esbuild: 0.28.1
-            fsevents: 2.3.3
-            jiti: 2.7.0
-            tsx: 4.22.4
-            yaml: 2.9.0
-        transitivePeerDependencies:
-            - '@emnapi/core'
-            - '@emnapi/runtime'
-
-    vitest@4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
-        dependencies:
-            '@vitest/expect': 4.1.8
-            '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-            '@vitest/pretty-format': 4.1.8
-            '@vitest/runner': 4.1.8
-            '@vitest/snapshot': 4.1.8
-            '@vitest/spy': 4.1.8
-            '@vitest/utils': 4.1.8
-            es-module-lexer: 2.1.0
-            expect-type: 1.3.0
-            magic-string: 0.30.21
-            obug: 2.1.3
-            pathe: 2.0.3
-            picomatch: 4.0.4
-            std-env: 4.1.0
-            tinybench: 2.9.0
-            tinyexec: 1.2.4
-            tinyglobby: 0.2.17
-            tinyrainbow: 3.1.0
-            vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-            why-is-node-running: 2.3.0
-        optionalDependencies:
-            '@types/node': 24.13.2
-            '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
-        transitivePeerDependencies:
-            - msw
-
-    w3c-keyname@2.2.8: {}
-
-    web-namespaces@2.0.1: {}
-
-    web-streams-polyfill@3.3.3: {}
-
-    when-exit@2.1.5: {}
-
-    which@2.0.2:
-        dependencies:
-            isexe: 2.0.0
-
-    why-is-node-running@2.3.0:
-        dependencies:
-            siginfo: 2.0.0
-            stackback: 0.0.2
-
-    wrap-ansi@9.0.2:
-        dependencies:
-            ansi-styles: 6.2.3
-            string-width: 7.2.0
-            strip-ansi: 7.2.0
-
-    write-file-atomic@5.0.1:
-        dependencies:
-            imurmurhash: 0.1.4
-            signal-exit: 4.1.0
-
-    ws@8.21.0: {}
-
-    xdg-basedir@5.1.0: {}
-
-    y18n@5.0.8: {}
-
-    yallist@3.1.1: {}
-
-    yaml@2.9.0: {}
-
-    yargs-parser@22.0.0: {}
-
-    yargs@18.0.0:
-        dependencies:
-            cliui: 9.0.1
-            escalade: 3.2.0
-            get-caller-file: 2.0.5
-            string-width: 7.2.0
-            y18n: 5.0.8
-            yargs-parser: 22.0.0
-
-    zod@4.4.3: {}
-
-    zwitch@2.0.4: {}
+  '@tanstack/table-core@8.21.3': {}
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@tiptap/core@3.27.1(@tiptap/pm@3.27.1)':
+    dependencies:
+      '@tiptap/pm': 3.27.1
+
+  '@tiptap/extension-blockquote@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-bold@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-bullet-list@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-code-block@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+      '@tiptap/pm': 3.27.1
+
+  '@tiptap/extension-code@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-document@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-dropcursor@3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-gapcursor@3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-hard-break@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-heading@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-horizontal-rule@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+      '@tiptap/pm': 3.27.1
+
+  '@tiptap/extension-image@3.26.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-italic@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-link@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+      '@tiptap/pm': 3.27.1
+      linkifyjs: 4.3.3
+
+  '@tiptap/extension-list-item@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-list-keymap@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+      '@tiptap/pm': 3.27.1
+
+  '@tiptap/extension-ordered-list@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-paragraph@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-strike@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-text@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+
+  '@tiptap/extension-underline@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+
+  '@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+      '@tiptap/pm': 3.27.1
+
+  '@tiptap/pm@3.27.1':
+    dependencies:
+      prosemirror-changeset: 2.4.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.8
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.9
+
+  '@tiptap/starter-kit@3.27.1':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+      '@tiptap/extension-blockquote': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      '@tiptap/extension-bold': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      '@tiptap/extension-bullet-list': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
+      '@tiptap/extension-code': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      '@tiptap/extension-code-block': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+      '@tiptap/extension-document': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      '@tiptap/extension-dropcursor': 3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
+      '@tiptap/extension-gapcursor': 3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
+      '@tiptap/extension-hard-break': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      '@tiptap/extension-heading': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      '@tiptap/extension-horizontal-rule': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+      '@tiptap/extension-italic': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      '@tiptap/extension-link': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+      '@tiptap/extension-list-item': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
+      '@tiptap/extension-list-keymap': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
+      '@tiptap/extension-ordered-list': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
+      '@tiptap/extension-paragraph': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      '@tiptap/extension-strike': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      '@tiptap/extension-text': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      '@tiptap/extension-underline': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+      '@tiptap/pm': 3.27.1
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/alpinejs@3.13.11': {}
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
+  '@types/estree@1.0.9': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/jscodeshift@17.3.0':
+    dependencies:
+      ast-types: 0.16.1
+      recast: 0.23.11
+
+  '@types/linkify-it@3.0.5': {}
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@13.0.9':
+    dependencies:
+      '@types/linkify-it': 3.0.5
+      '@types/mdurl': 1.0.5
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdurl@1.0.5': {}
+
+  '@types/mdurl@2.0.0': {}
+
+  '@types/mdx@2.0.14': {}
+
+  '@types/ms@2.1.0': {}
+
+  '@types/node@16.18.126': {}
+
+  '@types/node@24.13.2':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/postcss-import@14.0.3':
+    dependencies:
+      postcss: 8.5.15
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7': {}
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.13.2
+
+  '@ungap/structured-clone@1.3.1': {}
+
+  '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      playwright: 1.60.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@vue/reactivity@3.1.5':
+    dependencies:
+      '@vue/shared': 3.1.5
+
+  '@vue/shared@3.1.5': {}
+
+  '@worker-tools/html-rewriter@0.1.0-pre.19':
+    dependencies:
+      '@stardazed/streams-compression': 1.0.0
+      '@worker-tools/resolvable-promise': 0.2.0-pre.6
+
+  '@worker-tools/resolvable-promise@0.2.0-pre.6': {}
+
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  alpinejs@3.15.12:
+    dependencies:
+      '@vue/reactivity': 3.1.5
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
+
+  any-promise@1.3.0: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  arg@5.0.2: {}
+
+  argparse@2.0.1: {}
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  arkregex@0.0.5:
+    dependencies:
+      '@ark/util': 0.56.0
+
+  arktype@2.2.0:
+    dependencies:
+      '@ark/schema': 0.56.0
+      '@ark/util': 0.56.0
+      arkregex: 0.0.5
+
+  assertion-error@2.0.1: {}
+
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
+
+  astring@1.9.0: {}
+
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
+  autoprefixer@10.5.0(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001799
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  bail@2.0.2: {}
+
+  baseline-browser-mapping@2.10.37: {}
+
+  better-auth@1.6.18(drizzle-kit@1.0.0-rc.4-ca0f029)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8):
+    dependencies:
+      '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))
+      '@better-auth/kysely-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
+      '@better-auth/mongo-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
+      '@better-auth/prisma-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
+      '@better-auth/telemetry': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)
+      '@better-auth/utils': 0.4.1
+      '@better-fetch/fetch': 1.3.0
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      better-call: 1.3.6(zod@4.4.3)
+      defu: 6.1.7
+      jose: 6.2.3
+      kysely: 0.29.2
+      nanostores: 1.3.0
+      zod: 4.4.3
+    optionalDependencies:
+      drizzle-kit: 1.0.0-rc.4-ca0f029
+      drizzle-orm: 0.45.2(bun-types@1.3.14)(kysely@0.29.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      vitest: 4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-auth@1.6.21(drizzle-kit@1.0.0-rc.4-ca0f029)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8):
+    dependencies:
+      '@better-auth/core': 1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.21(@better-auth/core@1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2))
+      '@better-auth/kysely-adapter': 1.6.21(@better-auth/core@1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.6.21(@better-auth/core@1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.21(@better-auth/core@1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.21(@better-auth/core@1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.21(@better-auth/core@1.6.21(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      better-call: 1.3.7(zod@4.4.3)
+      defu: 6.1.7
+      jose: 6.2.3
+      kysely: 0.29.2
+      nanostores: 1.3.0
+      zod: 4.4.3
+    optionalDependencies:
+      drizzle-kit: 1.0.0-rc.4-ca0f029
+      drizzle-orm: 0.45.2(bun-types@1.3.14)(kysely@0.29.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      vitest: 4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-call@1.3.6(zod@4.4.3):
+    dependencies:
+      '@better-auth/utils': 0.4.1
+      '@better-fetch/fetch': 1.3.0
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.0
+    optionalDependencies:
+      zod: 4.4.3
+
+  better-call@1.3.7(zod@4.4.3):
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.0
+    optionalDependencies:
+      zod: 4.4.3
+
+  better-commits@1.24.0(typescript@5.9.3):
+    dependencies:
+      '@bomb.sh/args': 0.3.1
+      '@clack/core': 1.4.1
+      '@clack/prompts': 1.5.1
+      configstore: 8.0.0
+      jsonc-parser: 3.3.1
+      picocolors: 1.1.1
+      valibot: 1.4.1(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
+  binary-extensions@2.3.0: {}
+
+  boolbase@1.0.0: {}
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.37
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.372
+      node-releases: 2.0.47
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-from@1.1.2: {}
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 24.13.2
+
+  bun@1.3.14:
+    optionalDependencies:
+      '@oven/bun-darwin-aarch64': 1.3.14
+      '@oven/bun-darwin-x64': 1.3.14
+      '@oven/bun-darwin-x64-baseline': 1.3.14
+      '@oven/bun-freebsd-aarch64': 1.3.14
+      '@oven/bun-freebsd-x64': 1.3.14
+      '@oven/bun-linux-aarch64': 1.3.14
+      '@oven/bun-linux-aarch64-android': 1.3.14
+      '@oven/bun-linux-aarch64-musl': 1.3.14
+      '@oven/bun-linux-x64': 1.3.14
+      '@oven/bun-linux-x64-android': 1.3.14
+      '@oven/bun-linux-x64-baseline': 1.3.14
+      '@oven/bun-linux-x64-musl': 1.3.14
+      '@oven/bun-linux-x64-musl-baseline': 1.3.14
+      '@oven/bun-windows-aarch64': 1.3.14
+      '@oven/bun-windows-x64': 1.3.14
+      '@oven/bun-windows-x64-baseline': 1.3.14
+
+  camelcase-css@2.0.1: {}
+
+  caniuse-api@3.0.0:
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001799
+      lodash.memoize: 4.1.2
+      lodash.uniq: 4.5.0
+
+  caniuse-lite@1.0.30001799: {}
+
+  ccount@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  chalk@5.6.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  citty@0.2.2: {}
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-truncate@4.0.0:
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 7.2.0
+
+  client-only@0.0.1: {}
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
+  clone-deep@4.0.1:
+    dependencies:
+      is-plain-object: 2.0.4
+      kind-of: 6.0.3
+      shallow-clone: 3.0.1
+
+  clsx@2.1.1: {}
+
+  collapse-white-space@2.1.0: {}
+
+  colorette@2.0.20: {}
+
+  comma-separated-tokens@2.0.3: {}
+
+  commander@11.1.0: {}
+
+  commander@13.1.0: {}
+
+  commander@4.1.1: {}
+
+  commondir@1.0.1: {}
+
+  configstore@8.0.0:
+    dependencies:
+      atomically: 2.1.1
+      dot-prop: 10.1.0
+      graceful-fs: 4.2.11
+      is-safe-filename: 0.1.1
+      xdg-basedir: 5.1.0
+
+  consola@3.4.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  css-declaration-sorter@7.4.0(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-tree@2.2.1:
+    dependencies:
+      mdn-data: 2.0.28
+      source-map-js: 1.2.1
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
+
+  cssesc@3.0.0: {}
+
+  cssnano-preset-default@7.0.17(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      css-declaration-sorter: 7.4.0(postcss@8.5.15)
+      cssnano-utils: 5.0.3(postcss@8.5.15)
+      postcss: 8.5.15
+      postcss-calc: 10.1.1(postcss@8.5.15)
+      postcss-colormin: 7.0.10(postcss@8.5.15)
+      postcss-convert-values: 7.0.12(postcss@8.5.15)
+      postcss-discard-comments: 7.0.8(postcss@8.5.15)
+      postcss-discard-duplicates: 7.0.4(postcss@8.5.15)
+      postcss-discard-empty: 7.0.3(postcss@8.5.15)
+      postcss-discard-overridden: 7.0.3(postcss@8.5.15)
+      postcss-merge-longhand: 7.0.7(postcss@8.5.15)
+      postcss-merge-rules: 7.0.11(postcss@8.5.15)
+      postcss-minify-font-values: 7.0.3(postcss@8.5.15)
+      postcss-minify-gradients: 7.0.5(postcss@8.5.15)
+      postcss-minify-params: 7.0.9(postcss@8.5.15)
+      postcss-minify-selectors: 7.1.2(postcss@8.5.15)
+      postcss-normalize-charset: 7.0.3(postcss@8.5.15)
+      postcss-normalize-display-values: 7.0.3(postcss@8.5.15)
+      postcss-normalize-positions: 7.0.4(postcss@8.5.15)
+      postcss-normalize-repeat-style: 7.0.4(postcss@8.5.15)
+      postcss-normalize-string: 7.0.3(postcss@8.5.15)
+      postcss-normalize-timing-functions: 7.0.3(postcss@8.5.15)
+      postcss-normalize-unicode: 7.0.9(postcss@8.5.15)
+      postcss-normalize-url: 7.0.3(postcss@8.5.15)
+      postcss-normalize-whitespace: 7.0.3(postcss@8.5.15)
+      postcss-ordered-values: 7.0.4(postcss@8.5.15)
+      postcss-reduce-initial: 7.0.9(postcss@8.5.15)
+      postcss-reduce-transforms: 7.0.3(postcss@8.5.15)
+      postcss-svgo: 7.1.3(postcss@8.5.15)
+      postcss-unique-selectors: 7.0.7(postcss@8.5.15)
+
+  cssnano-utils@5.0.3(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+
+  cssnano@7.1.9(postcss@8.5.15):
+    dependencies:
+      cssnano-preset-default: 7.0.17(postcss@8.5.15)
+      lilconfig: 3.1.3
+      postcss: 8.5.15
+
+  csso@5.0.5:
+    dependencies:
+      css-tree: 2.2.1
+
+  csstype@3.2.3: {}
+
+  data-uri-to-buffer@4.0.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
+  defu@6.1.7: {}
+
+  dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  didyoumean@1.2.2: {}
+
+  dlv@1.1.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  dot-prop@10.1.0:
+    dependencies:
+      type-fest: 5.7.0
+
+  drizzle-kit@1.0.0-rc.4-ca0f029:
+    dependencies:
+      '@drizzle-team/brocli': 0.11.0
+      '@js-temporal/polyfill': 0.5.1
+      esbuild: 0.25.12
+      get-tsconfig: 4.14.0
+      jiti: 2.7.0
+
+  drizzle-orm@0.45.2(bun-types@1.3.14)(kysely@0.29.2):
+    optionalDependencies:
+      bun-types: 1.3.14
+      kysely: 0.29.2
+
+  electron-to-chromium@1.5.372: {}
+
+  emoji-regex-xs@1.0.0: {}
+
+  emoji-regex@10.6.0: {}
+
+  enhanced-resolve@5.21.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  enhanced-resolve@5.24.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  entities@4.5.0: {}
+
+  entities@6.0.1: {}
+
+  environment@1.1.0: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
+
+  esast-util-from-estree@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      unist-util-position-from-estree: 2.0.0
+
+  esast-util-from-js@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.17.0
+      esast-util-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@5.0.0: {}
+
+  esprima@4.0.1: {}
+
+  estree-util-attach-comments@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  estree-util-build-jsx@3.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-walker: 3.0.3
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-scope@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+
+  estree-util-to-js@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      astring: 1.9.0
+      source-map: 0.7.6
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  eventemitter3@5.0.4: {}
+
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
+  expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-cache-dir@2.1.0:
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 2.1.0
+      pkg-dir: 3.0.0
+
+  find-up@3.0.0:
+    dependencies:
+      locate-path: 3.0.0
+
+  flow-parser@0.318.0: {}
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  fraction.js@5.3.4: {}
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
+
+  get-stream@8.0.1: {}
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  ghtml@4.0.2: {}
+
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.7
+      node-fetch-native: 1.6.7
+      nypm: 0.6.7
+      pathe: 2.0.3
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  graceful-fs@4.2.11: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.2.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.1
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-to-estree@3.1.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-attach-comments: 3.0.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      zwitch: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+
+  html-void-elements@3.0.0: {}
+
+  human-signals@5.0.0: {}
+
+  husky@9.1.7: {}
+
+  imurmurhash@0.1.4: {}
+
+  inline-style-parser@0.2.7: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
+  is-decimal@2.0.1: {}
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@4.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
+
+  is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
+
+  is-plain-object@2.0.4:
+    dependencies:
+      isobject: 3.0.1
+
+  is-safe-filename@0.1.1: {}
+
+  is-stream@3.0.0: {}
+
+  isexe@2.0.0: {}
+
+  isobject@3.0.1: {}
+
+  jiti@1.21.7: {}
+
+  jiti@2.7.0: {}
+
+  jose@6.2.3: {}
+
+  js-tokens@4.0.0: {}
+
+  jsbi@4.3.2: {}
+
+  jscodeshift@17.3.0:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-flow': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/register': 7.29.7(@babel/core@7.29.7)
+      flow-parser: 0.318.0
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      neo-async: 2.6.2
+      picocolors: 1.1.1
+      recast: 0.23.11
+      tmp: 0.2.7
+      write-file-atomic: 5.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
+
+  kind-of@6.0.3: {}
+
+  kysely@0.29.2: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  linkify-it@5.0.1:
+    dependencies:
+      uc.micro: 2.1.0
+
+  linkifyjs@4.3.3: {}
+
+  lint-staged@15.5.2:
+    dependencies:
+      chalk: 5.6.2
+      commander: 13.1.0
+      debug: 4.4.3
+      execa: 8.0.1
+      lilconfig: 3.1.3
+      listr2: 8.3.3
+      micromatch: 4.0.8
+      pidtree: 0.6.1
+      string-argv: 0.3.2
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - supports-color
+
+  listr2@8.3.3:
+    dependencies:
+      cli-truncate: 4.0.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
+  lit-element@4.2.2:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
+      '@lit/reactive-element': 2.1.2
+      lit-html: 3.3.3
+
+  lit-html@3.3.3:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@3.3.3:
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit-element: 4.2.2
+      lit-html: 3.3.3
+
+  locate-path@3.0.0:
+    dependencies:
+      p-locate: 3.0.0
+      path-exists: 3.0.0
+
+  lodash.memoize@4.1.2: {}
+
+  lodash.uniq@4.5.0: {}
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
+  longest-streak@3.1.0: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  make-dir@2.1.0:
+    dependencies:
+      pify: 4.0.1
+      semver: 5.7.2
+
+  markdown-extensions@2.0.0: {}
+
+  markdown-it-task-lists@2.1.1: {}
+
+  markdown-it@14.2.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.1
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  mdn-data@2.0.28: {}
+
+  mdn-data@2.27.1: {}
+
+  mdurl@2.0.0: {}
+
+  merge-stream@2.0.0: {}
+
+  merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mimic-fn@4.0.0: {}
+
+  mimic-function@5.0.1: {}
+
+  mitata@1.0.34: {}
+
+  morphdom@2.7.8: {}
+
+  mrmime@2.0.1: {}
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.12: {}
+
+  nanostores@1.3.0: {}
+
+  neo-async@2.6.2: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch-native@1.6.7: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
+  node-releases@2.0.47: {}
+
+  normalize-path@3.0.0: {}
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
+  nypm@0.6.7:
+    dependencies:
+      citty: 0.2.2
+      pathe: 2.0.3
+      tinyexec: 1.2.4
+
+  object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
+
+  obug@2.1.3: {}
+
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@2.3.0:
+    dependencies:
+      emoji-regex-xs: 1.0.0
+      regex: 5.1.1
+      regex-recursion: 5.1.1
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
+  orderedmap@2.1.1: {}
+
+  oxc-parser@0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1):
+    dependencies:
+      '@oxc-project/types': 0.124.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.124.0
+      '@oxc-parser/binding-android-arm64': 0.124.0
+      '@oxc-parser/binding-darwin-arm64': 0.124.0
+      '@oxc-parser/binding-darwin-x64': 0.124.0
+      '@oxc-parser/binding-freebsd-x64': 0.124.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.124.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.124.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.124.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.124.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.124.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.124.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.124.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.124.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.124.0
+      '@oxc-parser/binding-linux-x64-musl': 0.124.0
+      '@oxc-parser/binding-openharmony-arm64': 0.124.0
+      '@oxc-parser/binding-wasm32-wasi': 0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
+      '@oxc-parser/binding-win32-arm64-msvc': 0.124.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.124.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.124.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  oxc-transform@0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1):
+    optionalDependencies:
+      '@oxc-transform/binding-android-arm-eabi': 0.124.0
+      '@oxc-transform/binding-android-arm64': 0.124.0
+      '@oxc-transform/binding-darwin-arm64': 0.124.0
+      '@oxc-transform/binding-darwin-x64': 0.124.0
+      '@oxc-transform/binding-freebsd-x64': 0.124.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.124.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.124.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.124.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.124.0
+      '@oxc-transform/binding-linux-ppc64-gnu': 0.124.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.124.0
+      '@oxc-transform/binding-linux-riscv64-musl': 0.124.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.124.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.124.0
+      '@oxc-transform/binding-linux-x64-musl': 0.124.0
+      '@oxc-transform/binding-openharmony-arm64': 0.124.0
+      '@oxc-transform/binding-wasm32-wasi': 0.124.0(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
+      '@oxc-transform/binding-win32-arm64-msvc': 0.124.0
+      '@oxc-transform/binding-win32-ia32-msvc': 0.124.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.124.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  oxlint@1.69.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.69.0
+      '@oxlint/binding-android-arm64': 1.69.0
+      '@oxlint/binding-darwin-arm64': 1.69.0
+      '@oxlint/binding-darwin-x64': 1.69.0
+      '@oxlint/binding-freebsd-x64': 1.69.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.69.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.69.0
+      '@oxlint/binding-linux-arm64-gnu': 1.69.0
+      '@oxlint/binding-linux-arm64-musl': 1.69.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.69.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.69.0
+      '@oxlint/binding-linux-riscv64-musl': 1.69.0
+      '@oxlint/binding-linux-s390x-gnu': 1.69.0
+      '@oxlint/binding-linux-x64-gnu': 1.69.0
+      '@oxlint/binding-linux-x64-musl': 1.69.0
+      '@oxlint/binding-openharmony-arm64': 1.69.0
+      '@oxlint/binding-win32-arm64-msvc': 1.69.0
+      '@oxlint/binding-win32-ia32-msvc': 1.69.0
+      '@oxlint/binding-win32-x64-msvc': 1.69.0
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@3.0.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-try@2.2.0: {}
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
+  parse-numeric-range@1.3.0: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  path-exists@3.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
+
+  path-parse@1.0.7: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  pidtree@0.6.1: {}
+
+  pify@2.3.0: {}
+
+  pify@4.0.1: {}
+
+  pirates@4.0.7: {}
+
+  pkg-dir@3.0.0:
+    dependencies:
+      find-up: 3.0.0
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
+
+  postcss-calc@10.1.1(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-selector-parser: 7.1.4
+      postcss-value-parser: 4.2.0
+
+  postcss-colormin@7.0.10(postcss@8.5.15):
+    dependencies:
+      '@colordx/core': 5.4.3
+      browserslist: 4.28.2
+      caniuse-api: 3.0.0
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-convert-values@7.0.12(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-discard-comments@7.0.8(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-selector-parser: 7.1.4
+
+  postcss-discard-duplicates@7.0.4(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+
+  postcss-discard-empty@7.0.3(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+
+  postcss-discard-overridden@7.0.3(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+
+  postcss-import@15.1.0(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
+  postcss-import@16.1.1(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
+  postcss-js@4.1.0(postcss@8.5.15):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.15
+
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.7
+      postcss: 8.5.15
+      tsx: 4.22.4
+      yaml: 2.9.0
+
+  postcss-merge-longhand@7.0.7(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+      stylehacks: 7.0.11(postcss@8.5.15)
+
+  postcss-merge-rules@7.0.11(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-api: 3.0.0
+      cssnano-utils: 5.0.3(postcss@8.5.15)
+      postcss: 8.5.15
+      postcss-selector-parser: 7.1.4
+
+  postcss-minify-font-values@7.0.3(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-gradients@7.0.5(postcss@8.5.15):
+    dependencies:
+      '@colordx/core': 5.4.3
+      cssnano-utils: 5.0.3(postcss@8.5.15)
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-params@7.0.9(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      cssnano-utils: 5.0.3(postcss@8.5.15)
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-selectors@7.1.2(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-api: 3.0.0
+      cssesc: 3.0.0
+      postcss: 8.5.15
+      postcss-selector-parser: 7.1.4
+
+  postcss-nested@6.2.0(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-selector-parser: 6.1.4
+
+  postcss-nested@7.0.2(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-selector-parser: 7.1.4
+
+  postcss-normalize-charset@7.0.3(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+
+  postcss-normalize-display-values@7.0.3(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-positions@7.0.4(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-repeat-style@7.0.4(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-string@7.0.3(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-timing-functions@7.0.3(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-unicode@7.0.9(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-url@7.0.3(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-whitespace@7.0.3(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-ordered-values@7.0.4(postcss@8.5.15):
+    dependencies:
+      cssnano-utils: 5.0.3(postcss@8.5.15)
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-reduce-initial@7.0.9(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-api: 3.0.0
+      postcss: 8.5.15
+
+  postcss-reduce-transforms@7.0.3(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-selector-parser@6.1.4:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-selector-parser@7.1.4:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-simple-vars@7.0.1(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+
+  postcss-svgo@7.1.3(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+      svgo: 4.0.1
+
+  postcss-unique-selectors@7.0.7(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-selector-parser: 7.1.4
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prettier@3.8.4: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  property-information@7.2.0: {}
+
+  prosemirror-changeset@2.4.1:
+    dependencies:
+      prosemirror-transform: 1.12.0
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.8
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-dropcursor@1.8.2:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.9
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.8
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.9
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.9
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-markdown@1.13.4:
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.2.0
+      prosemirror-model: 1.25.8
+
+  prosemirror-model@1.25.8:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.8
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.8
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.9
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.8
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.9
+
+  prosemirror-transform@1.12.0:
+    dependencies:
+      prosemirror-model: 1.25.8
+
+  prosemirror-view@1.41.9:
+    dependencies:
+      prosemirror-model: 1.25.8
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  punycode.js@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  react-aria-components@1.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@react-types/shared': 3.35.0(react@19.2.7)
+      '@swc/helpers': 0.5.23
+      client-only: 0.0.1
+      react: 19.2.7
+      react-aria: 3.49.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+      react-stately: 3.47.0(react@19.2.7)
+
+  react-aria@3.49.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.35.0(react@19.2.7)
+      '@swc/helpers': 0.5.23
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-stately: 3.47.0(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react-stately@3.47.0(react@19.2.7):
+    dependencies:
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.9
+      '@react-types/shared': 3.35.0(react@19.2.7)
+      '@swc/helpers': 0.5.23
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
+  react@19.2.7: {}
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
+  readdirp@5.0.0: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
+
+  recma-build-jsx@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-util-build-jsx: 3.0.1
+      vfile: 6.0.3
+
+  recma-jsx@1.0.1(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      estree-util-to-js: 2.0.0
+      recma-parse: 1.0.0
+      recma-stringify: 1.0.0
+      unified: 11.0.5
+
+  recma-parse@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      esast-util-from-js: 2.0.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  recma-stringify@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-util-to-js: 2.0.0
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  regex-recursion@5.1.1:
+    dependencies:
+      regex: 5.1.1
+      regex-utilities: 2.3.0
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@5.1.1:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  rehype-parse@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html: 2.0.3
+      unified: 11.0.5
+
+  rehype-pretty-code@0.14.3(shiki@3.23.0):
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-string: 3.0.1
+      parse-numeric-range: 1.3.0
+      rehype-parse: 9.0.1
+      shiki: 3.23.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-recma@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.4
+      hast-util-to-estree: 3.1.3
+    transitivePeerDependencies:
+      - supports-color
+
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+      unified: 11.0.5
+
+  rehype@13.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      rehype-parse: 9.0.1
+      rehype-stringify: 10.0.1
+      unified: 11.0.5
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
+
+  rolldown@1.0.0-rc.12(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1):
+    dependencies:
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.12
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
+
+  rolldown@1.1.1:
+    dependencies:
+      '@oxc-project/types': 0.135.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.1
+      '@rolldown/binding-darwin-arm64': 1.1.1
+      '@rolldown/binding-darwin-x64': 1.1.1
+      '@rolldown/binding-freebsd-x64': 1.1.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.1
+      '@rolldown/binding-linux-arm64-gnu': 1.1.1
+      '@rolldown/binding-linux-arm64-musl': 1.1.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.1
+      '@rolldown/binding-linux-s390x-gnu': 1.1.1
+      '@rolldown/binding-linux-x64-gnu': 1.1.1
+      '@rolldown/binding-linux-x64-musl': 1.1.1
+      '@rolldown/binding-openharmony-arm64': 1.1.1
+      '@rolldown/binding-wasm32-wasi': 1.1.1
+      '@rolldown/binding-win32-arm64-msvc': 1.1.1
+      '@rolldown/binding-win32-x64-msvc': 1.1.1
+
+  rope-sequence@1.3.4: {}
+
+  rou3@0.7.12: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  sax@1.6.0: {}
+
+  scheduler@0.27.0: {}
+
+  semver@5.7.2: {}
+
+  semver@6.3.1: {}
+
+  semver@7.8.4: {}
+
+  set-cookie-parser@3.1.0: {}
+
+  shallow-clone@3.0.1:
+    dependencies:
+      kind-of: 6.0.3
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  shiki@1.29.2:
+    dependencies:
+      '@shikijs/core': 1.29.2
+      '@shikijs/engine-javascript': 1.29.2
+      '@shikijs/engine-oniguruma': 1.29.2
+      '@shikijs/langs': 1.29.2
+      '@shikijs/themes': 1.29.2
+      '@shikijs/types': 1.29.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
+  sisteransi@1.0.5: {}
+
+  slice-ansi@5.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 4.0.0
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  source-map-js@1.2.1: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  source-map@0.7.6: {}
+
+  space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  string-argv@0.3.2: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  strip-final-newline@3.0.0: {}
+
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
+  stylehacks@7.0.11(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      postcss: 8.5.15
+      postcss-selector-parser: 7.1.4
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  svgo@4.0.1:
+    dependencies:
+      commander: 11.1.0
+      css-select: 5.2.2
+      css-tree: 3.2.1
+      css-what: 6.2.2
+      csso: 5.0.5
+      picocolors: 1.1.1
+      sax: 1.6.0
+
+  tagged-tag@1.0.0: {}
+
+  tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-import: 15.1.0(postcss@8.5.15)
+      postcss-js: 4.1.0(postcss@8.5.15)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.9.0)
+      postcss-nested: 6.2.0(postcss@8.5.15)
+      postcss-selector-parser: 6.1.4
+      resolve: 1.22.12
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - tsx
+      - yaml
+
+  tailwindcss@4.3.1: {}
+
+  tapable@2.3.3: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tiny-invariant@1.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tiptap-markdown@0.9.0(@tiptap/core@3.27.1(@tiptap/pm@3.27.1)):
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+      '@types/markdown-it': 13.0.9
+      markdown-it: 14.2.0
+      markdown-it-task-lists: 2.1.1
+      prosemirror-markdown: 1.13.4
+
+  tmp@0.2.7: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  totalist@3.0.1: {}
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tslib@2.8.1: {}
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  type-fest@5.7.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
+  typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
+
+  undici-types@7.18.2: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
+  util-deprecate@1.0.2: {}
+
+  valibot@1.4.1(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.2
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.22.4
+      yaml: 2.9.0
+
+  vite@8.0.4(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.1)
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.2
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.22.4
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  vitest@4.1.8(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.2
+      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+    transitivePeerDependencies:
+      - msw
+
+  w3c-keyname@2.2.8: {}
+
+  web-namespaces@2.0.1: {}
+
+  web-streams-polyfill@3.3.3: {}
+
+  when-exit@2.1.5: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  write-file-atomic@5.0.1:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 4.1.0
+
+  ws@8.21.0: {}
+
+  xdg-basedir@5.1.0: {}
+
+  y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
+
+  yaml@2.9.0: {}
+
+  yargs-parser@22.0.0: {}
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
+
+  zod@4.4.3: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- Add `@ecopages/mdx-core` with shared MDX loader, compiler-option, and extension helpers
- Replace triplicated loaders in mdx, react, and ecopages-jsx with thin wrappers

## Test plan
- [x] `vitest run packages/integrations/mdx/src/test/ packages/integrations/react/src/react.plugin.test.ts packages/integrations/ecopages-jsx/src/test/ecopages-jsx.plugin.test.ts`

## Dependencies
None