### PR TITLE
refactor(core): inject prepareRuntimeAssets into ServerStaticBuilder

### DIFF
--- a/packages/core/src/adapters/bun/server-adapter.ts
+++ b/packages/core/src/adapters/bun/server-adapter.ts
@@ -274,19 +274,21 @@ export class BunServerAdapter extends SharedServerAdapter<BunServerAdapterParams
 		}
 		prepareRuntimePublicDir(this.appConfig);
 
-		const staticBuilderOptions = {
+		this.staticBuilder = new ServerStaticBuilder({
 			appConfig: this.appConfig,
 			staticSiteGenerator: this.staticSiteGenerator,
 			serveOptions: this.serveOptions,
-			runtimeOrigin: this.runtimeOrigin,
 			apiHandlers: this.apiHandlers,
-			hmrManager: this.hmrManager,
-			onRuntimePlugin: (plugin: EcoBuildPlugin) => {
-				this.registerBunRuntimePlugin(plugin);
-			},
-		};
-
-		this.staticBuilder = new ServerStaticBuilder(staticBuilderOptions);
+			prepareRuntimeAssets: () =>
+				setupAppRuntimePlugins({
+					appConfig: this.appConfig,
+					runtimeOrigin: this.runtimeOrigin,
+					hmrManager: this.hmrManager,
+					onRuntimePlugin: (plugin: EcoBuildPlugin) => {
+						this.registerBunRuntimePlugin(plugin);
+					},
+				}),
+		});
 
 		if (!this.deferRuntimeAssetSetup) {
 			await this.initializeRuntimePlugins({ watch: this.options?.watch });

--- a/packages/core/src/adapters/node/server-adapter.ts
+++ b/packages/core/src/adapters/node/server-adapter.ts
@@ -203,9 +203,13 @@ export class NodeServerAdapter extends SharedServerAdapter<NodeServerAdapterPara
 			appConfig: this.appConfig,
 			staticSiteGenerator: this.staticSiteGenerator,
 			serveOptions: this.serveOptions,
-			runtimeOrigin: this.runtimeOrigin,
 			apiHandlers: this.apiHandlers,
-			hmrManager: this.hmrManager ?? undefined,
+			prepareRuntimeAssets: () =>
+				setupAppRuntimePlugins({
+					appConfig: this.appConfig,
+					runtimeOrigin: this.runtimeOrigin,
+					hmrManager: this.hmrManager ?? undefined,
+				}),
 		});
 		this.initialized = true;
 	}

--- a/packages/core/src/adapters/shared/build-start-contract.test.ts
+++ b/packages/core/src/adapters/shared/build-start-contract.test.ts
@@ -75,8 +75,8 @@ describe('build → start contract', () => {
 				appConfig,
 				staticSiteGenerator,
 				serveOptions: { hostname: '127.0.0.1', port: 3000 },
-				runtimeOrigin: 'http://127.0.0.1:3000',
 				entryFile: 'app.ts',
+				prepareRuntimeAssets: async () => {},
 			});
 
 			await builder.build(undefined, {

--- a/packages/core/src/adapters/shared/server-static-builder.test.ts
+++ b/packages/core/src/adapters/shared/server-static-builder.test.ts
@@ -9,7 +9,13 @@ import {
 	SERVER_BUNDLE_DIR,
 	SERVER_BUNDLE_FILENAME,
 } from '../../utils/resolve-entry-file';
-import { setAppBuildAdapter, type BuildAdapter, type BuildOptions, type BuildResult } from '../../build/build-adapter';
+import {
+	setAppBuildAdapter,
+	setupAppRuntimePlugins,
+	type BuildAdapter,
+	type BuildOptions,
+	type BuildResult,
+} from '../../build/build-adapter';
 import type { EcoPagesAppConfig } from '../../types/internal-types';
 import type { StaticSiteGenerator } from '../../static-site-generator/static-site-generator';
 import type { RouteRegistry } from '../../router/server/route-registry';
@@ -19,6 +25,17 @@ import path from 'node:path';
 import os from 'node:os';
 
 const TMP_DIR = path.join(os.tmpdir(), 'server-static-builder-test');
+
+function createPrepareRuntimeAssets(
+	appConfig: EcoPagesAppConfig,
+	runtimeOrigin = 'http://127.0.0.1:3000',
+): () => Promise<void> {
+	return () =>
+		setupAppRuntimePlugins({
+			appConfig,
+			runtimeOrigin,
+		});
+}
 
 function createMockDependencies() {
 	const calls = {
@@ -269,7 +286,7 @@ describe('ServerStaticBuilder', () => {
 				appConfig: AppConfig,
 				staticSiteGenerator: StaticSiteGenerator,
 				serveOptions: ServeOptions,
-				runtimeOrigin: 'http://127.0.0.1:3000',
+				prepareRuntimeAssets: createPrepareRuntimeAssets(AppConfig),
 				logger,
 			});
 			expect(builder).toBeDefined();
@@ -292,7 +309,7 @@ describe('ServerStaticBuilder', () => {
 				appConfig,
 				staticSiteGenerator: StaticSiteGenerator,
 				serveOptions: ServeOptions,
-				runtimeOrigin: 'http://127.0.0.1:3000',
+				prepareRuntimeAssets: createPrepareRuntimeAssets(appConfig),
 				logger,
 			});
 
@@ -326,7 +343,7 @@ describe('ServerStaticBuilder', () => {
 					appConfig,
 					staticSiteGenerator: StaticSiteGenerator,
 					serveOptions: ServeOptions,
-					runtimeOrigin: 'http://127.0.0.1:3000',
+					prepareRuntimeAssets: createPrepareRuntimeAssets(appConfig),
 					logger,
 				});
 
@@ -350,7 +367,7 @@ describe('ServerStaticBuilder', () => {
 				appConfig: AppConfig,
 				staticSiteGenerator: StaticSiteGenerator,
 				serveOptions: ServeOptions,
-				runtimeOrigin: 'http://127.0.0.1:3000',
+				prepareRuntimeAssets: createPrepareRuntimeAssets(AppConfig),
 				logger,
 			});
 
@@ -384,7 +401,7 @@ describe('ServerStaticBuilder', () => {
 				appConfig: AppConfig,
 				staticSiteGenerator: StaticSiteGenerator,
 				serveOptions: customServeOptions,
-				runtimeOrigin: 'http://0.0.0.0:8080',
+				prepareRuntimeAssets: createPrepareRuntimeAssets(AppConfig, 'http://0.0.0.0:8080'),
 				logger,
 			});
 
@@ -404,7 +421,7 @@ describe('ServerStaticBuilder', () => {
 				appConfig: AppConfig,
 				staticSiteGenerator: StaticSiteGenerator,
 				serveOptions: ServeOptions,
-				runtimeOrigin: 'http://127.0.0.1:3000',
+				prepareRuntimeAssets: createPrepareRuntimeAssets(AppConfig),
 				logger,
 			});
 
@@ -427,7 +444,7 @@ describe('ServerStaticBuilder', () => {
 				appConfig: AppConfig,
 				staticSiteGenerator: StaticSiteGenerator,
 				serveOptions: ServeOptions,
-				runtimeOrigin: 'http://127.0.0.1:3000',
+				prepareRuntimeAssets: createPrepareRuntimeAssets(AppConfig),
 				logger,
 			});
 
@@ -447,7 +464,7 @@ describe('ServerStaticBuilder', () => {
 				appConfig: AppConfig,
 				staticSiteGenerator: StaticSiteGenerator,
 				serveOptions: ServeOptions,
-				runtimeOrigin: 'http://127.0.0.1:3000',
+				prepareRuntimeAssets: createPrepareRuntimeAssets(AppConfig),
 				logger,
 			});
 
@@ -478,7 +495,7 @@ describe('ServerStaticBuilder', () => {
 				appConfig: AppConfig,
 				staticSiteGenerator: StaticSiteGenerator,
 				serveOptions: ServeOptions,
-				runtimeOrigin: 'http://127.0.0.1:3000',
+				prepareRuntimeAssets: createPrepareRuntimeAssets(AppConfig),
 				logger,
 			});
 
@@ -513,7 +530,7 @@ describe('ServerStaticBuilder', () => {
 					appConfig,
 					staticSiteGenerator: StaticSiteGenerator,
 					serveOptions: ServeOptions,
-					runtimeOrigin: 'http://127.0.0.1:3000',
+					prepareRuntimeAssets: createPrepareRuntimeAssets(appConfig),
 					logger,
 				});
 
@@ -542,7 +559,7 @@ describe('ServerStaticBuilder', () => {
 					appConfig,
 					staticSiteGenerator: StaticSiteGenerator,
 					serveOptions: ServeOptions,
-					runtimeOrigin: 'http://127.0.0.1:3000',
+					prepareRuntimeAssets: createPrepareRuntimeAssets(appConfig),
 					logger,
 					entryFile: 'nonexistent.ts',
 					apiHandlers: [{ method: 'GET', path: '/api/ping', handler: () => undefined } as any],
@@ -572,7 +589,7 @@ describe('ServerStaticBuilder', () => {
 					appConfig,
 					staticSiteGenerator: StaticSiteGenerator,
 					serveOptions: ServeOptions,
-					runtimeOrigin: 'http://127.0.0.1:3000',
+					prepareRuntimeAssets: createPrepareRuntimeAssets(appConfig),
 					logger,
 					apiHandlers: [{ method: 'GET', path: '/api/ping', handler: () => undefined } as any],
 				});
@@ -606,7 +623,7 @@ describe('ServerStaticBuilder', () => {
 						appConfig,
 						staticSiteGenerator: StaticSiteGenerator,
 						serveOptions: ServeOptions,
-						runtimeOrigin: 'http://127.0.0.1:3000',
+						prepareRuntimeAssets: createPrepareRuntimeAssets(appConfig),
 						logger,
 						apiHandlers: [{ method: 'GET', path: '/api/ping', handler: () => undefined } as any],
 					});
@@ -644,7 +661,7 @@ describe('ServerStaticBuilder', () => {
 						appConfig,
 						staticSiteGenerator: StaticSiteGenerator,
 						serveOptions: ServeOptions,
-						runtimeOrigin: 'http://127.0.0.1:3000',
+						prepareRuntimeAssets: createPrepareRuntimeAssets(appConfig),
 						logger,
 						entryFile: 'app.ts',
 						apiHandlers: [{ method: 'GET', path: '/api/ping', handler: () => undefined } as any],
@@ -695,7 +712,7 @@ describe('ServerStaticBuilder', () => {
 					appConfig,
 					staticSiteGenerator: StaticSiteGenerator,
 					serveOptions: ServeOptions,
-					runtimeOrigin: 'http://127.0.0.1:3000',
+					prepareRuntimeAssets: createPrepareRuntimeAssets(appConfig),
 					logger,
 					apiHandlers: [{ method: 'GET', path: '/api/ping', handler: () => undefined } as any],
 				});

--- a/packages/core/src/adapters/shared/server-static-builder.ts
+++ b/packages/core/src/adapters/shared/server-static-builder.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { fileSystem } from '@ecopages/file-system';
 import { DEFAULT_ECOPAGES_HOSTNAME, DEFAULT_ECOPAGES_PORT } from '../../config/constants.ts';
 import { appLogger } from '../../global/app-logger.ts';
-import { build, getAppBuildAdapter, setupAppRuntimePlugins, type BuildOptions } from '../../build/build-adapter.ts';
+import { build, getAppBuildAdapter, type BuildOptions } from '../../build/build-adapter.ts';
 import { resolveBuildProfileOptions } from '../../build/build-profile-options.ts';
 import {
 	getServerBundleOutputPaths,
@@ -16,8 +16,7 @@ import {
 	shouldResetStaticExportDirectory,
 } from '../../static-site-generator/static-build-invalidation.ts';
 import { resolveEntryFile, SERVER_BUNDLE_FILENAME } from '../../utils/resolve-entry-file.ts';
-import type { EcoPagesAppConfig, IHmrManager } from '../../types/internal-types.ts';
-import type { EcoBuildPlugin } from '../../build/build-types.ts';
+import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 import type { ApiHandler, StaticRoute } from '../../types/public-types.ts';
 import type { RouteRegistry } from '../../router/server/route-registry.ts';
 import type { StaticSiteGenerator } from '../../static-site-generator/static-site-generator.ts';
@@ -37,12 +36,11 @@ export interface ServerStaticBuilderParams {
 	appConfig: EcoPagesAppConfig;
 	staticSiteGenerator: StaticSiteGenerator;
 	serveOptions: ServeOptions;
-	runtimeOrigin: string;
 	apiHandlers?: ApiHandler[];
 	logger?: ServerStaticBuilderLogger;
 	entryFile?: string;
-	hmrManager?: IHmrManager;
-	onRuntimePlugin?: (plugin: EcoBuildPlugin) => void;
+	/** Prepares processor/integration runtime assets before static generation. */
+	prepareRuntimeAssets: () => Promise<void>;
 }
 
 /**
@@ -61,33 +59,27 @@ export class ServerStaticBuilder {
 	private readonly appConfig: EcoPagesAppConfig;
 	private readonly staticSiteGenerator: StaticSiteGenerator;
 	private readonly serveOptions: ServeOptions;
-	private readonly runtimeOrigin: string;
 	private readonly apiHandlers: ApiHandler[];
 	private readonly logger: ServerStaticBuilderLogger;
 	private readonly entryFile: string;
-	private readonly hmrManager?: IHmrManager;
-	private readonly onRuntimePlugin?: (plugin: EcoBuildPlugin) => void;
+	private readonly prepareRuntimeAssets: () => Promise<void>;
 
 	constructor({
 		appConfig,
 		staticSiteGenerator,
 		serveOptions,
-		runtimeOrigin,
 		apiHandlers,
 		logger,
 		entryFile,
-		hmrManager,
-		onRuntimePlugin,
+		prepareRuntimeAssets,
 	}: ServerStaticBuilderParams) {
 		this.appConfig = appConfig;
 		this.staticSiteGenerator = staticSiteGenerator;
 		this.serveOptions = serveOptions;
-		this.runtimeOrigin = runtimeOrigin;
 		this.apiHandlers = apiHandlers ?? [];
 		this.logger = logger ?? appLogger;
 		this.entryFile = resolveEntryFile({ entryFile });
-		this.hmrManager = hmrManager;
-		this.onRuntimePlugin = onRuntimePlugin;
+		this.prepareRuntimeAssets = prepareRuntimeAssets;
 	}
 
 	private prepareExportDirectory(force: boolean): boolean {
@@ -122,12 +114,7 @@ export class ServerStaticBuilder {
 	private async refreshRuntimeAssets(): Promise<void> {
 		appLogger.debugTime('refreshRuntimeAssets');
 		try {
-			await setupAppRuntimePlugins({
-				appConfig: this.appConfig,
-				runtimeOrigin: this.runtimeOrigin,
-				hmrManager: this.hmrManager,
-				onRuntimePlugin: this.onRuntimePlugin,
-			});
+			await this.prepareRuntimeAssets();
 		} finally {
 			appLogger.debugTimeEnd('refreshRuntimeAssets');
 		}


### PR DESCRIPTION
## Summary
- Replaces `runtimeOrigin`, `hmrManager`, and `onRuntimePlugin` on `ServerStaticBuilder` with a single `prepareRuntimeAssets` callback
- Node and Bun server adapters now own how runtime assets are prepared; the static builder only decides when to call the hook during `build()`
- Updates unit tests to pass adapter-style callbacks instead of leaking Bun/Node registration details into the shared builder

## Test plan
- [x] `pnpm typecheck`
- [x] `vitest run packages/core/src/adapters/shared/server-static-builder.test.ts packages/core/src/adapters/shared/build-start-contract.test.ts`
- [ ] Verify preview/build flows still prepare processor assets correctly on Node and Bun