### PR TITLE
feat(core): skip server entry bundle for static-only apps

### DIFF
--- a/packages/core/src/adapters/bun/server-adapter.ts
+++ b/packages/core/src/adapters/bun/server-adapter.ts
@@ -279,7 +279,7 @@ export class BunServerAdapter extends SharedServerAdapter<BunServerAdapterParams
 			staticSiteGenerator: this.staticSiteGenerator,
 			serveOptions: this.serveOptions,
 			runtimeOrigin: this.runtimeOrigin,
-			apiHandlers: this.apiHandlers,
+			needsServerBundle: this.apiHandlers.length > 0 || this.websocketHandlers.size > 0,
 			hmrManager: this.hmrManager,
 			onRuntimePlugin: (plugin: EcoBuildPlugin) => {
 				this.registerBunRuntimePlugin(plugin);

--- a/packages/core/src/adapters/node/server-adapter.ts
+++ b/packages/core/src/adapters/node/server-adapter.ts
@@ -204,7 +204,7 @@ export class NodeServerAdapter extends SharedServerAdapter<NodeServerAdapterPara
 			staticSiteGenerator: this.staticSiteGenerator,
 			serveOptions: this.serveOptions,
 			runtimeOrigin: this.runtimeOrigin,
-			apiHandlers: this.apiHandlers,
+			needsServerBundle: this.apiHandlers.length > 0 || this.websocketHandlers.size > 0,
 			hmrManager: this.hmrManager ?? undefined,
 		});
 		this.initialized = true;

--- a/packages/core/src/adapters/shared/build-start-contract.test.ts
+++ b/packages/core/src/adapters/shared/build-start-contract.test.ts
@@ -12,33 +12,6 @@ import type { RouteRegistry } from '../../router/server/route-registry.ts';
 import type { StaticGenerationRendererResolver } from '../../route-renderer/route-renderer.ts';
 import type { StaticSiteGenerator } from '../../static-site-generator/static-site-generator.ts';
 
-const scenarios = [
-	{
-		name: 'static-only app (no API handlers)',
-		entry: 'export const ready = true;\n',
-	},
-	{
-		name: 'API app entry',
-		entry: [
-			"import { EcopagesApp } from '@ecopages/core/adapters/create-app';",
-			'const app = new EcopagesApp({ appConfig: {} as never });',
-			"app.api('GET', '/api/ping', () => new Response('ok'));",
-			'export default app;',
-			'',
-		].join('\n'),
-	},
-	{
-		name: 'websocket-oriented app entry',
-		entry: [
-			"import { EcopagesApp } from '@ecopages/core/adapters/create-app';",
-			'const app = new EcopagesApp({ appConfig: {} as never });',
-			"app.websocket('/chat', { open() {}, message() {}, close() {} });",
-			'export default app;',
-			'',
-		].join('\n'),
-	},
-] as const;
-
 describe('build → start contract', () => {
 	const tempDirs: string[] = [];
 	const originalNodeEnv = process.env.NODE_ENV;
@@ -52,52 +25,83 @@ describe('build → start contract', () => {
 		}
 	});
 
-	for (const scenario of scenarios) {
-		it(`emits a runnable server bundle and manifest for ${scenario.name}`, async () => {
-			process.env.NODE_ENV = 'production';
-			const rootDir = mkdtempSync(path.join(tmpdir(), 'eco-build-start-contract-'));
-			tempDirs.push(rootDir);
-			process.chdir(rootDir);
+	it('emits a runnable server bundle and manifest when needsServerBundle is true', async () => {
+		process.env.NODE_ENV = 'production';
+		const rootDir = mkdtempSync(path.join(tmpdir(), 'eco-build-start-contract-'));
+		tempDirs.push(rootDir);
+		process.chdir(rootDir);
 
-			writeFileSync(path.join(rootDir, 'app.ts'), scenario.entry, 'utf8');
+		writeFileSync(path.join(rootDir, 'app.ts'), 'export const ready = true;\n', 'utf8');
 
-			const appConfig = await new ConfigBuilder()
-				.setRootDir(rootDir)
-				.setDistDir('dist')
-				.setWorkDir('.eco')
-				.build();
+		const appConfig = await new ConfigBuilder().setRootDir(rootDir).setDistDir('dist').setWorkDir('.eco').build();
 
-			const staticSiteGenerator = {
-				run: async () => {},
-			} as unknown as StaticSiteGenerator;
+		const staticSiteGenerator = {
+			run: async () => {},
+		} as unknown as StaticSiteGenerator;
 
-			const builder = new ServerStaticBuilder({
-				appConfig,
-				staticSiteGenerator,
-				serveOptions: { hostname: '127.0.0.1', port: 3000 },
-				runtimeOrigin: 'http://127.0.0.1:3000',
-				entryFile: 'app.ts',
-			});
-
-			await builder.build(undefined, {
-				router: {} as RouteRegistry,
-				routeRendererFactory: {} as StaticGenerationRendererResolver,
-			});
-
-			const { serverEntryPath, manifestPath } = getServerBundleOutputPaths(appConfig);
-
-			assert.equal(fileSystem.exists(serverEntryPath), true, 'expected dist/.server/app.mjs');
-			assert.equal(fileSystem.exists(manifestPath), true, 'expected dist/.server/manifest.json');
-
-			const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
-				serverEntry: string;
-				distDir: string;
-			};
-			assert.equal(manifest.serverEntry, SERVER_BUNDLE_FILENAME);
-			assert.equal(path.resolve(manifest.distDir), path.resolve(appConfig.absolutePaths.distDir));
-
-			const resolvedEntry = resolveProductionServerEntry(rootDir);
-			assert.equal(resolvedEntry, serverEntryPath);
+		const builder = new ServerStaticBuilder({
+			appConfig,
+			staticSiteGenerator,
+			serveOptions: { hostname: '127.0.0.1', port: 3000 },
+			runtimeOrigin: 'http://127.0.0.1:3000',
+			entryFile: 'app.ts',
+			needsServerBundle: true,
 		});
-	}
+
+		await builder.build(undefined, {
+			router: {} as RouteRegistry,
+			routeRendererFactory: {} as StaticGenerationRendererResolver,
+		});
+
+		const { serverEntryPath, manifestPath } = getServerBundleOutputPaths(appConfig);
+
+		assert.equal(fileSystem.exists(serverEntryPath), true, 'expected dist/.server/app.mjs');
+		assert.equal(fileSystem.exists(manifestPath), true, 'expected dist/.server/manifest.json');
+
+		const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+			serverEntry: string;
+			distDir: string;
+		};
+		assert.equal(manifest.serverEntry, SERVER_BUNDLE_FILENAME);
+		assert.equal(path.resolve(manifest.distDir), path.resolve(appConfig.absolutePaths.distDir));
+
+		const resolvedEntry = resolveProductionServerEntry(rootDir);
+		assert.equal(resolvedEntry, serverEntryPath);
+	});
+
+	it('does not emit a server bundle for static-only apps', async () => {
+		process.env.NODE_ENV = 'production';
+		const rootDir = mkdtempSync(path.join(tmpdir(), 'eco-build-start-contract-'));
+		tempDirs.push(rootDir);
+		process.chdir(rootDir);
+
+		writeFileSync(path.join(rootDir, 'app.ts'), 'export const ready = true;\n', 'utf8');
+
+		const appConfig = await new ConfigBuilder().setRootDir(rootDir).setDistDir('dist').setWorkDir('.eco').build();
+
+		const staticSiteGenerator = {
+			run: async () => {},
+		} as unknown as StaticSiteGenerator;
+
+		const builder = new ServerStaticBuilder({
+			appConfig,
+			staticSiteGenerator,
+			serveOptions: { hostname: '127.0.0.1', port: 3000 },
+			runtimeOrigin: 'http://127.0.0.1:3000',
+			entryFile: 'app.ts',
+		});
+
+		await builder.build(undefined, {
+			router: {} as RouteRegistry,
+			routeRendererFactory: {} as StaticGenerationRendererResolver,
+		});
+
+		const { serverEntryPath, manifestPath } = getServerBundleOutputPaths(appConfig);
+
+		assert.equal(fileSystem.exists(serverEntryPath), false, 'should not produce dist/.server/app.mjs');
+		assert.equal(fileSystem.exists(manifestPath), false, 'should not produce dist/.server/manifest.json');
+
+		const resolvedEntry = resolveProductionServerEntry(rootDir);
+		assert.equal(resolvedEntry, undefined);
+	});
 });

--- a/packages/core/src/adapters/shared/server-static-builder.test.ts
+++ b/packages/core/src/adapters/shared/server-static-builder.test.ts
@@ -113,7 +113,6 @@ function createMockDependencies() {
 		ServeOptions,
 		Router,
 		RouteRendererFactory,
-		ApiHandlers: [],
 	};
 }
 
@@ -498,7 +497,7 @@ describe('ServerStaticBuilder', () => {
 				return distDir;
 			}
 
-			it('bundles server entry even when no API endpoints are registered', async () => {
+			it('skips server entry bundling when needsServerBundle is false', async () => {
 				const { AppConfig, StaticSiteGenerator, ServeOptions, Router, RouteRendererFactory, logger, calls } =
 					createMockDependencies();
 				const distDir = setupBundleFixture('no-endpoints');
@@ -526,7 +525,7 @@ describe('ServerStaticBuilder', () => {
 					calls.info.some(
 						(m) => m === 'Bundling server entry file...' || m === 'Reusing cached server entry bundle',
 					),
-				).toBe(true);
+				).toBe(false);
 			});
 
 			it('throws when entry file does not exist', async () => {
@@ -545,7 +544,7 @@ describe('ServerStaticBuilder', () => {
 					runtimeOrigin: 'http://127.0.0.1:3000',
 					logger,
 					entryFile: 'nonexistent.ts',
-					apiHandlers: [{ method: 'GET', path: '/api/ping', handler: () => undefined } as any],
+					needsServerBundle: true,
 				});
 
 				await assert.rejects(
@@ -574,7 +573,7 @@ describe('ServerStaticBuilder', () => {
 					serveOptions: ServeOptions,
 					runtimeOrigin: 'http://127.0.0.1:3000',
 					logger,
-					apiHandlers: [{ method: 'GET', path: '/api/ping', handler: () => undefined } as any],
+					needsServerBundle: true,
 				});
 
 				await assert.rejects(
@@ -608,7 +607,7 @@ describe('ServerStaticBuilder', () => {
 						serveOptions: ServeOptions,
 						runtimeOrigin: 'http://127.0.0.1:3000',
 						logger,
-						apiHandlers: [{ method: 'GET', path: '/api/ping', handler: () => undefined } as any],
+						needsServerBundle: true,
 					});
 
 					await builder.build(undefined, {
@@ -647,7 +646,7 @@ describe('ServerStaticBuilder', () => {
 						runtimeOrigin: 'http://127.0.0.1:3000',
 						logger,
 						entryFile: 'app.ts',
-						apiHandlers: [{ method: 'GET', path: '/api/ping', handler: () => undefined } as any],
+						needsServerBundle: true,
 					});
 
 					await builder.build(undefined, {
@@ -697,7 +696,7 @@ describe('ServerStaticBuilder', () => {
 					serveOptions: ServeOptions,
 					runtimeOrigin: 'http://127.0.0.1:3000',
 					logger,
-					apiHandlers: [{ method: 'GET', path: '/api/ping', handler: () => undefined } as any],
+					needsServerBundle: true,
 				});
 
 				await builder.build(undefined, {

--- a/packages/core/src/adapters/shared/server-static-builder.ts
+++ b/packages/core/src/adapters/shared/server-static-builder.ts
@@ -18,7 +18,7 @@ import {
 import { resolveEntryFile, SERVER_BUNDLE_FILENAME } from '../../utils/resolve-entry-file.ts';
 import type { EcoPagesAppConfig, IHmrManager } from '../../types/internal-types.ts';
 import type { EcoBuildPlugin } from '../../build/build-types.ts';
-import type { ApiHandler, StaticRoute } from '../../types/public-types.ts';
+import type { StaticRoute } from '../../types/public-types.ts';
 import type { RouteRegistry } from '../../router/server/route-registry.ts';
 import type { StaticSiteGenerator } from '../../static-site-generator/static-site-generator.ts';
 import type { StaticGenerationRendererResolver } from '../../route-renderer/route-renderer.ts';
@@ -38,7 +38,12 @@ export interface ServerStaticBuilderParams {
 	staticSiteGenerator: StaticSiteGenerator;
 	serveOptions: ServeOptions;
 	runtimeOrigin: string;
-	apiHandlers?: ApiHandler[];
+	/**
+	 * Whether the app requires a server entry bundle for production use.
+	 * When `true`, the build step bundles the server entry file for `ecopages start`.
+	 * Defaults to `false` (static-only build, no server needed).
+	 */
+	needsServerBundle?: boolean;
 	logger?: ServerStaticBuilderLogger;
 	entryFile?: string;
 	hmrManager?: IHmrManager;
@@ -62,7 +67,7 @@ export class ServerStaticBuilder {
 	private readonly staticSiteGenerator: StaticSiteGenerator;
 	private readonly serveOptions: ServeOptions;
 	private readonly runtimeOrigin: string;
-	private readonly apiHandlers: ApiHandler[];
+	private readonly needsServerBundle: boolean;
 	private readonly logger: ServerStaticBuilderLogger;
 	private readonly entryFile: string;
 	private readonly hmrManager?: IHmrManager;
@@ -73,7 +78,7 @@ export class ServerStaticBuilder {
 		staticSiteGenerator,
 		serveOptions,
 		runtimeOrigin,
-		apiHandlers,
+		needsServerBundle,
 		logger,
 		entryFile,
 		hmrManager,
@@ -83,7 +88,7 @@ export class ServerStaticBuilder {
 		this.staticSiteGenerator = staticSiteGenerator;
 		this.serveOptions = serveOptions;
 		this.runtimeOrigin = runtimeOrigin;
-		this.apiHandlers = apiHandlers ?? [];
+		this.needsServerBundle = needsServerBundle ?? false;
 		this.logger = logger ?? appLogger;
 		this.entryFile = resolveEntryFile({ entryFile });
 		this.hmrManager = hmrManager;
@@ -137,9 +142,10 @@ export class ServerStaticBuilder {
 	 * Bundles the server entry file for production use.
 	 *
 	 * @remarks
-	 * Every production build emits a runnable server entry for `ecopages start`,
-	 * including static-only and websocket-only apps. Incremental builds may skip
-	 * Rolldown when the `.eco/.server-entry` cache is still valid.
+	 * Only invoked when the app requires a runtime server (API handlers,
+	 * websocket handlers, etc.). Static-only apps skip this step entirely.
+	 * Incremental builds may skip Rolldown when the `.eco/.server-entry`
+	 * cache is still valid.
 	 *
 	 * Package imports remain external so native addons and runtime-owned
 	 * dependencies continue to load through the app's installed
@@ -247,7 +253,10 @@ export class ServerStaticBuilder {
 
 		const preserveExportDirectory = this.prepareExportDirectory(force);
 		await this.refreshRuntimeAssets();
-		await this.bundleServerEntry({ force });
+
+		if (this.needsServerBundle) {
+			await this.bundleServerEntry({ force });
+		}
 
 		await this.staticSiteGenerator.run({
 			router: dependencies.router,

--- a/scripts/build-npm-packages.ts
+++ b/scripts/build-npm-packages.ts
@@ -12,13 +12,13 @@ import {
 } from 'node:fs';
 import { transform } from 'esbuild';
 import ts from 'typescript';
-import { readJsonFile, rewriteWorkspaceRanges, toPosix, type WorkspaceDependencyManifest } from './package-utils';
+import { readJsonFile, rewriteWorkspaceRanges, toPosix, type WorkspaceDependencyManifest } from './package-utils.ts';
 import {
 	assertBundledDependenciesInDist,
 	copyBundledDependenciesToDist,
 	findAllPackageDirs,
 	getBundleDependencyNames,
-} from './bundle-workspace-deps';
+} from './bundle-workspace-deps.ts';
 
 type PackageManifest = WorkspaceDependencyManifest & {
 	private?: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
+		"allowImportingTsExtensions": true,
+		"noEmit": true,
 		"esModuleInterop": true,
 		"experimentalDecorators": true,
 		"forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- Replace `apiHandlers` pass-through on `ServerStaticBuilder` with an explicit `needsServerBundle` flag (defaults to `false`)
- Node and Bun adapters derive the flag from registered API and websocket handlers
- Static-only production builds no longer emit `dist/.server/app.mjs` or its manifest
- Restore `.ts` extensions on `build-npm-packages.ts` local imports so `node` can resolve them at runtime
- Align root `tsconfig.json` with package conventions (`allowImportingTsExtensions`, `noEmit`)