### PR TITLE
docs(server): align server docs with v0.2.0 APIs

### DIFF
--- a/apps/docs/src/pages/docs/server/api-handlers.mdx
+++ b/apps/docs/src/pages/docs/server/api-handlers.mdx
@@ -15,14 +15,14 @@ Ecopages provides a straightforward way to define API endpoints within your appl
 
 ## Defining Handlers
 
-You define API handlers using methods on your `EcopagesApp` instance, typically in your `app.ts` file. Each method corresponds to an HTTP verb (GET, POST, etc.).
+You define API handlers using methods on your app instance, typically in your `app.ts` file. Each method corresponds to an HTTP verb (GET, POST, etc.).
 
 ```typescript
 // filepath: app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 // Define a GET handler
 app.get('/api/greet', async ({ response }) => {
@@ -179,7 +179,7 @@ Using the `ApiResponseBuilder` makes your API handler code cleaner, more readabl
 
 ## WebSocket Handlers
 
-If your application requires real-time bidirectional communication, you can define WebSocket handlers when starting your application. Ecopages inherits Bun's powerful WebSocket implementation.
+If your application requires real-time bidirectional communication, you can define WebSocket handlers when starting your application. Ecopages provides a runtime-agnostic WebSocket API (see [WebSockets](/docs/server/websockets)).
 
 ```typescript
 await app.start({
@@ -200,11 +200,11 @@ await app.start({
 Use `app.group()` to organize related routes under a shared prefix with optional middleware. This is useful for sections like admin panels or authenticated APIs.
 
 ```typescript
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import * as admin from './handlers/admin';
 import { authMiddleware } from './middleware/auth';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.group(
 	'/admin',

--- a/apps/docs/src/pages/docs/server/define-handlers.mdx
+++ b/apps/docs/src/pages/docs/server/define-handlers.mdx
@@ -45,7 +45,7 @@ Use `defineApiHandler` to create a self-contained handler with its path, method,
 
 ```typescript
 // handlers/blog.ts
-import { defineApiHandler } from '@ecopages/core/bun';
+import { defineApiHandler } from '@ecopages/core';
 
 export const list = defineApiHandler({
   path: '/api/posts',
@@ -73,13 +73,13 @@ Register handlers directly with HTTP method functions:
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import * as blog from './handlers/blog';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
-app.get(blog.list.path, blog.list.handler);
-app.get(blog.detail.path, blog.detail.handler);
+app.add(blog.list);
+app.add(blog.detail);
 
 await app.start();
 ```
@@ -89,7 +89,7 @@ await app.start();
 Define a schema to get typed access to request body, query parameters, and headers:
 
 ```typescript
-import { defineApiHandler } from '@ecopages/core/bun';
+import { defineApiHandler } from '@ecopages/core';
 import { z } from 'zod';
 
 const createPostSchema = {
@@ -121,7 +121,7 @@ export const createPost = defineApiHandler({
 Attach route-specific middleware that extends the handler context:
 
 ```typescript
-import { defineApiHandler } from '@ecopages/core/bun';
+import { defineApiHandler } from '@ecopages/core';
 import { rateLimitMiddleware } from './middleware/rate-limit';
 
 export const sensitiveEndpoint = defineApiHandler({
@@ -143,7 +143,7 @@ Use `defineGroupHandler` when you have multiple routes that share a URL prefix a
 
 ```typescript
 // handlers/admin.ts
-import { defineGroupHandler } from '@ecopages/core/bun';
+import { defineGroupHandler } from '@ecopages/core';
 import { authMiddleware } from './middleware/auth';
 import type { AuthenticatedContext } from './middleware/auth';
 
@@ -187,11 +187,11 @@ Register the entire group with `app.group()`:
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import { adminGroup } from './handlers/admin';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.group(adminGroup);
 
@@ -259,13 +259,13 @@ Middleware can extend the handler context with additional properties:
 
 ```typescript
 // middleware/auth.ts
-import type { BunMiddleware } from '@ecopages/core/bun';
+import type { EcoMiddleware } from '@ecopages/core';
 
 export type AuthenticatedContext = {
   session: { user: User; token: string };
 };
 
-export const authMiddleware: BunMiddleware<AuthenticatedContext> = async (ctx, next) => {
+export const authMiddleware: EcoMiddleware<AuthenticatedContext> = async (ctx, next) => {
   const token = ctx.request.headers.get('Authorization');
   const user = await validateToken(token);
   
@@ -284,7 +284,7 @@ When used with `defineGroupHandler`, all routes receive the extended context aut
 
 ```typescript
 // handlers/blog.ts
-import { defineApiHandler, defineGroupHandler } from '@ecopages/core/bun';
+import { defineApiHandler, defineGroupHandler } from '@ecopages/core';
 import { authMiddleware, type AuthenticatedContext } from '../middleware/auth';
 import { z } from 'zod';
 
@@ -359,14 +359,14 @@ export const protectedGroup = defineGroupHandler({
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import * as blog from './handlers/blog';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 // Public
-app.get(blog.list);
-app.get(blog.detail);
+app.add(blog.list);
+app.add(blog.detail);
 
 // Protected
 app.group(blog.protectedGroup);
@@ -394,4 +394,4 @@ interface GroupHandler<TPrefix> {
 }
 ```
 
-Both can be passed directly to `app.[method]()` or `app.group()` respectively.
+Both can be passed to `app.add()` for individual handlers or `app.group()` for grouped routes.

--- a/apps/docs/src/pages/docs/server/explicit-routing.mdx
+++ b/apps/docs/src/pages/docs/server/explicit-routing.mdx
@@ -25,13 +25,13 @@ For architectural patterns and code organization examples, see [Routing Patterns
 
 ## Basic Routes
 
-Define routes using HTTP method functions on your `EcopagesApp` instance:
+Define routes using HTTP method functions on your app instance:
 
 ```typescript
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.get('/api/users', async (ctx) => {
 	const users = await getUsers();
@@ -142,13 +142,12 @@ const logMiddleware: Middleware = async (ctx, next) => {
 
 ### Extending Context with Middleware
 
-Middleware can extend the request context with additional properties (like session data, user info, etc.). Use the `BunMiddleware` helper type to define middleware that adds properties to the context:
+Middleware can extend the request context with additional properties (like session data, user info, etc.). Use the `EcoMiddleware` helper type to define middleware that adds properties to the context:
 
 ```typescript
-import type { BunMiddleware } from '@ecopages/core/create-app';
+import type { EcoMiddleware } from '@ecopages/core';
 
-// Define middleware that extends context with session data
-const authMiddleware: BunMiddleware<{ session: Session }> = async (ctx, next) => {
+const authMiddleware: EcoMiddleware<{ session: Session }> = async (ctx, next) => {
 	const session = await getSession(ctx.request.headers);
 	if (!session) {
 		return Response.redirect('/login');
@@ -382,12 +381,14 @@ import { eco } from '@ecopages/core';
 const PostView = eco.page<PostViewProps>({
 	staticPaths: async () => {
 		const posts = await getPosts();
-		return posts.map((post) => ({ slug: post.slug }));
+		return {
+			paths: posts.map((post) => ({ params: { slug: post.slug } })),
+		};
 	},
 
 	staticProps: async ({ params }) => {
 		const post = await getPost(params.slug);
-		return { title: post.title, content: post.content };
+		return { props: { title: post.title, content: post.content } };
 	},
 
 	render: (props) => <article>...</article>
@@ -433,7 +434,7 @@ export default PostView;
 Explicit routes take precedence over file-system routes:
 
 ```typescript
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 // Explicit routes (higher priority)
 app.get('/posts', posts.index);
@@ -449,17 +450,16 @@ await app.start();
 ## Complete Example
 
 ```typescript
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import { HttpError } from '@ecopages/core/errors';
 import { z } from 'zod';
 import appConfig from './eco.config';
 import { PostView, PostListView } from './src/views';
-import type { BunMiddleware } from '@ecopages/core/create-app';
+import type { EcoMiddleware } from '@ecopages/core';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
-// Middleware that extends context
-const authMiddleware: BunMiddleware<{ session: Session }> = async (ctx, next) => {
+const authMiddleware: EcoMiddleware<{ session: Session }> = async (ctx, next) => {
 	const session = await getSession(ctx.request.headers);
 	if (!session) throw HttpError.Unauthorized();
 	ctx.session = session;

--- a/apps/docs/src/pages/docs/server/routing-patterns.mdx
+++ b/apps/docs/src/pages/docs/server/routing-patterns.mdx
@@ -84,12 +84,12 @@ For small projects or rapid prototyping, define everything inline in `app.ts`.
 ### Example
 
 ```typescript
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import { HttpError } from '@ecopages/core/errors';
 import { db } from './src/db';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.get('/posts', async (ctx) => {
 	const { default: PostListView } = await import('./src/views/post-list');
@@ -209,12 +209,12 @@ export async function destroy(ctx: ApiHandlerContext) {
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import * as posts from './src/handlers/posts';
 import * as users from './src/handlers/users';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 // Posts routes
 app.get('/posts', posts.index);
@@ -309,12 +309,12 @@ export function createPostsHandlers(db: Database) {
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import { createPostsHandlers } from './src/handlers/posts';
 import { db } from './src/db';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 const posts = createPostsHandlers(db);
 
 app.get('/posts', posts.index);
@@ -487,13 +487,13 @@ export class PostsController {
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import { PostsController } from './src/controllers/posts.controller';
 import { PostsService } from './src/services/posts.service';
 import { db } from './src/db';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 const postsService = new PostsService(db);
 const postsController = new PostsController(postsService);
@@ -700,14 +700,14 @@ export function createPostsHandlers(
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import { createBlogService } from './src/services/blog.service';
 import { postAdapter } from './src/adapters/post.adapter';
 import { createPostsHandlers } from './src/handlers/posts';
 import { db } from './src/db';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 const blogService = createBlogService(db);
 const posts = createPostsHandlers(blogService, postAdapter);
@@ -740,7 +740,7 @@ await app.start();
 You don't need to pick one pattern for your entire app. Mix patterns based on complexity:
 
 ```typescript
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 // Simple inline handler for about page
 app.get('/about', async (ctx) => {
@@ -770,7 +770,7 @@ Explicit routes take precedence over file-system routes. This allows you to:
 
 ```typescript
 // app.ts
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 // Explicit routes (higher priority)
 app.get('/posts', posts.index);

--- a/apps/docs/src/pages/docs/server/server-api.mdx
+++ b/apps/docs/src/pages/docs/server/server-api.mdx
@@ -18,10 +18,10 @@ Ecopages provides a powerful server API that allows you to create endpoints and 
 Create an `app.ts` file in your project root:
 
 ```typescript
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.get('/api/hello', async () => {
 	return new Response('Hello World');
@@ -60,24 +60,16 @@ app.get('/api/users/:id/posts/:postId', async ({ params }) => {
 
 Ecopages leverages TypeScript to provide strong type safety for your API handlers, especially for route parameters.
 
-Handlers can be defined directly, but keeping the `params` type aligned with the `path` string requires explicit manual typing. Ecopages provides adapter-specific helper functions to remove that duplication and keep route definitions organized.
-
-### Using `defineApiHandler`
-
-When using the Bun adapter, you can use the `defineApiHandler` helper function. This function automatically infers the parameter types from the `path` string literal, ensuring your `params` object is correctly typed without explicit annotations.
+Handlers can be defined directly, but keeping the `params` type aligned with the `path` string requires explicit manual typing. Use `defineApiHandler` to infer parameter types from the path literal and keep route definitions organized.
 
 ```typescript
-// Import the adapter-specific helper
-import { defineApiHandler } from '@ecopages/core/bun';
+import { defineApiHandler } from '@ecopages/core';
 
-// Define the handler using the helper
 const getUserHandler = defineApiHandler({
 	method: 'GET',
-	path: '/api/users/:id', // Type of 'id' is inferred from here
+	path: '/api/users/:id',
 	handler: async ({ params }) => {
-		// params is automatically typed as { id: string }
 		const { id } = params;
-		// Fetch user logic...
 		const user = { id: id, name: 'Example User' };
 
 		if (!user) {
@@ -87,22 +79,18 @@ const getUserHandler = defineApiHandler({
 	},
 });
 
-// Register the handler with the app
-app.get(getUserHandler.path, getUserHandler.handler);
+app.add(getUserHandler);
 
-// You can define multiple handlers this way and keep them organized
 const updateUserHandler = defineApiHandler({
 	method: 'PUT',
 	path: '/api/users/:id',
 	handler: async ({ params }) => {
 		const { id } = params;
-		// Update user logic...
 		return new Response(JSON.stringify({ id, message: 'User updated' }));
-	}
+	},
 });
 
-app.put(updateUserHandler.path, updateUserHandler.handler);
-
+app.add(updateUserHandler);
 ```
 
 ### Benefits of Using `defineApiHandler`
@@ -154,7 +142,7 @@ export default eco.page({
 
 The development server includes:
 
-- Hot Module Replacement (HMR) (beta)
+- Hot Module Replacement (HMR)
 - Automatic route reloading
 - API endpoint hot reloading
 - Static file serving
@@ -192,7 +180,7 @@ See [WebSockets](/docs/server/websockets) for the full guide.
 Ecopages provides a convenient `request()` method on the app instance that allows you to trigger internal HTTP requests for testing without needing to manage actual network connections.
 
 ```typescript
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 await app.start();
 
 const response = await app.request('/api/hello');


### PR DESCRIPTION
## Summary
- `@ecopages/core/bun` → `@ecopages/core`
- `BunMiddleware` → `EcoMiddleware`
- `EcopagesApp` → `createApp()`
- `app.get(handler)` → `app.add(handler)`
- Fix `staticPaths` / `staticProps` shapes in explicit routing docs

## Test plan
- [x] `pnpm --filter @ecopages/docs run build`
- [x] No stale `@ecopages/core/bun` / `BunMiddleware` / `EcopagesApp` in server docs

**Merge order:** PR 3 of 4 — merge after PR #2. Base: `release/changelog-first-entry-prep`.