### PR TITLE
refactor(integrations): add StringMarkupRenderer and defineIntegration

### DIFF
--- a/apps/docs/src/pages/docs/plugins/custom-integration.mdx
+++ b/apps/docs/src/pages/docs/plugins/custom-integration.mdx
@@ -20,6 +20,29 @@ Integrations in Ecopages add support for new templating engines or frameworks. A
 
 Core still owns lifecycle ordering. Integration plugins declare contributions; `ConfigBuilder.build()` and app startup decide when those hooks run.
 
+## Minimal Integrations
+
+For string-markup integrations that only need declarative config and a renderer class, use `defineIntegration()` instead of writing a plugin class by hand:
+
+```typescript
+import { defineIntegration } from '@ecopages/core/plugins/define-integration';
+import { StringMarkupRenderer } from '@ecopages/core/route-renderer/string-markup-renderer';
+
+class CustomRenderer extends StringMarkupRenderer {
+	name = 'custom-integration';
+}
+
+export const customPlugin = defineIntegration({
+	name: 'custom-integration',
+	extensions: ['.custom'],
+	renderer: CustomRenderer,
+});
+```
+
+`customPlugin()` returns a configured integration instance. `customPlugin.Plugin` exposes the generated class when you need an explicit constructor.
+
+For integrations with runtime services, HMR strategies, or build loaders, continue using the class-based pattern below.
+
 ## Basic Structure
 
 An integration extends `IntegrationPlugin` and provides a renderer class. Keep the constructor declarative: use it to describe ownership, not to perform runtime side effects.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,6 +60,10 @@
 			"types": "./src/route-renderer/orchestration/integration-renderer.ts",
 			"default": "./src/route-renderer/orchestration/integration-renderer.ts"
 		},
+		"./route-renderer/string-markup-renderer": {
+			"types": "./src/route-renderer/orchestration/string-markup-renderer.ts",
+			"default": "./src/route-renderer/orchestration/string-markup-renderer.ts"
+		},
 		"./route-renderer/route-renderer": {
 			"types": "./src/route-renderer/route-renderer.ts",
 			"default": "./src/route-renderer/route-renderer.ts"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -140,6 +140,10 @@
 			"types": "./src/plugins/integration-plugin.ts",
 			"default": "./src/plugins/integration-plugin.ts"
 		},
+		"./plugins/define-integration": {
+			"types": "./src/plugins/define-integration.ts",
+			"default": "./src/plugins/define-integration.ts"
+		},
 		"./plugins/source-transform": {
 			"types": "./src/plugins/source-transform.ts",
 			"default": "./src/plugins/source-transform.ts"

--- a/packages/core/src/integrations/ghtml/ghtml-renderer.ts
+++ b/packages/core/src/integrations/ghtml/ghtml-renderer.ts
@@ -3,85 +3,13 @@
  * @module
  */
 
-import type {
-	ComponentRenderInput,
-	ComponentRenderResult,
-	EcoComponent,
-	EcoPagesElement,
-	IntegrationRendererRenderOptions,
-	RouteRendererBody,
-} from '../../types/public-types.ts';
-import {
-	IntegrationRenderer,
-	type RenderToResponseContext,
-} from '../../route-renderer/orchestration/integration-renderer.ts';
+import { StringMarkupRenderer } from '../../route-renderer/orchestration/string-markup-renderer.ts';
 import { GHTML_PLUGIN_NAME } from './ghtml.constants.ts';
-
-type GhtmlViewFn<P> = (props: P) => Promise<EcoPagesElement> | EcoPagesElement;
-type GhtmlLayoutFn = (
-	props: { children: string } & Record<string, unknown>,
-) => Promise<EcoPagesElement> | EcoPagesElement;
 
 /**
  * A renderer for the ghtml integration.
  * It renders a page using the HtmlTemplate and Page components.
  */
-export class GhtmlRenderer extends IntegrationRenderer<EcoPagesElement> {
+export class GhtmlRenderer extends StringMarkupRenderer {
 	name = GHTML_PLUGIN_NAME;
-
-	override async renderComponent(input: ComponentRenderInput): Promise<ComponentRenderResult> {
-		return this.renderStringComponentWithQueuedForeignSubtrees(
-			input,
-			input.component as GhtmlViewFn<Record<string, unknown>>,
-		);
-	}
-
-	async render({
-		params,
-		query,
-		props,
-		locals,
-		pageLocals,
-		metadata,
-		Page,
-		Layout,
-		HtmlTemplate,
-	}: IntegrationRendererRenderOptions): Promise<RouteRendererBody> {
-		try {
-			return await this.renderPageWithDocumentShell({
-				page: {
-					component: Page as EcoComponent,
-					props: { params, query, ...props, locals: pageLocals },
-				},
-				layout: Layout
-					? {
-							component: Layout as EcoComponent,
-							props: locals ? { locals } : {},
-						}
-					: undefined,
-				htmlTemplate: HtmlTemplate as EcoComponent,
-				metadata,
-				pageProps: props ?? {},
-			});
-		} catch (error) {
-			throw this.createRenderError('Error rendering page', error);
-		}
-	}
-
-	async renderToResponse<P = Record<string, unknown>>(
-		view: EcoComponent<P>,
-		props: P,
-		ctx: RenderToResponseContext,
-	): Promise<Response> {
-		try {
-			return await this.renderViewWithDocumentShell({
-				view,
-				props,
-				ctx,
-				layout: view.config?.layout as GhtmlLayoutFn | undefined,
-			});
-		} catch (error) {
-			throw this.createRenderError('Error rendering view', error);
-		}
-	}
 }

--- a/packages/core/src/integrations/ghtml/ghtml.plugin.ts
+++ b/packages/core/src/integrations/ghtml/ghtml.plugin.ts
@@ -1,28 +1,12 @@
-import { IntegrationPlugin, type IntegrationPluginConfig } from '../../plugins/integration-plugin.ts';
+import { defineIntegration } from '../../plugins/define-integration.ts';
 import { GhtmlRenderer } from './ghtml-renderer.ts';
 import { GHTML_PLUGIN_NAME } from './ghtml.constants.ts';
 
-/**
- * The Ghtml plugin class
- * This plugin provides support for ghtml components in Ecopages
- */
-export class GhtmlPlugin extends IntegrationPlugin {
-	renderer = GhtmlRenderer;
+export const ghtmlPlugin = defineIntegration({
+	name: GHTML_PLUGIN_NAME,
+	extensions: ['.ghtml.ts', '.ghtml.tsx', '.ghtml'],
+	renderer: GhtmlRenderer,
+});
 
-	constructor(options?: Omit<IntegrationPluginConfig, 'name'>) {
-		super({
-			name: GHTML_PLUGIN_NAME,
-			extensions: ['.ghtml.ts', '.ghtml.tsx', '.ghtml'],
-			...options,
-		});
-	}
-}
-
-/**
- * Factory function to create a Ghtml plugin instance
- * @param options Configuration options for the Ghtml plugin
- * @returns A new GhtmlPlugin instance
- */
-export function ghtmlPlugin(options?: Omit<IntegrationPluginConfig, 'name'>): GhtmlPlugin {
-	return new GhtmlPlugin(options);
-}
+/** @deprecated Use {@link ghtmlPlugin.Plugin} or {@link ghtmlPlugin} instead. */
+export const GhtmlPlugin = ghtmlPlugin.Plugin;

--- a/packages/core/src/plugins/define-integration.test.ts
+++ b/packages/core/src/plugins/define-integration.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { StringMarkupRenderer } from '../route-renderer/orchestration/string-markup-renderer.ts';
+import { defineIntegration } from './define-integration.ts';
+
+class ExampleRenderer extends StringMarkupRenderer {
+	name = 'example';
+}
+
+describe('defineIntegration', () => {
+	const examplePlugin = defineIntegration({
+		name: 'example',
+		extensions: ['.example'],
+		renderer: ExampleRenderer,
+	});
+
+	it('creates a plugin with the declared config', () => {
+		const plugin = examplePlugin();
+
+		expect(plugin.name).toBe('example');
+		expect(plugin.extensions).toEqual(['.example']);
+		expect(plugin.renderer).toBe(ExampleRenderer);
+	});
+
+	it('merges factory options over defaults', () => {
+		const plugin = examplePlugin({
+			extensions: ['.example', '.ex'],
+			jsxImportSource: '@example/jsx',
+		});
+
+		expect(plugin.extensions).toEqual(['.example', '.ex']);
+		expect(plugin.jsxImportSource).toBe('@example/jsx');
+	});
+
+	it('exposes the generated plugin class', () => {
+		const plugin = new examplePlugin.Plugin();
+
+		expect(plugin).toBeInstanceOf(examplePlugin.Plugin);
+		expect(plugin.name).toBe('example');
+	});
+});

--- a/packages/core/src/plugins/define-integration.ts
+++ b/packages/core/src/plugins/define-integration.ts
@@ -1,0 +1,51 @@
+import type { EcoPagesAppConfig } from '../types/internal-types.ts';
+import type { AssetProcessingService } from '../services/assets/asset-processing-service/asset-processing.service.ts';
+import type { ProcessedAsset } from '../services/assets/asset-processing-service/assets.types.ts';
+import type { EcoPagesElement } from '../types/public-types.ts';
+import type { IntegrationRenderer } from '../route-renderer/orchestration/integration-renderer.ts';
+import { IntegrationPlugin, type IntegrationPluginConfig } from './integration-plugin.ts';
+
+type RendererClass<C> = new (options: {
+	appConfig: EcoPagesAppConfig;
+	assetProcessingService: AssetProcessingService;
+	resolvedIntegrationDependencies: ProcessedAsset[];
+	rendererModules?: unknown;
+	runtimeOrigin: string;
+}) => IntegrationRenderer<C>;
+
+export interface DefineIntegrationDefinition<C = EcoPagesElement> extends IntegrationPluginConfig {
+	renderer: RendererClass<C>;
+}
+
+export interface DefinedIntegration<C = EcoPagesElement> {
+	(options?: Omit<IntegrationPluginConfig, 'name'>): IntegrationPlugin<C>;
+	Plugin: new (options?: Omit<IntegrationPluginConfig, 'name'>) => IntegrationPlugin<C>;
+}
+
+/**
+ * Creates a typed integration plugin factory for integrations that only need
+ * declarative config and a renderer class.
+ */
+export function defineIntegration<C = EcoPagesElement>(
+	definition: DefineIntegrationDefinition<C>,
+): DefinedIntegration<C> {
+	const { renderer, ...defaultConfig } = definition;
+
+	class DefinedIntegrationPlugin extends IntegrationPlugin<C> {
+		renderer = renderer;
+
+		constructor(options?: Omit<IntegrationPluginConfig, 'name'>) {
+			super({
+				...defaultConfig,
+				...options,
+			});
+		}
+	}
+
+	const factory = ((options?: Omit<IntegrationPluginConfig, 'name'>) =>
+		new DefinedIntegrationPlugin(options)) as DefinedIntegration<C>;
+
+	factory.Plugin = DefinedIntegrationPlugin;
+
+	return factory;
+}

--- a/packages/core/src/plugins/integration-plugin.ts
+++ b/packages/core/src/plugins/integration-plugin.ts
@@ -36,6 +36,8 @@ export type {
  */
 export type AnyIntegrationPlugin = IntegrationPlugin<unknown>;
 
+export { defineIntegration, type DefinedIntegration, type DefineIntegrationDefinition } from './define-integration.ts';
+
 export const INTEGRATION_PLUGIN_ERRORS = {
 	NOT_INITIALIZED_WITH_APP_CONFIG: 'Plugin not initialized with app config',
 	NOT_INITIALIZED_WITH_ASSET_SERVICE: 'Plugin not initialized with asset dependency service',

--- a/packages/core/src/route-renderer/orchestration/string-markup-renderer.ts
+++ b/packages/core/src/route-renderer/orchestration/string-markup-renderer.ts
@@ -1,0 +1,85 @@
+import type {
+	ComponentRenderInput,
+	ComponentRenderResult,
+	EcoComponent,
+	EcoFunctionComponent,
+	EcoPagesElement,
+	IntegrationRendererRenderOptions,
+	RouteRendererBody,
+} from '../../types/public-types.ts';
+import { IntegrationRenderer, type RenderToResponseContext } from './integration-renderer.ts';
+
+type StringMarkupViewFn<P = Record<string, unknown>> = EcoFunctionComponent<
+	P,
+	Promise<EcoPagesElement> | EcoPagesElement
+>;
+
+/**
+ * Base renderer for integrations whose page output is string HTML markup.
+ *
+ * @remarks
+ * Ghtml, KitaJS, and MDX share the same document-shell rendering path. Subclasses
+ * only need to set `name` and override hooks for integration-specific behavior.
+ */
+export abstract class StringMarkupRenderer extends IntegrationRenderer<EcoPagesElement> {
+	override async renderComponent(input: ComponentRenderInput): Promise<ComponentRenderResult> {
+		if (typeof input.component !== 'function') {
+			throw new TypeError(`${this.name} renderer expected a callable component.`);
+		}
+
+		return this.renderStringComponentWithQueuedForeignSubtrees(
+			input,
+			input.component as StringMarkupViewFn,
+		);
+	}
+
+	async render({
+		params,
+		query,
+		props,
+		locals,
+		pageLocals,
+		metadata,
+		Page,
+		Layout,
+		HtmlTemplate,
+		pageProps,
+	}: IntegrationRendererRenderOptions): Promise<RouteRendererBody> {
+		try {
+			return await this.renderPageWithDocumentShell({
+				page: {
+					component: Page,
+					props: { params, query, ...props, locals: pageLocals },
+				},
+				layout: Layout
+					? {
+							component: Layout,
+							props: locals ? { locals } : {},
+						}
+					: undefined,
+				htmlTemplate: HtmlTemplate,
+				metadata,
+				pageProps: pageProps ?? props ?? {},
+			});
+		} catch (error) {
+			throw this.createRenderError('Error rendering page', error);
+		}
+	}
+
+	async renderToResponse<P = Record<string, unknown>>(
+		view: EcoComponent<P>,
+		props: P,
+		ctx: RenderToResponseContext,
+	): Promise<Response> {
+		try {
+			return await this.renderViewWithDocumentShell({
+				view,
+				props,
+				ctx,
+				layout: view.config?.layout,
+			});
+		} catch (error) {
+			throw this.createRenderError('Error rendering view', error);
+		}
+	}
+}

--- a/packages/integrations/kitajs/src/kitajs-renderer.ts
+++ b/packages/integrations/kitajs/src/kitajs-renderer.ts
@@ -3,91 +3,13 @@
  * @module
  */
 
-import type {
-	ComponentRenderInput,
-	ComponentRenderResult,
-	EcoComponent,
-	EcoFunctionComponent,
-	EcoPagesElement,
-	IntegrationRendererRenderOptions,
-	RouteRendererBody,
-} from '@ecopages/core';
-import { IntegrationRenderer, type RenderToResponseContext } from '@ecopages/core/route-renderer/integration-renderer';
+import { StringMarkupRenderer } from '@ecopages/core/route-renderer/string-markup-renderer';
 import { KITAJS_PLUGIN_NAME } from './kitajs.constants.ts';
-
-/** Narrows an EcoComponent to its KitaJS callable signature. */
-type KitaViewFn<P> = EcoFunctionComponent<P, Promise<EcoPagesElement> | EcoPagesElement>;
 
 /**
  * A renderer for the Kita.js integration.
  * It renders a page using the HtmlTemplate and Page components.
  */
-export class KitaRenderer extends IntegrationRenderer<EcoPagesElement> {
+export class KitaRenderer extends StringMarkupRenderer {
 	name = KITAJS_PLUGIN_NAME;
-
-	private isFunctionComponent(component: EcoComponent): component is KitaViewFn<Record<string, unknown>> {
-		return typeof component === 'function';
-	}
-
-	/**
-	 * Renders a Kita-owned foreign subtree for component-level orchestration.
-	 *
-	 * Includes component-scoped dependency assets when declared.
-	 */
-	override async renderComponent(input: ComponentRenderInput): Promise<ComponentRenderResult> {
-		if (!this.isFunctionComponent(input.component)) {
-			throw new TypeError('Kita renderer expected a callable component.');
-		}
-
-		return this.renderStringComponentWithQueuedForeignSubtrees(input, input.component);
-	}
-
-	async render({
-		params,
-		query,
-		props,
-		locals,
-		pageLocals,
-		metadata,
-		Page,
-		Layout,
-		HtmlTemplate,
-	}: IntegrationRendererRenderOptions): Promise<RouteRendererBody> {
-		try {
-			return await this.renderPageWithDocumentShell({
-				page: {
-					component: Page,
-					props: { params, query, ...props, locals: pageLocals },
-				},
-				layout: Layout
-					? {
-							component: Layout,
-							props: locals ? { locals } : {},
-						}
-					: undefined,
-				htmlTemplate: HtmlTemplate,
-				metadata,
-				pageProps: props ?? {},
-			});
-		} catch (error) {
-			throw this.createRenderError('Error rendering page', error);
-		}
-	}
-
-	async renderToResponse<P = Record<string, unknown>>(
-		view: EcoComponent<P>,
-		props: P,
-		ctx: RenderToResponseContext,
-	): Promise<Response> {
-		try {
-			return await this.renderViewWithDocumentShell({
-				view,
-				props,
-				ctx,
-				layout: view.config?.layout,
-			});
-		} catch (error) {
-			throw this.createRenderError('Error rendering view', error);
-		}
-	}
 }

--- a/packages/integrations/kitajs/src/kitajs.plugin.ts
+++ b/packages/integrations/kitajs/src/kitajs.plugin.ts
@@ -1,4 +1,4 @@
-import { IntegrationPlugin, type IntegrationPluginConfig } from '@ecopages/core/plugins/integration-plugin';
+import { defineIntegration } from '@ecopages/core/plugins/define-integration';
 import { KitaRenderer } from './kitajs-renderer.ts';
 import { KITAJS_PLUGIN_NAME } from './kitajs.constants.ts';
 
@@ -7,28 +7,12 @@ import { KITAJS_PLUGIN_NAME } from './kitajs.constants.ts';
  */
 export const PLUGIN_NAME = KITAJS_PLUGIN_NAME;
 
-/**
- * The Kita.js plugin class
- * This plugin provides support for Kita.js components in Ecopages
- */
-export class KitaHtmlPlugin extends IntegrationPlugin {
-	renderer = KitaRenderer;
+export const kitajsPlugin = defineIntegration({
+	name: PLUGIN_NAME,
+	extensions: ['.kita.tsx'],
+	jsxImportSource: '@kitajs/html',
+	renderer: KitaRenderer,
+});
 
-	constructor(options?: Omit<IntegrationPluginConfig, 'name'>) {
-		super({
-			name: PLUGIN_NAME,
-			extensions: ['.kita.tsx'],
-			jsxImportSource: '@kitajs/html',
-			...options,
-		});
-	}
-}
-
-/**
- * Factory function to create a Kita.js plugin instance.
- * @param options Configuration options for the Kita.js plugin
- * @returns A new KitaHtmlPlugin instance
- */
-export function kitajsPlugin(options?: Omit<IntegrationPluginConfig, 'name'>): KitaHtmlPlugin {
-	return new KitaHtmlPlugin(options);
-}
+/** @deprecated Use {@link kitajsPlugin.Plugin} or {@link kitajsPlugin} instead. */
+export const KitaHtmlPlugin = kitajsPlugin.Plugin;

--- a/packages/integrations/mdx/src/mdx-renderer.ts
+++ b/packages/integrations/mdx/src/mdx-renderer.ts
@@ -4,23 +4,16 @@
  */
 
 import type {
-	ComponentRenderInput,
-	ComponentRenderResult,
 	EcoComponent,
 	EcoComponentConfig,
-	EcoFunctionComponent,
 	EcoPageFile,
-	EcoPagesElement,
-	IntegrationRendererRenderOptions,
-	RouteRendererBody,
 } from '@ecopages/core';
 import { assertIntegrationInvariant } from '@ecopages/core/plugins/integration-plugin';
 import {
-	IntegrationRenderer,
 	type PageBrowserGraphContribution,
 	type PageBrowserGraphContributionContext,
-	type RenderToResponseContext,
 } from '@ecopages/core/route-renderer/integration-renderer';
+import { StringMarkupRenderer } from '@ecopages/core/route-renderer/string-markup-renderer';
 import type { CompileOptions } from '@mdx-js/mdx';
 import { MDX_PLUGIN_NAME } from './mdx.constants.ts';
 import { rapidhash } from '@ecopages/core/hash';
@@ -29,22 +22,11 @@ import type { MDXRendererOptions } from './mdx.types.ts';
 export type { MDXFile, MDXRendererConfig, MDXRendererOptions } from './mdx.types.ts';
 
 /**
- * Options for the MDX renderer
- */
-interface MDXIntegrationRendererOptions<C = EcoPagesElement> extends IntegrationRendererRenderOptions<C> {}
-
-/**
  * A renderer for the MDX integration.
  */
-export class MDXRenderer extends IntegrationRenderer<EcoPagesElement> {
+export class MDXRenderer extends StringMarkupRenderer {
 	name = MDX_PLUGIN_NAME;
 	readonly compilerOptions: CompileOptions;
-
-	private isFunctionComponent(
-		component: EcoComponent,
-	): component is EcoFunctionComponent<Record<string, unknown>, EcoPagesElement | Promise<EcoPagesElement>> {
-		return typeof component === 'function';
-	}
 
 	constructor({ mdxConfig, ...options }: MDXRendererOptions) {
 		super(options);
@@ -105,64 +87,6 @@ export class MDXRenderer extends IntegrationRenderer<EcoPagesElement> {
 			} as TPageModule;
 		} catch (error) {
 			assertIntegrationInvariant(false, `Error importing MDX file: ${error}`);
-		}
-	}
-
-	override async renderComponent(input: ComponentRenderInput): Promise<ComponentRenderResult> {
-		if (!this.isFunctionComponent(input.component)) {
-			throw new TypeError('MDX renderer expected a callable component.');
-		}
-
-		return this.renderStringComponentWithQueuedForeignSubtrees(input, input.component);
-	}
-
-	async render({
-		params,
-		query,
-		props,
-		locals,
-		pageLocals,
-		metadata,
-		Page,
-		HtmlTemplate,
-		Layout,
-		pageProps,
-	}: MDXIntegrationRendererOptions): Promise<RouteRendererBody> {
-		try {
-			return await this.renderPageWithDocumentShell({
-				page: {
-					component: Page,
-					props: { params, query, ...props, locals: pageLocals },
-				},
-				layout: Layout
-					? {
-							component: Layout,
-							props: locals ? { locals } : {},
-						}
-					: undefined,
-				htmlTemplate: HtmlTemplate,
-				metadata,
-				pageProps: pageProps || {},
-			});
-		} catch (error) {
-			throw this.createRenderError('Error rendering page', error);
-		}
-	}
-
-	async renderToResponse<P = Record<string, unknown>>(
-		view: EcoComponent<P>,
-		props: P,
-		ctx: RenderToResponseContext,
-	): Promise<Response> {
-		try {
-			return await this.renderViewWithDocumentShell({
-				view,
-				props,
-				ctx,
-				layout: view.config?.layout,
-			});
-		} catch (error) {
-			throw this.createRenderError('Error rendering view', error);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `StringMarkupRenderer` base for Ghtml, KitaJS, and MDX document-shell rendering
- Add `defineIntegration()` factory and migrate Ghtml + KitaJS to it
- Document the minimal integration path in custom-integration docs

## Test plan
- [x] `vitest run packages/core/src/integrations/ghtml/ packages/integrations/mdx/src/test/mdx-renderer.test.ts packages/integrations/kitajs/src/test/`
- [x] `vitest run packages/core/src/plugins/define-integration.test.ts`

## Dependencies
None (P4 and P5 are combined on this branch because `defineIntegration` builds on `StringMarkupRenderer`)