### PR TITLE
docs: update core pages, nav, architecture, and skill.txt

### DIFF
--- a/apps/docs/src/data/docs-config.ts
+++ b/apps/docs/src/data/docs-config.ts
@@ -38,6 +38,7 @@ export const docsConfig: DocsConfig = {
 			pages: [
 				{ title: 'Concepts', slug: 'concepts' },
 				{ title: 'Architecture', slug: 'architecture' },
+				{ title: 'Build and Host', slug: 'build-and-host' },
 				{ title: 'Pages', slug: 'pages' },
 				{ title: 'Routing', slug: 'routing' },
 				{ title: 'Data Fetching', slug: 'data-fetching' },
@@ -45,6 +46,8 @@ export const docsConfig: DocsConfig = {
 				{ title: 'Layouts', slug: 'layouts' },
 				{ title: 'Components', slug: 'components' },
 				{ title: 'Includes', slug: 'includes' },
+				{ title: 'HMR', slug: 'hmr' },
+				{ title: 'Plugin Lifecycle', slug: 'plugin-lifecycle' },
 			],
 		},
 		{
@@ -64,6 +67,7 @@ export const docsConfig: DocsConfig = {
 			name: 'Integrations',
 			subdirectory: 'integrations',
 			pages: [
+				{ title: 'Overview', slug: 'overview' },
 				{ title: 'Kitajs', slug: 'kitajs' },
 				{ title: 'React', slug: 'react' },
 				{ title: 'Lit', slug: 'lit' },
@@ -77,6 +81,8 @@ export const docsConfig: DocsConfig = {
 			pages: [
 				{ title: 'Ecopages CLI', slug: 'ecopages' },
 				{ title: 'Packages', slug: 'packages' },
+				{ title: 'Vite Plugin', slug: 'vite-plugin' },
+				{ title: 'Radiant', slug: 'radiant' },
 				{ title: 'Browser Router', slug: 'browser-router' },
 				{ title: 'React Router', slug: 'react-router' },
 				{ title: 'File System', slug: 'file-system' },

--- a/apps/docs/src/pages/docs/core/architecture.mdx
+++ b/apps/docs/src/pages/docs/core/architecture.mdx
@@ -48,11 +48,15 @@ The integration and processor lifecycle is split into stable framework-owned pha
 
 See the dedicated [Plugin Lifecycle](/docs/core/plugin-lifecycle) guide for the exact ordering and boundaries.
 
+## Build and bundling
+
+Core uses [Rolldown](https://rolldown.rs) as the default bundled backend. Browser and server artifacts are produced through the build adapter; optional [Vite host](/docs/ecosystem/vite-plugin) integration delegates dev-server orchestration to Vite. See [Build and Host](/docs/core/build-and-host).
+
 ## Core Modules
 
 For those wishing to dive deeper, we recommend exploring the source code:
 
-- **[`EcopagesApp`](https://github.com/ecopages/ecopages/blob/main/packages/core/src/adapters/create-app.ts)**: The runtime-neutral application entry point that selects the active adapter.
+- **[`createApp`](https://github.com/ecopages/ecopages/blob/main/packages/core/src/adapters/create-app.ts)**: Recommended runtime entrypoint; selects Bun or Node adapter.
 - **[`SharedServerAdapter`](https://github.com/ecopages/ecopages/blob/main/packages/core/src/adapters/shared/server-adapter.ts)**: The core server logic shared across environments.
 - **[`BunServerAdapter`](https://github.com/ecopages/ecopages/blob/main/packages/core/src/adapters/bun/server-adapter.ts)**: Handles the low-level Bun server interface.
 - **[`NodeServerAdapter`](https://github.com/ecopages/ecopages/blob/main/packages/core/src/adapters/node/server-adapter.ts)**: Handles the low-level Node server interface.

--- a/apps/docs/src/pages/docs/core/build-and-host.mdx
+++ b/apps/docs/src/pages/docs/core/build-and-host.mdx
@@ -1,0 +1,42 @@
+import { DocsLayout } from '@/layouts/docs-layout';
+
+export const config = {
+	layout: DocsLayout,
+};
+
+export const getMetadata = () => ({
+	title: 'Docs | Build and Host',
+	description: 'How Ecopages builds browser and server artifacts with Rolldown and optional Vite host integration',
+});
+
+# Build and Host
+
+Ecopages separates **core-owned build execution** from **host-managed dev/build** boundaries.
+
+## Build ownership
+
+| Mode | Who owns the bundler | Typical use |
+|------|----------------------|-------------|
+| **Rolldown (default)** | `@ecopages/core` via the build adapter | CLI, Bun/Node runtime, production server bundles |
+| **Vite host** | Vite + `@ecopages/vite-plugin` | Vite dev server, host-managed module graph |
+
+Core uses [Rolldown](https://rolldown.rs) as the default bundled backend. Ecopages plugins are bridged to Rolldown through a single consolidated plugin to minimize FFI overhead.
+
+## What gets built
+
+- **Server entry** — app bootstrap and request handling
+- **Route modules** — page and layout server modules per integration
+- **Browser graphs** — Page Browser Graph entries and chunks per route or route cohort
+- **Static HTML** — build-time output for static cache strategies
+
+Development uses one-shot Rolldown builds with shared HMR and invalidation services; route-module and browser builds can run in parallel.
+
+## Runtime entrypoint
+
+Apps start through `createApp()` from `@ecopages/core/create-app`. It selects Bun when available and falls back to Node. Vite/Nitro hosts still use the same app config and `app.fetch()` contract.
+
+## Further reading
+
+- [Architecture](/docs/core/architecture)
+- [Vite Plugin](/docs/ecosystem/vite-plugin)
+- [Rolldown integration guide](https://github.com/ecopages/ecopages/blob/release/v0.2.0/docs/rolldown-integration-guide.md) in the repository

--- a/apps/docs/src/pages/docs/core/components.mdx
+++ b/apps/docs/src/pages/docs/core/components.mdx
@@ -6,12 +6,12 @@ export const config = {
 
 export const getMetadata = () => ({
 	title: 'Docs | Creating Components',
-	description: 'Learn how to create reusable components in Ecopages using ghtml',
+	description: 'Learn how to create reusable components in Ecopages with Ecopages JSX and eco.component',
 });
 
 # Creating Components in Ecopages
 
-Components are the building blocks of your Ecopages project. They allow you to create reusable pieces of UI that can be easily composed to build complex pages. In this guide, we'll explore how to create components using the default ghtml approach with `@ecopages/core`.
+Components are reusable UI units composed into pages and layouts. With **Ecopages JSX**, components are typically `.tsx` files using `eco.component` and JSX in `render`. The examples below use Radiant for client interactivity; the same dependency and lazy-loading patterns apply across integrations.
 
 ## Basic Component Structure
 

--- a/apps/docs/src/pages/docs/core/concepts.mdx
+++ b/apps/docs/src/pages/docs/core/concepts.mdx
@@ -214,10 +214,10 @@ This means you'll need to:
 Ecopages provides a simple and intuitive way to create API endpoints and handle server-side logic. You can find more details in the [Server API](/docs/server/server-api) documentation.
 
 ```typescript
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.get('/api/hello', async () => {
 	return new Response(JSON.stringify({ message: 'Hello world!' }));

--- a/apps/docs/src/pages/docs/core/includes.mdx
+++ b/apps/docs/src/pages/docs/core/includes.mdx
@@ -21,7 +21,7 @@ By default, Ecopages looks for three main include files:
 2. `head.{ext}`: The HTML head section
 3. `seo.{ext}`: SEO-related meta tags
 
-The extension depends on your chosen integration (e.g., `.kita.tsx`, `.lit.ts`, etc.).
+The extension depends on your chosen integration (e.g. `.tsx` for Ecopages JSX, `.kita.tsx`, `.lit.tsx`).
 
 ## Configuration
 

--- a/apps/docs/src/pages/docs/core/layouts.mdx
+++ b/apps/docs/src/pages/docs/core/layouts.mdx
@@ -17,8 +17,7 @@ Layouts are an essential part of structuring your Ecopages project. They provide
 
 Includes files are mandatory in Ecopages and play a crucial role in defining the overall structure of your HTML. There are two main includes files you need to be aware of:
 
-1. `html.ts`: Defines the outer HTML structure
-2. `head.ts`: Defines the content of the `<head>` tag
+1. `html.{ext}` and `head.{ext}` under `src/includes` (e.g. `html.tsx`, `head.tsx` with Ecopages JSX)
 
 These files are typically located in the `src/includes` directory.
 

--- a/apps/docs/src/pages/docs/core/pages.mdx
+++ b/apps/docs/src/pages/docs/core/pages.mdx
@@ -6,98 +6,84 @@ export const config = {
 
 export const getMetadata = () => ({
 	title: 'Docs | Creating Pages',
-	description: 'Learn how to create pages in Ecopages using the ghtml integration',
+	description: 'Learn how to create pages in Ecopages using Ecopages JSX',
 });
 
 # Creating Pages in Ecopages
 
-Pages are the core of your Ecopages project. They represent the different routes and content of your website. In this guide, we'll explore how to create pages using the ghtml integration.
+Pages are the core of your Ecopages project. They represent the different routes and content of your website. This guide uses **Ecopages JSX** (`.tsx` routes owned by `@ecopages/ecopages-jsx`), which matches the [Installation](/docs/getting-started/installation) default. Other integrations use the same `eco.page` API with different file extensions.
 
 ## Basic Page Structure
 
-A typical page in Ecopages using the ghtml integration consists of a single TypeScript file. Here's a basic example:
+A typical page is a single `.tsx` file under `src/pages`:
 
-```typescript
+```tsx
 import { BaseLayout } from '@/layouts/base-layout';
 import { eco } from '@ecopages/core';
-import { html } from '@ecopages/core/html';
 
 export default eco.page({
 	metadata: () => ({
 		title: 'Home page',
 		description: 'This is the homepage of the website',
-		image: 'public/assets/images/default-og.png',
-		keywords: ['typescript', 'framework', 'static'],
 	}),
 	dependencies: {
 		components: [BaseLayout],
 	},
-	render: () => html`${BaseLayout({
-		class: 'main-content',
-		children: html`<h1>Ecopages</h1><p>Welcome to my Ecopages website!</p>`,
-	})}`,
+	render: () => (
+		<BaseLayout class="main-content">
+			<h1>Ecopages</h1>
+			<p>Welcome to my Ecopages website!</p>
+		</BaseLayout>
+	),
 });
 ```
 
-Let's break down the key elements of a page:
+Key elements:
 
-1. **Imports**: Import necessary components and types from `@ecopages/core` and your project files.
-
-2. **`eco.page`**: Use the `eco.page` factory to create your page component.
-
-3. **Metadata**: Define page-specific metadata in the `metadata` property.
-
-4. **Dependencies**: Declare components, scripts, and stylesheets in the `dependencies` object.
-
-5. **Render**: Implement the `render` function to define your page's structure using the `html` template literal.
-
-6. **Export**: Export the result of `eco.page` as the default export.
+1. **`eco.page`**: Factory for a file-based route page.
+2. **`metadata`**: Page title, description, and social metadata.
+3. **`dependencies`**: Components, scripts, and stylesheets the page needs.
+4. **`render`**: Returns JSX for the page body (wrapped by layout and HTML shell).
 
 ## Using Components in Pages
 
-To use components in your pages, import them and include them in your HTML template:
+Import components and list them in `dependencies.components`:
 
-```typescript
+```tsx
 import { RadiantCounter } from '@/components/radiant-counter';
 import { BaseLayout } from '@/layouts/base-layout';
 import { eco } from '@ecopages/core';
-import { html } from '@ecopages/core/html';
 
 export default eco.page({
 	dependencies: {
 		components: [BaseLayout, RadiantCounter],
 	},
-	render: () => html`${BaseLayout({
-		class: 'main-content',
-		children: html`
+	render: () => (
+		<BaseLayout class="main-content">
 			<h1>Ecopages</h1>
-			${RadiantCounter({ count: 5 })}
-		`,
-	})}`,
+			<RadiantCounter count={5} />
+		</BaseLayout>
+	),
 });
 ```
 
 ## Working with Data
 
-Ecopages provides built-in support for data fetching and metadata management. For a deep dive into how to handle data at build-time and runtime, check out the [Data Fetching Guide](/docs/guides/data-fetching).
+For build-time and request-time data, see [Data Fetching](/docs/core/data-fetching).
 
 ## Lazy Loading Components
 
-Ecopages provides powerful tools for lazy loading components, which can significantly improve your site's performance.
+Lazy loading is configured on `dependencies.scripts` entries:
 
-Ecopages provides powerful tools for lazy loading components, which can significantly improve your site's performance.
-
-Lazy loading is handled directly within dependency entries in `dependencies.scripts`.
-
-```typescript
+```tsx
 import { eco } from '@ecopages/core';
 
 export const MyComponent = eco.component({
 	dependencies: {
-		scripts: [{ src: './my-component.script.ts', lazy: { 'on:interaction': 'mouseenter,focusin' } }], // Load on interaction
+		scripts: [{ src: './my-component.script.ts', lazy: { 'on:interaction': 'mouseenter,focusin' } }],
 	},
 	render: (props) => <my-component {...props} />,
 });
 ```
 
-When you define a lazy dependency, Ecopages automatically handles the injection of the required scripts only when the specified interaction occurs or when the component enters the viewport (using `on:visible`). This eliminates the need for manual script injection and keeps your initial bundle size small.
+See [Components](/docs/core/components) for more patterns.

--- a/apps/docs/src/pages/docs/core/routing.mdx
+++ b/apps/docs/src/pages/docs/core/routing.mdx
@@ -1,109 +1,98 @@
 import { DocsLayout } from '@/layouts/docs-layout';
 
 export const config = {
-    layout: DocsLayout,
+	layout: DocsLayout,
 };
 
 export const getMetadata = () => ({
-    title: 'Docs | Routing',
-    description: 'Learn how routing works in Ecopages, from file-based routes to dynamic parameters',
+	title: 'Docs | Routing',
+	description: 'Learn how routing works in Ecopages, from file-based routes to dynamic parameters',
 });
 
 # Routing
 
-Ecopages uses a file-based routing system for your pages and a programmatic routing system for your API endpoints. This combination provides both simplicity for content and flexibility for logic.
+Ecopages uses file-based routing for pages and programmatic routing for API endpoints.
 
 ## File-Based Routing
 
-Every file in your `src/pages` directory corresponds to a route in your application. The path of the file relative to `src/pages` determines the URL.
+Every file in your `src/pages` directory corresponds to a route. The path relative to `src/pages` determines the URL.
 
 ### Supported File Extensions
 
-Ecopages handles different file types based on your active integrations:
-- `.kita.tsx` (KitaJS)
-- `.tsx` (React)
-- `.lit.ts` (Lit)
-- `.mdx` (MDX)
-- `.ghtml.ts` (Core HTML)
+Extensions depend on your active integrations:
+
+- `.tsx` — [Ecopages JSX](/docs/integrations/ecopages-jsx) (default in Installation)
+- `.kita.tsx` — [KitaJS](/docs/integrations/kitajs)
+- `.tsx` with [React](/docs/integrations/react) when React owns the route
+- `.lit.tsx` — [Lit](/docs/integrations/lit)
+- `.mdx` — [MDX](/docs/integrations/mdx)
 
 ### Index Routes
 
-A file named `index` will represent the root of its directory.
-- `src/pages/index.kita.tsx` → `/`
-- `src/pages/blog/index.kita.tsx` → `/blog`
+- `src/pages/index.tsx` → `/`
+- `src/pages/blog/index.tsx` → `/blog`
 
 ### Nested Routes
 
-Simply create subdirectories in `src/pages` to create nested paths.
-- `src/pages/about/team.kita.tsx` → `/about/team`
+- `src/pages/about/team.tsx` → `/about/team`
 
 ---
 
 ## Dynamic Routes
 
-Ecopages supports dynamic routing using the square bracket syntax: `[param]`.
+Use bracket syntax: `[param]`.
 
-### Path Parameters
+- `src/pages/blog/[slug].tsx` → `/blog/:slug`
+- `src/pages/users/[id]/profile.tsx` → `/users/:id/profile`
 
-To create a dynamic path, use brackets in the filename or directory name.
-- `src/pages/blog/[slug].kita.tsx` → `/blog/:slug`
-- `src/pages/users/[id]/profile.kita.tsx` → `/users/:id/profile`
-
-Inside your page, you can access these parameters via `getStaticPaths` or `getStaticProps`.
+Access params via `staticPaths` and `staticProps` on `eco.page` views, or at request time with `cache: 'dynamic'`.
 
 ### Catch-all Routes
 
-You can capture all remaining path segments using `[...param]`.
-- `src/pages/docs/[...slug].kita.tsx` → `/docs/a`, `/docs/a/b`, `/docs/a/b/c`, etc.
+- `src/pages/docs/[...slug].tsx` → `/docs/a`, `/docs/a/b`, etc.
 
 ---
 
 ## Programmatic API Routing
 
-While pages are file-based, API routes are defined programmatically on your `EcopagesApp` instance, typically in `app.ts`.
+API routes are defined on your app instance in `app.ts`:
 
 ```typescript
-// app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
+import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig: config });
+const app = await createApp({ appConfig });
 
 app.get('/api/users/:id', async ({ params, response }) => {
-    const { id } = params;
-    return response.json({ userId: id });
+	return response.json({ userId: params.id });
 });
+
+await app.start();
 ```
+
+Use `app.add(handler)` for handlers created with `defineApiHandler`. See [Define Handlers](/docs/server/define-handlers).
 
 ### Route Priority
 
-1. **API Routes**: Programmatic routes defined in `app.ts` are evaluated first.
-2. **Static Files**: Files in the `public` directory are served if no API route matches.
-3. **File-Based Routes**: Pages in `src/pages` are evaluated last.
+1. **API / explicit routes** in `app.ts`
+2. **Static files** in `public`
+3. **File-based pages** in `src/pages`
 
 ---
 
 ## Route Configuration
 
-### Canonical Base URL
-
-In production, Ecopages needs to know your site's base URL to generate correct canonical links and social share images. This is set in `eco.config.ts`:
+Set the canonical base URL in `eco.config.ts`:
 
 ```typescript
 const config = await new ConfigBuilder()
-    .setBaseUrl('https://example.com')
-    .build();
+	.setBaseUrl('https://example.com')
+	.build();
 ```
 
-### 404 Error Page
+### 404 Page
 
-You can define a custom 404 page by creating a `404.{ext}` file in your `src/pages` directory:
-
-```typescript
-// src/pages/404.kita.tsx
-export default eco.page({
-    render: () => <h1>Not found</h1>,
-});
-```
+Create `404.tsx` (or your integration extension) under `src/pages`.
 
 ---
 
@@ -111,6 +100,6 @@ export default eco.page({
 
 | Type | Definition | Usage |
 | :--- | :--- | :--- |
-| **Static Pages** | `src/pages/*.{ext}` | Marketing, Docs, Blogs |
-| **Dynamic Pages** | `src/pages/[slug].{ext}` | Individual blog posts, user profiles |
-| **API Endpoints** | `app.get('/api/...')` | Data fetching, form submissions |
+| **Static pages** | `src/pages/*.{ext}` | Marketing, docs, blogs |
+| **Dynamic pages** | `src/pages/[slug].{ext}` | Posts, profiles |
+| **API endpoints** | `app.get('/api/...')` | Data, forms |

--- a/apps/docs/src/pages/docs/ecosystem/packages.mdx
+++ b/apps/docs/src/pages/docs/ecosystem/packages.mdx
@@ -40,7 +40,7 @@ These packages add support for different rendering engines.
 
 | Package | Purpose |
 | :--- | :--- |
-| **[`@ecopages/ecopages-jsx`](https://www.npmjs.com/package/@ecopages/ecopages-jsx)** | Ecopages-owned JSX routes with optional Radiant and MDX support. |
+| **[`@ecopages/ecopages-jsx`](https://jsr.io/@ecopages/ecopages-jsx)** | Ecopages-owned JSX routes with optional Radiant and MDX support. Published on **JSR** (ships TypeScript source; not on npm). |
 | **[`@ecopages/kitajs`](https://www.npmjs.com/package/@ecopages/kitajs)** | HTML-first JSX rendering for `.kita.tsx` routes. |
 | **[`@ecopages/react`](https://www.npmjs.com/package/@ecopages/react)** | React 19 support with SSR and hydration. |
 | **[`@ecopages/lit`](https://www.npmjs.com/package/@ecopages/lit)** | Lit Web Components integration with SSR support. |
@@ -50,7 +50,7 @@ These packages add support for different rendering engines.
 
 ## Processors & Loaders
 
-Tools for processing assets and extending Bun's loading capabilities.
+Tools for processing assets at build time.
 
 | Package | Purpose |
 | :--- | :--- |

--- a/apps/docs/src/pages/docs/ecosystem/react-router.mdx
+++ b/apps/docs/src/pages/docs/ecosystem/react-router.mdx
@@ -236,7 +236,7 @@ This allows for alternative router implementations while keeping the core integr
 | Framework | React only | MPA (KitaJS, Lit, vanilla) |
 | DOM Strategy | React reconciliation | morphdom diffing |
 | Layout Persistence | Via React component tree | Via `data-eco-persist` |
-| View Transitions | Not yet supported | Supported |
+| View Transitions | Supported | Supported |
 | State Preservation | React state in layout | DOM element state |
 
 ## License

--- a/apps/docs/src/pages/docs/ecosystem/vite-plugin.mdx
+++ b/apps/docs/src/pages/docs/ecosystem/vite-plugin.mdx
@@ -1,0 +1,58 @@
+import { CodeTabs } from '@/components/code-tabs';
+import { DocsLayout } from '@/layouts/docs-layout';
+
+export const config = {
+	layout: DocsLayout,
+};
+
+export const getMetadata = () => ({
+	title: 'Docs | Vite Plugin',
+	description: 'Run Ecopages inside a Vite dev and build host with @ecopages/vite-plugin',
+});
+
+# Vite Plugin
+
+`@ecopages/vite-plugin` integrates Ecopages with [Vite](https://vite.dev/) so you can use Vite's dev server, transforms, and plugin ecosystem alongside Ecopages routing and rendering.
+
+The plugin is **private to the monorepo** today but documents the host-side integration pattern used with Vite and Nitro-style deployments.
+
+## Installation
+
+<CodeTabs
+	name="vite-plugin-install"
+	tabs={[
+		{ id: 'pnpm', label: 'pnpm', code: 'pnpm add -D vite @ecopages/vite-plugin @ecopages/core' },
+		{ id: 'npm', label: 'npm', code: 'npm install -D vite @ecopages/vite-plugin @ecopages/core' },
+		{ id: 'bun', label: 'bun', code: 'bun add -d vite @ecopages/vite-plugin @ecopages/core' },
+	]}
+	defaultSelectedKey="pnpm"
+/>
+
+Export your app config from `eco.config.ts` using `ConfigBuilder` (see [Configuration](/docs/getting-started/configuration)).
+
+## Usage
+
+```typescript
+import { defineConfig } from 'vite';
+import { ecopages } from '@ecopages/vite-plugin';
+import appConfig from './eco.config';
+
+export default defineConfig({
+	plugins: [ecopages({ appConfig })],
+});
+```
+
+Register `ecopages()` **before** framework plugins such as `@vitejs/plugin-react` or Tailwind when those plugins also transform JSX or CSS.
+
+## What the plugin provides
+
+- Vite config merging for Ecopages defaults (aliases, `optimizeDeps`, `ssr.noExternal`)
+- Ecopages source transforms as Vite plugins
+- Virtual modules for integration manifests
+- Ecopages-aware HMR and dev-server bridging to `app.fetch()`
+
+## CLI vs Vite host
+
+The `ecopages` CLI runs apps through Bun or Node (`tsx`) directly. Use this plugin when you want Ecopages to run **inside** a Vite host for dev and build orchestration.
+
+See [Build and Host](/docs/core/build-and-host) for how this fits the Rolldown and Vite-host build model.

--- a/apps/docs/src/pages/docs/getting-started/introduction.mdx
+++ b/apps/docs/src/pages/docs/getting-started/introduction.mdx
@@ -17,7 +17,7 @@ export const getMetadata = () => ({
 <Banner type="alert">
 	<Banner.Title>Beta Notice</Banner.Title>
 	<p>
-		Ecopages is currently in beta. The API may change before the stable release. <a href="https://github.com/ecopages/ecopages/tree/main/examples" target="_blank">Check out the examples.</a>
+		Ecopages is currently in beta (`0.2.0` prerelease on the release branch). The API may change before the stable release. <a href="https://github.com/ecopages/ecopages/tree/main/examples" target="_blank">Check out the examples.</a>
 	</p>
 </Banner>
 
@@ -50,7 +50,7 @@ The result? Fast static pages, minimal dependencies, and code you can actually u
 3. **Static by Default**: Generate HTML at build time. Host anywhere. No server costs for most sites.
 
 4. **Lightweight, Safe Backend**:
-   - **Typed Handlers**: Define API handlers with full type inference using `defineHandlers`.
+   - **Typed Handlers**: Define API handlers with full type inference using `defineApiHandler`.
    - **Explicit Routing**: Use `app.get()`, `app.post()`, etc. for granular control over your API endpoints.
    - **Zero Overhead**: The server module is tree-shaken away when you only build static pages.
 
@@ -73,7 +73,7 @@ The result? Fast static pages, minimal dependencies, and code you can actually u
 
 - **Marketing sites** – Static pages with excellent SEO
 - **Documentation** – MDX-powered docs like the one you're reading
-- **Blogs** – Dynamic routes with `getStaticPaths` for each post
+- **Blogs** – Dynamic routes with `staticPaths` for each post
 - **Portfolios** – Beautiful static sites with interactive components
 - **Full-Stack Apps** – Combine static pages with typed API handlers for dynamic features
 - **Dashboards** – React or Lit components with live API data
@@ -131,10 +131,10 @@ Good for simple, quick endpoints.
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import config from './eco.config';
 
-const app = new EcopagesApp({ appConfig: config });
+const app = await createApp({ appConfig: config });
 
 app.get('/api/hello', async (ctx) => {
   return ctx.response.json({ message: 'Hello world!' });
@@ -146,7 +146,7 @@ For larger apps, define handlers in separate files using `defineApiHandler`. Thi
 
 ```typescript
 // handlers/greet.ts
-import { defineApiHandler } from '@ecopages/core/bun';
+import { defineApiHandler } from '@ecopages/core';
 import { z } from 'zod';
 
 export const greetHandler = defineApiHandler({
@@ -169,7 +169,7 @@ import { greetHandler } from './handlers/greet';
 
 // ... app initialization
 
-app.post(greetHandler.path, greetHandler.handler);
+app.add(greetHandler);
 ```
 
 ## AI Agents & Ecopages

--- a/apps/docs/src/pages/docs/reference/cli-reference.mdx
+++ b/apps/docs/src/pages/docs/reference/cli-reference.mdx
@@ -110,7 +110,7 @@ Used for generating absolute URLs in production builds (meta tags, sitemaps, etc
 ### Server Hostname & Port
 Used to determine where the server listens.
 
-1. **`serverOptions`**: Highest priority. Passed to the `EcopagesApp` constructor.
+1. **`serverOptions`**: Highest priority. Passed to `createApp()` options.
 2. **Environment Variables**: `ECOPAGES_PORT` and `ECOPAGES_HOSTNAME`.
 3. **Defaults**: `localhost:3000`.
 

--- a/apps/docs/src/pages/docs/reference/deployment.mdx
+++ b/apps/docs/src/pages/docs/reference/deployment.mdx
@@ -18,6 +18,8 @@ Deploying an Ecopages application depends on whether you are using only static f
 
 Before deploying, you must create a production build. This processes your assets, pre-renders static pages, and prepares the `dist` directory.
 
+For projects using the [Vite host plugin](/docs/ecosystem/vite-plugin), `ecopages build` still produces the same `dist` output; Vite orchestrates dev and optional build integration only.
+
 ```bash
 pnpm run build
 ```

--- a/apps/docs/src/public/skill.txt
+++ b/apps/docs/src/public/skill.txt
@@ -208,10 +208,10 @@ export default config;
 Create `app.ts`:
 
 ```typescript
-import { EcopagesApp } from "@ecopages/core/create-app";
+import { createApp } from "@ecopages/core/create-app";
 import appConfig from "./eco.config";
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 await app.start();
 ```
@@ -350,7 +350,7 @@ export default eco.page<{ user: User }>({
 
 ```typescript
 // src/handlers/dashboard.ts
-import { defineGroupHandler } from "@ecopages/core/bun";
+import { defineGroupHandler } from "@ecopages/core";
 
 export const dashboardGroup = defineGroupHandler({
   prefix: "/dashboard",
@@ -411,7 +411,7 @@ export function SimpleButton({ label, onClick }) {
 For individual API routes:
 
 ```typescript
-import { defineApiHandler } from "@ecopages/core/bun";
+import { defineApiHandler } from "@ecopages/core";
 import { z } from "zod";
 
 const createPostSchema = {
@@ -437,7 +437,7 @@ export const createPost = defineApiHandler({
 For routes that share a prefix and middleware:
 
 ```typescript
-import { defineGroupHandler } from "@ecopages/core/bun";
+import { defineGroupHandler } from "@ecopages/core";
 import { authMiddleware } from "./auth";
 
 export const adminGroup = defineGroupHandler({
@@ -467,7 +467,7 @@ Register handlers in `app.ts`:
 import * as posts from "./src/handlers/posts";
 import { adminGroup } from "./src/handlers/admin";
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.post(posts.createPost);
 app.group(adminGroup);
@@ -925,12 +925,12 @@ Create `src/handlers/auth.ts`:
 
 ```typescript
 import type { ApiHandlerContext } from "@ecopages/core";
-import type { BunMiddleware } from "@ecopages/core/bun";
+import type { EcoMiddleware } from "@ecopages/core";
 import { auth } from "@/lib/auth";
 
 export type Session = (typeof auth)["$Infer"]["Session"];
 
-export const authMiddleware: BunMiddleware<{ session: Session }> = async (
+export const authMiddleware: EcoMiddleware<{ session: Session }> = async (
   ctx,
   next
 ) => {
@@ -954,11 +954,11 @@ export const authHandler = async (ctx: ApiHandlerContext) => {
 In `app.ts`:
 
 ```typescript
-import { EcopagesApp } from "@ecopages/core/create-app";
+import { createApp } from "@ecopages/core/create-app";
 import appConfig from "./eco.config";
 import * as auth from "./src/handlers/auth";
 
-new EcopagesApp({ appConfig })
+await createApp({ appConfig })
   .get("/api/auth/*", auth.authHandler)
   .post("/api/auth/*", auth.authHandler)
   .put("/api/auth/*", auth.authHandler)
@@ -1020,7 +1020,7 @@ export const AuthNav = eco.component({
 Use `authMiddleware` with `defineGroupHandler`:
 
 ```typescript
-import { defineGroupHandler } from "@ecopages/core/bun";
+import { defineGroupHandler } from "@ecopages/core";
 import { authMiddleware } from "./auth";
 
 export const protectedGroup = defineGroupHandler({


### PR DESCRIPTION
## Summary
- Rewrite core pages for Ecopages JSX defaults (pages, routing, concepts)
- Add `build-and-host.mdx` and `vite-plugin.mdx`; update docs nav
- Architecture Rolldown/Vite-host section; JSR-only note for `@ecopages/ecopages-jsx`
- Fix `skill.txt`, introduction beta banner, deployment/cli-reference

## Test plan
- [x] `pnpm --filter @ecopages/docs run build`
- [x] `pnpm run build:docs`

**Merge order:** PR 4 of 4 — merge last. Base: `docs/server-api-fixes`. After all four land on `release/v0.2.0`, ready for future stable publish (no merge to `main` in this program).