### PR TITLE
docs: v0.2.0 release prep — changelogs, server APIs, and docs site

### DIFF
--- a/apps/docs/src/data/docs-config.ts
+++ b/apps/docs/src/data/docs-config.ts
@@ -38,6 +38,7 @@ export const docsConfig: DocsConfig = {
 			pages: [
 				{ title: 'Concepts', slug: 'concepts' },
 				{ title: 'Architecture', slug: 'architecture' },
+				{ title: 'Build and Host', slug: 'build-and-host' },
 				{ title: 'Pages', slug: 'pages' },
 				{ title: 'Routing', slug: 'routing' },
 				{ title: 'Data Fetching', slug: 'data-fetching' },
@@ -45,6 +46,8 @@ export const docsConfig: DocsConfig = {
 				{ title: 'Layouts', slug: 'layouts' },
 				{ title: 'Components', slug: 'components' },
 				{ title: 'Includes', slug: 'includes' },
+				{ title: 'HMR', slug: 'hmr' },
+				{ title: 'Plugin Lifecycle', slug: 'plugin-lifecycle' },
 			],
 		},
 		{
@@ -64,6 +67,7 @@ export const docsConfig: DocsConfig = {
 			name: 'Integrations',
 			subdirectory: 'integrations',
 			pages: [
+				{ title: 'Overview', slug: 'overview' },
 				{ title: 'Kitajs', slug: 'kitajs' },
 				{ title: 'React', slug: 'react' },
 				{ title: 'Lit', slug: 'lit' },
@@ -77,6 +81,8 @@ export const docsConfig: DocsConfig = {
 			pages: [
 				{ title: 'Ecopages CLI', slug: 'ecopages' },
 				{ title: 'Packages', slug: 'packages' },
+				{ title: 'Vite Plugin', slug: 'vite-plugin' },
+				{ title: 'Radiant', slug: 'radiant' },
 				{ title: 'Browser Router', slug: 'browser-router' },
 				{ title: 'React Router', slug: 'react-router' },
 				{ title: 'File System', slug: 'file-system' },

--- a/apps/docs/src/pages/docs/core/architecture.mdx
+++ b/apps/docs/src/pages/docs/core/architecture.mdx
@@ -48,11 +48,15 @@ The integration and processor lifecycle is split into stable framework-owned pha
 
 See the dedicated [Plugin Lifecycle](/docs/core/plugin-lifecycle) guide for the exact ordering and boundaries.
 
+## Build and bundling
+
+Core uses [Rolldown](https://rolldown.rs) as the default bundled backend. Browser and server artifacts are produced through the build adapter; optional [Vite host](/docs/ecosystem/vite-plugin) integration delegates dev-server orchestration to Vite. See [Build and Host](/docs/core/build-and-host).
+
 ## Core Modules
 
 For those wishing to dive deeper, we recommend exploring the source code:
 
-- **[`EcopagesApp`](https://github.com/ecopages/ecopages/blob/main/packages/core/src/adapters/create-app.ts)**: The runtime-neutral application entry point that selects the active adapter.
+- **[`createApp`](https://github.com/ecopages/ecopages/blob/main/packages/core/src/adapters/create-app.ts)**: Recommended runtime entrypoint; selects Bun or Node adapter.
 - **[`SharedServerAdapter`](https://github.com/ecopages/ecopages/blob/main/packages/core/src/adapters/shared/server-adapter.ts)**: The core server logic shared across environments.
 - **[`BunServerAdapter`](https://github.com/ecopages/ecopages/blob/main/packages/core/src/adapters/bun/server-adapter.ts)**: Handles the low-level Bun server interface.
 - **[`NodeServerAdapter`](https://github.com/ecopages/ecopages/blob/main/packages/core/src/adapters/node/server-adapter.ts)**: Handles the low-level Node server interface.

--- a/apps/docs/src/pages/docs/core/build-and-host.mdx
+++ b/apps/docs/src/pages/docs/core/build-and-host.mdx
@@ -1,0 +1,42 @@
+import { DocsLayout } from '@/layouts/docs-layout';
+
+export const config = {
+	layout: DocsLayout,
+};
+
+export const getMetadata = () => ({
+	title: 'Docs | Build and Host',
+	description: 'How Ecopages builds browser and server artifacts with Rolldown and optional Vite host integration',
+});
+
+# Build and Host
+
+Ecopages separates **core-owned build execution** from **host-managed dev/build** boundaries.
+
+## Build ownership
+
+| Mode | Who owns the bundler | Typical use |
+|------|----------------------|-------------|
+| **Rolldown (default)** | `@ecopages/core` via the build adapter | CLI, Bun/Node runtime, production server bundles |
+| **Vite host** | Vite + `@ecopages/vite-plugin` | Vite dev server, host-managed module graph |
+
+Core uses [Rolldown](https://rolldown.rs) as the default bundled backend. Ecopages plugins are bridged to Rolldown through a single consolidated plugin to minimize FFI overhead.
+
+## What gets built
+
+- **Server entry** — app bootstrap and request handling
+- **Route modules** — page and layout server modules per integration
+- **Browser graphs** — Page Browser Graph entries and chunks per route or route cohort
+- **Static HTML** — build-time output for static cache strategies
+
+Development uses one-shot Rolldown builds with shared HMR and invalidation services; route-module and browser builds can run in parallel.
+
+## Runtime entrypoint
+
+Apps start through `createApp()` from `@ecopages/core/create-app`. It selects Bun when available and falls back to Node. Vite/Nitro hosts still use the same app config and `app.fetch()` contract.
+
+## Further reading
+
+- [Architecture](/docs/core/architecture)
+- [Vite Plugin](/docs/ecosystem/vite-plugin)
+- [Rolldown integration guide](https://github.com/ecopages/ecopages/blob/release/v0.2.0/docs/rolldown-integration-guide.md) in the repository

--- a/apps/docs/src/pages/docs/core/components.mdx
+++ b/apps/docs/src/pages/docs/core/components.mdx
@@ -6,12 +6,12 @@ export const config = {
 
 export const getMetadata = () => ({
 	title: 'Docs | Creating Components',
-	description: 'Learn how to create reusable components in Ecopages using ghtml',
+	description: 'Learn how to create reusable components in Ecopages with Ecopages JSX and eco.component',
 });
 
 # Creating Components in Ecopages
 
-Components are the building blocks of your Ecopages project. They allow you to create reusable pieces of UI that can be easily composed to build complex pages. In this guide, we'll explore how to create components using the default ghtml approach with `@ecopages/core`.
+Components are reusable UI units composed into pages and layouts. With **Ecopages JSX**, components are typically `.tsx` files using `eco.component` and JSX in `render`. The examples below use Radiant for client interactivity; the same dependency and lazy-loading patterns apply across integrations.
 
 ## Basic Component Structure
 

--- a/apps/docs/src/pages/docs/core/concepts.mdx
+++ b/apps/docs/src/pages/docs/core/concepts.mdx
@@ -214,10 +214,10 @@ This means you'll need to:
 Ecopages provides a simple and intuitive way to create API endpoints and handle server-side logic. You can find more details in the [Server API](/docs/server/server-api) documentation.
 
 ```typescript
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.get('/api/hello', async () => {
 	return new Response(JSON.stringify({ message: 'Hello world!' }));

--- a/apps/docs/src/pages/docs/core/includes.mdx
+++ b/apps/docs/src/pages/docs/core/includes.mdx
@@ -21,7 +21,7 @@ By default, Ecopages looks for three main include files:
 2. `head.{ext}`: The HTML head section
 3. `seo.{ext}`: SEO-related meta tags
 
-The extension depends on your chosen integration (e.g., `.kita.tsx`, `.lit.ts`, etc.).
+The extension depends on your chosen integration (e.g. `.tsx` for Ecopages JSX, `.kita.tsx`, `.lit.tsx`).
 
 ## Configuration
 

--- a/apps/docs/src/pages/docs/core/layouts.mdx
+++ b/apps/docs/src/pages/docs/core/layouts.mdx
@@ -17,8 +17,7 @@ Layouts are an essential part of structuring your Ecopages project. They provide
 
 Includes files are mandatory in Ecopages and play a crucial role in defining the overall structure of your HTML. There are two main includes files you need to be aware of:
 
-1. `html.ts`: Defines the outer HTML structure
-2. `head.ts`: Defines the content of the `<head>` tag
+1. `html.{ext}` and `head.{ext}` under `src/includes` (e.g. `html.tsx`, `head.tsx` with Ecopages JSX)
 
 These files are typically located in the `src/includes` directory.
 

--- a/apps/docs/src/pages/docs/core/pages.mdx
+++ b/apps/docs/src/pages/docs/core/pages.mdx
@@ -6,98 +6,84 @@ export const config = {
 
 export const getMetadata = () => ({
 	title: 'Docs | Creating Pages',
-	description: 'Learn how to create pages in Ecopages using the ghtml integration',
+	description: 'Learn how to create pages in Ecopages using Ecopages JSX',
 });
 
 # Creating Pages in Ecopages
 
-Pages are the core of your Ecopages project. They represent the different routes and content of your website. In this guide, we'll explore how to create pages using the ghtml integration.
+Pages are the core of your Ecopages project. They represent the different routes and content of your website. This guide uses **Ecopages JSX** (`.tsx` routes owned by `@ecopages/ecopages-jsx`), which matches the [Installation](/docs/getting-started/installation) default. Other integrations use the same `eco.page` API with different file extensions.
 
 ## Basic Page Structure
 
-A typical page in Ecopages using the ghtml integration consists of a single TypeScript file. Here's a basic example:
+A typical page is a single `.tsx` file under `src/pages`:
 
-```typescript
+```tsx
 import { BaseLayout } from '@/layouts/base-layout';
 import { eco } from '@ecopages/core';
-import { html } from '@ecopages/core/html';
 
 export default eco.page({
 	metadata: () => ({
 		title: 'Home page',
 		description: 'This is the homepage of the website',
-		image: 'public/assets/images/default-og.png',
-		keywords: ['typescript', 'framework', 'static'],
 	}),
 	dependencies: {
 		components: [BaseLayout],
 	},
-	render: () => html`${BaseLayout({
-		class: 'main-content',
-		children: html`<h1>Ecopages</h1><p>Welcome to my Ecopages website!</p>`,
-	})}`,
+	render: () => (
+		<BaseLayout class="main-content">
+			<h1>Ecopages</h1>
+			<p>Welcome to my Ecopages website!</p>
+		</BaseLayout>
+	),
 });
 ```
 
-Let's break down the key elements of a page:
+Key elements:
 
-1. **Imports**: Import necessary components and types from `@ecopages/core` and your project files.
-
-2. **`eco.page`**: Use the `eco.page` factory to create your page component.
-
-3. **Metadata**: Define page-specific metadata in the `metadata` property.
-
-4. **Dependencies**: Declare components, scripts, and stylesheets in the `dependencies` object.
-
-5. **Render**: Implement the `render` function to define your page's structure using the `html` template literal.
-
-6. **Export**: Export the result of `eco.page` as the default export.
+1. **`eco.page`**: Factory for a file-based route page.
+2. **`metadata`**: Page title, description, and social metadata.
+3. **`dependencies`**: Components, scripts, and stylesheets the page needs.
+4. **`render`**: Returns JSX for the page body (wrapped by layout and HTML shell).
 
 ## Using Components in Pages
 
-To use components in your pages, import them and include them in your HTML template:
+Import components and list them in `dependencies.components`:
 
-```typescript
+```tsx
 import { RadiantCounter } from '@/components/radiant-counter';
 import { BaseLayout } from '@/layouts/base-layout';
 import { eco } from '@ecopages/core';
-import { html } from '@ecopages/core/html';
 
 export default eco.page({
 	dependencies: {
 		components: [BaseLayout, RadiantCounter],
 	},
-	render: () => html`${BaseLayout({
-		class: 'main-content',
-		children: html`
+	render: () => (
+		<BaseLayout class="main-content">
 			<h1>Ecopages</h1>
-			${RadiantCounter({ count: 5 })}
-		`,
-	})}`,
+			<RadiantCounter count={5} />
+		</BaseLayout>
+	),
 });
 ```
 
 ## Working with Data
 
-Ecopages provides built-in support for data fetching and metadata management. For a deep dive into how to handle data at build-time and runtime, check out the [Data Fetching Guide](/docs/guides/data-fetching).
+For build-time and request-time data, see [Data Fetching](/docs/core/data-fetching).
 
 ## Lazy Loading Components
 
-Ecopages provides powerful tools for lazy loading components, which can significantly improve your site's performance.
+Lazy loading is configured on `dependencies.scripts` entries:
 
-Ecopages provides powerful tools for lazy loading components, which can significantly improve your site's performance.
-
-Lazy loading is handled directly within dependency entries in `dependencies.scripts`.
-
-```typescript
+```tsx
 import { eco } from '@ecopages/core';
 
 export const MyComponent = eco.component({
 	dependencies: {
-		scripts: [{ src: './my-component.script.ts', lazy: { 'on:interaction': 'mouseenter,focusin' } }], // Load on interaction
+		scripts: [{ src: './my-component.script.ts', lazy: { 'on:interaction': 'mouseenter,focusin' } }],
 	},
 	render: (props) => <my-component {...props} />,
 });
 ```
 
-When you define a lazy dependency, Ecopages automatically handles the injection of the required scripts only when the specified interaction occurs or when the component enters the viewport (using `on:visible`). This eliminates the need for manual script injection and keeps your initial bundle size small.
+See [Components](/docs/core/components) for more patterns.

--- a/apps/docs/src/pages/docs/core/routing.mdx
+++ b/apps/docs/src/pages/docs/core/routing.mdx
@@ -1,109 +1,98 @@
 import { DocsLayout } from '@/layouts/docs-layout';
 
 export const config = {
-    layout: DocsLayout,
+	layout: DocsLayout,
 };
 
 export const getMetadata = () => ({
-    title: 'Docs | Routing',
-    description: 'Learn how routing works in Ecopages, from file-based routes to dynamic parameters',
+	title: 'Docs | Routing',
+	description: 'Learn how routing works in Ecopages, from file-based routes to dynamic parameters',
 });
 
 # Routing
 
-Ecopages uses a file-based routing system for your pages and a programmatic routing system for your API endpoints. This combination provides both simplicity for content and flexibility for logic.
+Ecopages uses file-based routing for pages and programmatic routing for API endpoints.
 
 ## File-Based Routing
 
-Every file in your `src/pages` directory corresponds to a route in your application. The path of the file relative to `src/pages` determines the URL.
+Every file in your `src/pages` directory corresponds to a route. The path relative to `src/pages` determines the URL.
 
 ### Supported File Extensions
 
-Ecopages handles different file types based on your active integrations:
-- `.kita.tsx` (KitaJS)
-- `.tsx` (React)
-- `.lit.ts` (Lit)
-- `.mdx` (MDX)
-- `.ghtml.ts` (Core HTML)
+Extensions depend on your active integrations:
+
+- `.tsx` — [Ecopages JSX](/docs/integrations/ecopages-jsx) (default in Installation)
+- `.kita.tsx` — [KitaJS](/docs/integrations/kitajs)
+- `.tsx` with [React](/docs/integrations/react) when React owns the route
+- `.lit.tsx` — [Lit](/docs/integrations/lit)
+- `.mdx` — [MDX](/docs/integrations/mdx)
 
 ### Index Routes
 
-A file named `index` will represent the root of its directory.
-- `src/pages/index.kita.tsx` → `/`
-- `src/pages/blog/index.kita.tsx` → `/blog`
+- `src/pages/index.tsx` → `/`
+- `src/pages/blog/index.tsx` → `/blog`
 
 ### Nested Routes
 
-Simply create subdirectories in `src/pages` to create nested paths.
-- `src/pages/about/team.kita.tsx` → `/about/team`
+- `src/pages/about/team.tsx` → `/about/team`
 
 ---
 
 ## Dynamic Routes
 
-Ecopages supports dynamic routing using the square bracket syntax: `[param]`.
+Use bracket syntax: `[param]`.
 
-### Path Parameters
+- `src/pages/blog/[slug].tsx` → `/blog/:slug`
+- `src/pages/users/[id]/profile.tsx` → `/users/:id/profile`
 
-To create a dynamic path, use brackets in the filename or directory name.
-- `src/pages/blog/[slug].kita.tsx` → `/blog/:slug`
-- `src/pages/users/[id]/profile.kita.tsx` → `/users/:id/profile`
-
-Inside your page, you can access these parameters via `getStaticPaths` or `getStaticProps`.
+Access params via `staticPaths` and `staticProps` on `eco.page` views, or at request time with `cache: 'dynamic'`.
 
 ### Catch-all Routes
 
-You can capture all remaining path segments using `[...param]`.
-- `src/pages/docs/[...slug].kita.tsx` → `/docs/a`, `/docs/a/b`, `/docs/a/b/c`, etc.
+- `src/pages/docs/[...slug].tsx` → `/docs/a`, `/docs/a/b`, etc.
 
 ---
 
 ## Programmatic API Routing
 
-While pages are file-based, API routes are defined programmatically on your `EcopagesApp` instance, typically in `app.ts`.
+API routes are defined on your app instance in `app.ts`:
 
 ```typescript
-// app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
+import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig: config });
+const app = await createApp({ appConfig });
 
 app.get('/api/users/:id', async ({ params, response }) => {
-    const { id } = params;
-    return response.json({ userId: id });
+	return response.json({ userId: params.id });
 });
+
+await app.start();
 ```
+
+Use `app.add(handler)` for handlers created with `defineApiHandler`. See [Define Handlers](/docs/server/define-handlers).
 
 ### Route Priority
 
-1. **API Routes**: Programmatic routes defined in `app.ts` are evaluated first.
-2. **Static Files**: Files in the `public` directory are served if no API route matches.
-3. **File-Based Routes**: Pages in `src/pages` are evaluated last.
+1. **API / explicit routes** in `app.ts`
+2. **Static files** in `public`
+3. **File-based pages** in `src/pages`
 
 ---
 
 ## Route Configuration
 
-### Canonical Base URL
-
-In production, Ecopages needs to know your site's base URL to generate correct canonical links and social share images. This is set in `eco.config.ts`:
+Set the canonical base URL in `eco.config.ts`:
 
 ```typescript
 const config = await new ConfigBuilder()
-    .setBaseUrl('https://example.com')
-    .build();
+	.setBaseUrl('https://example.com')
+	.build();
 ```
 
-### 404 Error Page
+### 404 Page
 
-You can define a custom 404 page by creating a `404.{ext}` file in your `src/pages` directory:
-
-```typescript
-// src/pages/404.kita.tsx
-export default eco.page({
-    render: () => <h1>Not found</h1>,
-});
-```
+Create `404.tsx` (or your integration extension) under `src/pages`.
 
 ---
 
@@ -111,6 +100,6 @@ export default eco.page({
 
 | Type | Definition | Usage |
 | :--- | :--- | :--- |
-| **Static Pages** | `src/pages/*.{ext}` | Marketing, Docs, Blogs |
-| **Dynamic Pages** | `src/pages/[slug].{ext}` | Individual blog posts, user profiles |
-| **API Endpoints** | `app.get('/api/...')` | Data fetching, form submissions |
+| **Static pages** | `src/pages/*.{ext}` | Marketing, docs, blogs |
+| **Dynamic pages** | `src/pages/[slug].{ext}` | Posts, profiles |
+| **API endpoints** | `app.get('/api/...')` | Data, forms |

--- a/apps/docs/src/pages/docs/ecosystem/packages.mdx
+++ b/apps/docs/src/pages/docs/ecosystem/packages.mdx
@@ -40,7 +40,7 @@ These packages add support for different rendering engines.
 
 | Package | Purpose |
 | :--- | :--- |
-| **[`@ecopages/ecopages-jsx`](https://www.npmjs.com/package/@ecopages/ecopages-jsx)** | Ecopages-owned JSX routes with optional Radiant and MDX support. |
+| **[`@ecopages/ecopages-jsx`](https://jsr.io/@ecopages/ecopages-jsx)** | Ecopages-owned JSX routes with optional Radiant and MDX support. Published on **JSR** (ships TypeScript source; not on npm). |
 | **[`@ecopages/kitajs`](https://www.npmjs.com/package/@ecopages/kitajs)** | HTML-first JSX rendering for `.kita.tsx` routes. |
 | **[`@ecopages/react`](https://www.npmjs.com/package/@ecopages/react)** | React 19 support with SSR and hydration. |
 | **[`@ecopages/lit`](https://www.npmjs.com/package/@ecopages/lit)** | Lit Web Components integration with SSR support. |
@@ -50,7 +50,7 @@ These packages add support for different rendering engines.
 
 ## Processors & Loaders
 
-Tools for processing assets and extending Bun's loading capabilities.
+Tools for processing assets at build time.
 
 | Package | Purpose |
 | :--- | :--- |

--- a/apps/docs/src/pages/docs/ecosystem/react-router.mdx
+++ b/apps/docs/src/pages/docs/ecosystem/react-router.mdx
@@ -236,7 +236,7 @@ This allows for alternative router implementations while keeping the core integr
 | Framework | React only | MPA (KitaJS, Lit, vanilla) |
 | DOM Strategy | React reconciliation | morphdom diffing |
 | Layout Persistence | Via React component tree | Via `data-eco-persist` |
-| View Transitions | Not yet supported | Supported |
+| View Transitions | Supported | Supported |
 | State Preservation | React state in layout | DOM element state |
 
 ## License

--- a/apps/docs/src/pages/docs/ecosystem/vite-plugin.mdx
+++ b/apps/docs/src/pages/docs/ecosystem/vite-plugin.mdx
@@ -1,0 +1,58 @@
+import { CodeTabs } from '@/components/code-tabs';
+import { DocsLayout } from '@/layouts/docs-layout';
+
+export const config = {
+	layout: DocsLayout,
+};
+
+export const getMetadata = () => ({
+	title: 'Docs | Vite Plugin',
+	description: 'Run Ecopages inside a Vite dev and build host with @ecopages/vite-plugin',
+});
+
+# Vite Plugin
+
+`@ecopages/vite-plugin` integrates Ecopages with [Vite](https://vite.dev/) so you can use Vite's dev server, transforms, and plugin ecosystem alongside Ecopages routing and rendering.
+
+The plugin is **private to the monorepo** today but documents the host-side integration pattern used with Vite and Nitro-style deployments.
+
+## Installation
+
+<CodeTabs
+	name="vite-plugin-install"
+	tabs={[
+		{ id: 'pnpm', label: 'pnpm', code: 'pnpm add -D vite @ecopages/vite-plugin @ecopages/core' },
+		{ id: 'npm', label: 'npm', code: 'npm install -D vite @ecopages/vite-plugin @ecopages/core' },
+		{ id: 'bun', label: 'bun', code: 'bun add -d vite @ecopages/vite-plugin @ecopages/core' },
+	]}
+	defaultSelectedKey="pnpm"
+/>
+
+Export your app config from `eco.config.ts` using `ConfigBuilder` (see [Configuration](/docs/getting-started/configuration)).
+
+## Usage
+
+```typescript
+import { defineConfig } from 'vite';
+import { ecopages } from '@ecopages/vite-plugin';
+import appConfig from './eco.config';
+
+export default defineConfig({
+	plugins: [ecopages({ appConfig })],
+});
+```
+
+Register `ecopages()` **before** framework plugins such as `@vitejs/plugin-react` or Tailwind when those plugins also transform JSX or CSS.
+
+## What the plugin provides
+
+- Vite config merging for Ecopages defaults (aliases, `optimizeDeps`, `ssr.noExternal`)
+- Ecopages source transforms as Vite plugins
+- Virtual modules for integration manifests
+- Ecopages-aware HMR and dev-server bridging to `app.fetch()`
+
+## CLI vs Vite host
+
+The `ecopages` CLI runs apps through Bun or Node (`tsx`) directly. Use this plugin when you want Ecopages to run **inside** a Vite host for dev and build orchestration.
+
+See [Build and Host](/docs/core/build-and-host) for how this fits the Rolldown and Vite-host build model.

--- a/apps/docs/src/pages/docs/getting-started/introduction.mdx
+++ b/apps/docs/src/pages/docs/getting-started/introduction.mdx
@@ -17,7 +17,7 @@ export const getMetadata = () => ({
 <Banner type="alert">
 	<Banner.Title>Beta Notice</Banner.Title>
 	<p>
-		Ecopages is currently in beta. The API may change before the stable release. <a href="https://github.com/ecopages/ecopages/tree/main/examples" target="_blank">Check out the examples.</a>
+		Ecopages is currently in beta (`0.2.0` prerelease on the release branch). The API may change before the stable release. <a href="https://github.com/ecopages/ecopages/tree/main/examples" target="_blank">Check out the examples.</a>
 	</p>
 </Banner>
 
@@ -50,7 +50,7 @@ The result? Fast static pages, minimal dependencies, and code you can actually u
 3. **Static by Default**: Generate HTML at build time. Host anywhere. No server costs for most sites.
 
 4. **Lightweight, Safe Backend**:
-   - **Typed Handlers**: Define API handlers with full type inference using `defineHandlers`.
+   - **Typed Handlers**: Define API handlers with full type inference using `defineApiHandler`.
    - **Explicit Routing**: Use `app.get()`, `app.post()`, etc. for granular control over your API endpoints.
    - **Zero Overhead**: The server module is tree-shaken away when you only build static pages.
 
@@ -73,7 +73,7 @@ The result? Fast static pages, minimal dependencies, and code you can actually u
 
 - **Marketing sites** – Static pages with excellent SEO
 - **Documentation** – MDX-powered docs like the one you're reading
-- **Blogs** – Dynamic routes with `getStaticPaths` for each post
+- **Blogs** – Dynamic routes with `staticPaths` for each post
 - **Portfolios** – Beautiful static sites with interactive components
 - **Full-Stack Apps** – Combine static pages with typed API handlers for dynamic features
 - **Dashboards** – React or Lit components with live API data
@@ -131,10 +131,10 @@ Good for simple, quick endpoints.
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import config from './eco.config';
 
-const app = new EcopagesApp({ appConfig: config });
+const app = await createApp({ appConfig: config });
 
 app.get('/api/hello', async (ctx) => {
   return ctx.response.json({ message: 'Hello world!' });
@@ -146,7 +146,7 @@ For larger apps, define handlers in separate files using `defineApiHandler`. Thi
 
 ```typescript
 // handlers/greet.ts
-import { defineApiHandler } from '@ecopages/core/bun';
+import { defineApiHandler } from '@ecopages/core';
 import { z } from 'zod';
 
 export const greetHandler = defineApiHandler({
@@ -169,7 +169,7 @@ import { greetHandler } from './handlers/greet';
 
 // ... app initialization
 
-app.post(greetHandler.path, greetHandler.handler);
+app.add(greetHandler);
 ```
 
 ## AI Agents & Ecopages

--- a/apps/docs/src/pages/docs/reference/cli-reference.mdx
+++ b/apps/docs/src/pages/docs/reference/cli-reference.mdx
@@ -110,7 +110,7 @@ Used for generating absolute URLs in production builds (meta tags, sitemaps, etc
 ### Server Hostname & Port
 Used to determine where the server listens.
 
-1. **`serverOptions`**: Highest priority. Passed to the `EcopagesApp` constructor.
+1. **`serverOptions`**: Highest priority. Passed to `createApp()` options.
 2. **Environment Variables**: `ECOPAGES_PORT` and `ECOPAGES_HOSTNAME`.
 3. **Defaults**: `localhost:3000`.
 

--- a/apps/docs/src/pages/docs/reference/deployment.mdx
+++ b/apps/docs/src/pages/docs/reference/deployment.mdx
@@ -18,6 +18,8 @@ Deploying an Ecopages application depends on whether you are using only static f
 
 Before deploying, you must create a production build. This processes your assets, pre-renders static pages, and prepares the `dist` directory.
 
+For projects using the [Vite host plugin](/docs/ecosystem/vite-plugin), `ecopages build` still produces the same `dist` output; Vite orchestrates dev and optional build integration only.
+
 ```bash
 pnpm run build
 ```

--- a/apps/docs/src/pages/docs/server/api-handlers.mdx
+++ b/apps/docs/src/pages/docs/server/api-handlers.mdx
@@ -15,14 +15,14 @@ Ecopages provides a straightforward way to define API endpoints within your appl
 
 ## Defining Handlers
 
-You define API handlers using methods on your `EcopagesApp` instance, typically in your `app.ts` file. Each method corresponds to an HTTP verb (GET, POST, etc.).
+You define API handlers using methods on your app instance, typically in your `app.ts` file. Each method corresponds to an HTTP verb (GET, POST, etc.).
 
 ```typescript
 // filepath: app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 // Define a GET handler
 app.get('/api/greet', async ({ response }) => {
@@ -179,7 +179,7 @@ Using the `ApiResponseBuilder` makes your API handler code cleaner, more readabl
 
 ## WebSocket Handlers
 
-If your application requires real-time bidirectional communication, you can define WebSocket handlers when starting your application. Ecopages inherits Bun's powerful WebSocket implementation.
+If your application requires real-time bidirectional communication, you can define WebSocket handlers when starting your application. Ecopages provides a runtime-agnostic WebSocket API (see [WebSockets](/docs/server/websockets)).
 
 ```typescript
 await app.start({
@@ -200,11 +200,11 @@ await app.start({
 Use `app.group()` to organize related routes under a shared prefix with optional middleware. This is useful for sections like admin panels or authenticated APIs.
 
 ```typescript
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import * as admin from './handlers/admin';
 import { authMiddleware } from './middleware/auth';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.group(
 	'/admin',

--- a/apps/docs/src/pages/docs/server/define-handlers.mdx
+++ b/apps/docs/src/pages/docs/server/define-handlers.mdx
@@ -45,7 +45,7 @@ Use `defineApiHandler` to create a self-contained handler with its path, method,
 
 ```typescript
 // handlers/blog.ts
-import { defineApiHandler } from '@ecopages/core/bun';
+import { defineApiHandler } from '@ecopages/core';
 
 export const list = defineApiHandler({
   path: '/api/posts',
@@ -73,13 +73,13 @@ Register handlers directly with HTTP method functions:
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import * as blog from './handlers/blog';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
-app.get(blog.list.path, blog.list.handler);
-app.get(blog.detail.path, blog.detail.handler);
+app.add(blog.list);
+app.add(blog.detail);
 
 await app.start();
 ```
@@ -89,7 +89,7 @@ await app.start();
 Define a schema to get typed access to request body, query parameters, and headers:
 
 ```typescript
-import { defineApiHandler } from '@ecopages/core/bun';
+import { defineApiHandler } from '@ecopages/core';
 import { z } from 'zod';
 
 const createPostSchema = {
@@ -121,7 +121,7 @@ export const createPost = defineApiHandler({
 Attach route-specific middleware that extends the handler context:
 
 ```typescript
-import { defineApiHandler } from '@ecopages/core/bun';
+import { defineApiHandler } from '@ecopages/core';
 import { rateLimitMiddleware } from './middleware/rate-limit';
 
 export const sensitiveEndpoint = defineApiHandler({
@@ -143,7 +143,7 @@ Use `defineGroupHandler` when you have multiple routes that share a URL prefix a
 
 ```typescript
 // handlers/admin.ts
-import { defineGroupHandler } from '@ecopages/core/bun';
+import { defineGroupHandler } from '@ecopages/core';
 import { authMiddleware } from './middleware/auth';
 import type { AuthenticatedContext } from './middleware/auth';
 
@@ -187,11 +187,11 @@ Register the entire group with `app.group()`:
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import { adminGroup } from './handlers/admin';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.group(adminGroup);
 
@@ -259,13 +259,13 @@ Middleware can extend the handler context with additional properties:
 
 ```typescript
 // middleware/auth.ts
-import type { BunMiddleware } from '@ecopages/core/bun';
+import type { EcoMiddleware } from '@ecopages/core';
 
 export type AuthenticatedContext = {
   session: { user: User; token: string };
 };
 
-export const authMiddleware: BunMiddleware<AuthenticatedContext> = async (ctx, next) => {
+export const authMiddleware: EcoMiddleware<AuthenticatedContext> = async (ctx, next) => {
   const token = ctx.request.headers.get('Authorization');
   const user = await validateToken(token);
   
@@ -284,7 +284,7 @@ When used with `defineGroupHandler`, all routes receive the extended context aut
 
 ```typescript
 // handlers/blog.ts
-import { defineApiHandler, defineGroupHandler } from '@ecopages/core/bun';
+import { defineApiHandler, defineGroupHandler } from '@ecopages/core';
 import { authMiddleware, type AuthenticatedContext } from '../middleware/auth';
 import { z } from 'zod';
 
@@ -359,14 +359,14 @@ export const protectedGroup = defineGroupHandler({
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import * as blog from './handlers/blog';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 // Public
-app.get(blog.list);
-app.get(blog.detail);
+app.add(blog.list);
+app.add(blog.detail);
 
 // Protected
 app.group(blog.protectedGroup);
@@ -394,4 +394,4 @@ interface GroupHandler<TPrefix> {
 }
 ```
 
-Both can be passed directly to `app.[method]()` or `app.group()` respectively.
+Both can be passed to `app.add()` for individual handlers or `app.group()` for grouped routes.

--- a/apps/docs/src/pages/docs/server/explicit-routing.mdx
+++ b/apps/docs/src/pages/docs/server/explicit-routing.mdx
@@ -25,13 +25,13 @@ For architectural patterns and code organization examples, see [Routing Patterns
 
 ## Basic Routes
 
-Define routes using HTTP method functions on your `EcopagesApp` instance:
+Define routes using HTTP method functions on your app instance:
 
 ```typescript
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.get('/api/users', async (ctx) => {
 	const users = await getUsers();
@@ -142,13 +142,12 @@ const logMiddleware: Middleware = async (ctx, next) => {
 
 ### Extending Context with Middleware
 
-Middleware can extend the request context with additional properties (like session data, user info, etc.). Use the `BunMiddleware` helper type to define middleware that adds properties to the context:
+Middleware can extend the request context with additional properties (like session data, user info, etc.). Use the `EcoMiddleware` helper type to define middleware that adds properties to the context:
 
 ```typescript
-import type { BunMiddleware } from '@ecopages/core/create-app';
+import type { EcoMiddleware } from '@ecopages/core';
 
-// Define middleware that extends context with session data
-const authMiddleware: BunMiddleware<{ session: Session }> = async (ctx, next) => {
+const authMiddleware: EcoMiddleware<{ session: Session }> = async (ctx, next) => {
 	const session = await getSession(ctx.request.headers);
 	if (!session) {
 		return Response.redirect('/login');
@@ -382,12 +381,14 @@ import { eco } from '@ecopages/core';
 const PostView = eco.page<PostViewProps>({
 	staticPaths: async () => {
 		const posts = await getPosts();
-		return posts.map((post) => ({ slug: post.slug }));
+		return {
+			paths: posts.map((post) => ({ params: { slug: post.slug } })),
+		};
 	},
 
 	staticProps: async ({ params }) => {
 		const post = await getPost(params.slug);
-		return { title: post.title, content: post.content };
+		return { props: { title: post.title, content: post.content } };
 	},
 
 	render: (props) => <article>...</article>
@@ -433,7 +434,7 @@ export default PostView;
 Explicit routes take precedence over file-system routes:
 
 ```typescript
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 // Explicit routes (higher priority)
 app.get('/posts', posts.index);
@@ -449,17 +450,16 @@ await app.start();
 ## Complete Example
 
 ```typescript
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import { HttpError } from '@ecopages/core/errors';
 import { z } from 'zod';
 import appConfig from './eco.config';
 import { PostView, PostListView } from './src/views';
-import type { BunMiddleware } from '@ecopages/core/create-app';
+import type { EcoMiddleware } from '@ecopages/core';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
-// Middleware that extends context
-const authMiddleware: BunMiddleware<{ session: Session }> = async (ctx, next) => {
+const authMiddleware: EcoMiddleware<{ session: Session }> = async (ctx, next) => {
 	const session = await getSession(ctx.request.headers);
 	if (!session) throw HttpError.Unauthorized();
 	ctx.session = session;

--- a/apps/docs/src/pages/docs/server/routing-patterns.mdx
+++ b/apps/docs/src/pages/docs/server/routing-patterns.mdx
@@ -84,12 +84,12 @@ For small projects or rapid prototyping, define everything inline in `app.ts`.
 ### Example
 
 ```typescript
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import { HttpError } from '@ecopages/core/errors';
 import { db } from './src/db';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.get('/posts', async (ctx) => {
 	const { default: PostListView } = await import('./src/views/post-list');
@@ -209,12 +209,12 @@ export async function destroy(ctx: ApiHandlerContext) {
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import * as posts from './src/handlers/posts';
 import * as users from './src/handlers/users';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 // Posts routes
 app.get('/posts', posts.index);
@@ -309,12 +309,12 @@ export function createPostsHandlers(db: Database) {
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import { createPostsHandlers } from './src/handlers/posts';
 import { db } from './src/db';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 const posts = createPostsHandlers(db);
 
 app.get('/posts', posts.index);
@@ -487,13 +487,13 @@ export class PostsController {
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import { PostsController } from './src/controllers/posts.controller';
 import { PostsService } from './src/services/posts.service';
 import { db } from './src/db';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 const postsService = new PostsService(db);
 const postsController = new PostsController(postsService);
@@ -700,14 +700,14 @@ export function createPostsHandlers(
 
 ```typescript
 // app.ts
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import { createBlogService } from './src/services/blog.service';
 import { postAdapter } from './src/adapters/post.adapter';
 import { createPostsHandlers } from './src/handlers/posts';
 import { db } from './src/db';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 const blogService = createBlogService(db);
 const posts = createPostsHandlers(blogService, postAdapter);
@@ -740,7 +740,7 @@ await app.start();
 You don't need to pick one pattern for your entire app. Mix patterns based on complexity:
 
 ```typescript
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 // Simple inline handler for about page
 app.get('/about', async (ctx) => {
@@ -770,7 +770,7 @@ Explicit routes take precedence over file-system routes. This allows you to:
 
 ```typescript
 // app.ts
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 // Explicit routes (higher priority)
 app.get('/posts', posts.index);

--- a/apps/docs/src/pages/docs/server/server-api.mdx
+++ b/apps/docs/src/pages/docs/server/server-api.mdx
@@ -18,10 +18,10 @@ Ecopages provides a powerful server API that allows you to create endpoints and 
 Create an `app.ts` file in your project root:
 
 ```typescript
-import { EcopagesApp } from '@ecopages/core/create-app';
+import { createApp } from '@ecopages/core/create-app';
 import appConfig from './eco.config';
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.get('/api/hello', async () => {
 	return new Response('Hello World');
@@ -60,24 +60,16 @@ app.get('/api/users/:id/posts/:postId', async ({ params }) => {
 
 Ecopages leverages TypeScript to provide strong type safety for your API handlers, especially for route parameters.
 
-Handlers can be defined directly, but keeping the `params` type aligned with the `path` string requires explicit manual typing. Ecopages provides adapter-specific helper functions to remove that duplication and keep route definitions organized.
-
-### Using `defineApiHandler`
-
-When using the Bun adapter, you can use the `defineApiHandler` helper function. This function automatically infers the parameter types from the `path` string literal, ensuring your `params` object is correctly typed without explicit annotations.
+Handlers can be defined directly, but keeping the `params` type aligned with the `path` string requires explicit manual typing. Use `defineApiHandler` to infer parameter types from the path literal and keep route definitions organized.
 
 ```typescript
-// Import the adapter-specific helper
-import { defineApiHandler } from '@ecopages/core/bun';
+import { defineApiHandler } from '@ecopages/core';
 
-// Define the handler using the helper
 const getUserHandler = defineApiHandler({
 	method: 'GET',
-	path: '/api/users/:id', // Type of 'id' is inferred from here
+	path: '/api/users/:id',
 	handler: async ({ params }) => {
-		// params is automatically typed as { id: string }
 		const { id } = params;
-		// Fetch user logic...
 		const user = { id: id, name: 'Example User' };
 
 		if (!user) {
@@ -87,22 +79,18 @@ const getUserHandler = defineApiHandler({
 	},
 });
 
-// Register the handler with the app
-app.get(getUserHandler.path, getUserHandler.handler);
+app.add(getUserHandler);
 
-// You can define multiple handlers this way and keep them organized
 const updateUserHandler = defineApiHandler({
 	method: 'PUT',
 	path: '/api/users/:id',
 	handler: async ({ params }) => {
 		const { id } = params;
-		// Update user logic...
 		return new Response(JSON.stringify({ id, message: 'User updated' }));
-	}
+	},
 });
 
-app.put(updateUserHandler.path, updateUserHandler.handler);
-
+app.add(updateUserHandler);
 ```
 
 ### Benefits of Using `defineApiHandler`
@@ -154,7 +142,7 @@ export default eco.page({
 
 The development server includes:
 
-- Hot Module Replacement (HMR) (beta)
+- Hot Module Replacement (HMR)
 - Automatic route reloading
 - API endpoint hot reloading
 - Static file serving
@@ -192,7 +180,7 @@ See [WebSockets](/docs/server/websockets) for the full guide.
 Ecopages provides a convenient `request()` method on the app instance that allows you to trigger internal HTTP requests for testing without needing to manage actual network connections.
 
 ```typescript
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 await app.start();
 
 const response = await app.request('/api/hello');

--- a/apps/docs/src/public/skill.txt
+++ b/apps/docs/src/public/skill.txt
@@ -208,10 +208,10 @@ export default config;
 Create `app.ts`:
 
 ```typescript
-import { EcopagesApp } from "@ecopages/core/create-app";
+import { createApp } from "@ecopages/core/create-app";
 import appConfig from "./eco.config";
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 await app.start();
 ```
@@ -350,7 +350,7 @@ export default eco.page<{ user: User }>({
 
 ```typescript
 // src/handlers/dashboard.ts
-import { defineGroupHandler } from "@ecopages/core/bun";
+import { defineGroupHandler } from "@ecopages/core";
 
 export const dashboardGroup = defineGroupHandler({
   prefix: "/dashboard",
@@ -411,7 +411,7 @@ export function SimpleButton({ label, onClick }) {
 For individual API routes:
 
 ```typescript
-import { defineApiHandler } from "@ecopages/core/bun";
+import { defineApiHandler } from "@ecopages/core";
 import { z } from "zod";
 
 const createPostSchema = {
@@ -437,7 +437,7 @@ export const createPost = defineApiHandler({
 For routes that share a prefix and middleware:
 
 ```typescript
-import { defineGroupHandler } from "@ecopages/core/bun";
+import { defineGroupHandler } from "@ecopages/core";
 import { authMiddleware } from "./auth";
 
 export const adminGroup = defineGroupHandler({
@@ -467,7 +467,7 @@ Register handlers in `app.ts`:
 import * as posts from "./src/handlers/posts";
 import { adminGroup } from "./src/handlers/admin";
 
-const app = new EcopagesApp({ appConfig });
+const app = await createApp({ appConfig });
 
 app.post(posts.createPost);
 app.group(adminGroup);
@@ -925,12 +925,12 @@ Create `src/handlers/auth.ts`:
 
 ```typescript
 import type { ApiHandlerContext } from "@ecopages/core";
-import type { BunMiddleware } from "@ecopages/core/bun";
+import type { EcoMiddleware } from "@ecopages/core";
 import { auth } from "@/lib/auth";
 
 export type Session = (typeof auth)["$Infer"]["Session"];
 
-export const authMiddleware: BunMiddleware<{ session: Session }> = async (
+export const authMiddleware: EcoMiddleware<{ session: Session }> = async (
   ctx,
   next
 ) => {
@@ -954,11 +954,11 @@ export const authHandler = async (ctx: ApiHandlerContext) => {
 In `app.ts`:
 
 ```typescript
-import { EcopagesApp } from "@ecopages/core/create-app";
+import { createApp } from "@ecopages/core/create-app";
 import appConfig from "./eco.config";
 import * as auth from "./src/handlers/auth";
 
-new EcopagesApp({ appConfig })
+await createApp({ appConfig })
   .get("/api/auth/*", auth.authHandler)
   .post("/api/auth/*", auth.authHandler)
   .put("/api/auth/*", auth.authHandler)
@@ -1020,7 +1020,7 @@ export const AuthNav = eco.component({
 Use `authMiddleware` with `defineGroupHandler`:
 
 ```typescript
-import { defineGroupHandler } from "@ecopages/core/bun";
+import { defineGroupHandler } from "@ecopages/core";
 import { authMiddleware } from "./auth";
 
 export const protectedGroup = defineGroupHandler({

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,132 +6,42 @@ All notable changes to `@ecopages/core` are documented here.
 
 ## [UNRELEASED] — TBD
 
-### Bug Fixes
-
-- Externalized package imports while bundling the production server entry so native addons such as Tailwind's platform binaries keep loading from installed dependencies instead of failing the server bundle build.
-- Fixed server-module package ownership so `externalPackages: true` now keeps app-declared packages external while bundling or rewriting undeclared core-owned dependencies such as `@ecopages/file-system`, `oxc-parser`, and lowered OXC runtime helpers for preview, static generation, and Vite-hosted dev module loads.
-- Fixed app-owned server module imports to apply manifest runtime plugins during request-time and static-page loads so integration-owned loaders such as React MDX participate outside the main bundle pipeline.
-- Added the OXC runtime dependency required by rolldown-lowered server modules so static generation and server page imports resolve injected helper imports such as `@oxc-project/runtime/helpers/decorate`.
-- Batched grouped page-browser graph builds across sibling routes per integration so SPA navigation can reuse one shared route browser graph instead of rebuilding page-local copies.
-- Fixed grouped page-browser route remapping to match emitted assets by grouped bundle identity as well as entry name, preventing cross-route asset leakage when cohorts reuse names like `index`.
-- Prevent unrelated sibling-route contribution failures from taking down grouped page-browser asset resolution for the current route during render.
-- Avoid caching partial grouped page-browser asset maps after sibling contribution failures so later route renders retry the full grouped build instead of reusing incomplete results.
-- Fixed Node bootstrap bare-package linking to preserve the installed package root when a resolved entry lives under a nested internal manifest such as `postgres/cjs/package.json`.
-- Fixed Node bootstrap project-source rewriting to support minimal `import.meta.env` compatibility by mapping it to `process.env` alongside the existing file-path aliases.
-- Suppressed Node response-stream client disconnects during runtime serving so navigation-driven aborts no longer log `ERR_STREAM_UNABLE_TO_PIPE` as server failures in tests and development.
-- Preserved Node preview-host state through async shutdown failures and coalesced overlapping preview `stop()` calls onto one in-flight shutdown.
-- Streamed Node adapter Web `Response` bodies directly into `ServerResponse` so large payloads and streaming responses no longer buffer through `arrayBuffer()` first.
-- Fixed Bun adapter runtime and HMR type contracts so Bun-specific collaborators type-check cleanly during core package builds.
-- Restored the Bun server adapter static-generation import path so preview and E2E startup no longer fail with `StaticSiteGenerator is not defined` during runtime initialization.
-- Preserved configured Node hostnames in reported runtime origins while still normalizing bare IPv6 literals, so localhost binds no longer log as resolved socket addresses like `[::1]`.
-- Fixed Node-target server-module ESM outputs to emit `.mjs` runtime artifacts so top-level `await` and other ESM semantics do not depend on app-level `"type": "module"`.
-- Preserve foreign-child runtime normalized props on inline renders so mixed-integration children stay serialized during server rendering.
-- Fixed Bun component render contexts to keep async foreign-child interception active during Lit and Ecopages JSX renderer passes in preview and static builds.
-- Fixed Bun app-module server builds to run metadata loaders before JSX ownership overrides so foreign-owned layouts and HTML shells keep their integration metadata during preview and static rendering.
-- Fixed page-module import caching to include JSX ownership and plugin inputs so preview and static generation do not reuse server modules compiled for the wrong integration runtime.
-
 ### Features
 
-- Added a browser runtime import rewrite plugin that turns manifest-owned ESM runtime specifiers into concrete public asset URLs during module loading.
-- Added a core browser runtime asset manifest model for migrating runtime imports from import-map-style aliases to deterministic concrete URLs.
-- Added app-owned runtime and build ownership around `createApp()`, host module loading, the browser-safe `eco` export, `eco.html()`, `eco.layout()`, and the published `EcoPagesAppConfig` surface.
-- Added boundary-plan metadata and a compatibility `renderBoundary()` payload contract for mixed-renderer orchestration.
+- Added `createApp()` as the recommended runtime entrypoint with Bun-first execution and Node fallback.
+- Added app-owned build and runtime ownership: host module loading, browser-safe `eco` export, `eco.html()`, `eco.layout()`, and published `EcoPagesAppConfig`.
+- Added Page Browser Graph orchestration so integrations declare browser graph contributions and routes share grouped browser assets where appropriate.
+- Added browser runtime asset manifest and import rewrite so runtime modules resolve to concrete public URLs instead of import-map aliases.
+- Added boundary-plan metadata and mixed-renderer `renderBoundary()` payload contract for cross-integration pages.
+- Added `@ecopages/core/dev/host-runtime` for Vite and other host integrations.
+- Replaced filesystem route discovery with `RouteRegistry` for matching, static-generation planning, and dev reload.
+
+### Bug Fixes
+
+- Fixed server bundle externalization so native addons (e.g. Tailwind platform binaries) and app-declared packages load correctly from installed dependencies.
+- Fixed app-owned server module loading so integration loaders (including React MDX) participate during request-time and static generation.
+- Fixed Node and Bun adapter stability for preview, static generation, HMR, and mixed-integration rendering across built-in integrations.
+- Fixed grouped page-browser graph builds so sibling routes reuse shared assets without cross-route leakage or stale partial caches.
+- Fixed Node bootstrap for bare package linking, `import.meta.env` compatibility, streaming responses, preview shutdown, and `.mjs` server-module output.
+- Fixed foreign-child and mixed-integration rendering so delegated children serialize in the owning integration during server rendering.
+- Fixed page-module import caching to respect JSX ownership and plugin inputs across preview and static builds.
+- Fixed development HMR to reload layouts, includes, and script entrypoints without stale caches or over-broad rebuilds.
+- Fixed page dependency packaging so stylesheets and scripts emit correctly for static, dynamic, and HMR flows.
+- Fixed `ecopages build` failing when the configured serve port is already in use.
 
 ### Refactoring
 
-- Removed the emitted-JS runtime specifier alias fallback so browser runtime imports resolve through manifest-owned module loading instead of post-build rewriting.
-- Re-exported the renderer contribution contracts through the integration plugin surface so integrations declare page-browser and document HTML hooks from one core boundary.
-- Moved Page Browser Graph assembly into the shared route orchestrator so integrations now declare graph contributions instead of building page-browser assets inside renderer execution.
-- Cached shared Page Browser Graph resolution across repeated route preparation while automatically bypassing that cache when HMR is enabled.
-- Split resolved Page Browser Graph outputs into explicit entry and chunk asset groups while keeping route packaging flattening in the shared orchestrator.
-- Moved Page Browser Graph flattening behind `createPagePackage()` and threaded the structured graph through `PagePackageResult` so route preparation no longer collapses browser graph shape before packaging.
-- Updated HTML finalization to inject Page Browser Graph entry assets from `PagePackageResult` while keeping chunk assets out of the initial document injection path.
-- Preserved structured Page Browser Graph metadata through explicit renderer hydration paths so full-document view rendering reuses the shared graph contract without flattening it back into a plain page package.
-- Routed Bun runtime loader registration through the shared runtime plugin bootstrap so loaders and runtime plugins now follow one startup registration path.
-- Removed the Bun `ServerLifecycle` and shared runtime-bootstrap forwarding seams so Bun and Node adapters own their runtime startup directly against the shared build, plugin, and watcher helpers.
-- Moved shared HMR registration, strategy dispatch, runtime bundling, and entrypoint bookkeeping behind one shared manager module so Bun and Node now differ only at the runtime-specific transport hooks.
-- Moved runtime binding resolution and static build runtime decisions behind shared app-startup primitives so Bun and Node app modules no longer duplicate host and preview/build setup policy.
-- Extracted shared runtime-origin resolution for server adapters and introduced a small runtime host contract so Bun and Node app startup now call the same transport lifecycle shape.
-- Moved preview server lifecycle behind shared preview-host contracts and extracted Node's HTTP request/response bridge into a reusable module so `create-app` no longer owns runtime transport details.
-- Moved runtime hosts, preview hosts, and the Node request bridge to constructor-injected collaborators with factory-edge defaults so app and server adapters no longer construct services inline.
-- Moved Bun and Node server-adapter collaborator assembly behind runtime-specific dependency bundles, including an injected Node dev-runtime factory for websocket, bridge, and HMR setup.
-- Removed the dead Bun route-handler factory seam and the remaining Bun static-builder callback so server adapters now consume only runtime collaborators instead of construction hooks.
-- Collapsed one-shot server-adapter dependency wrapper helpers back into the factory edge, keeping only the injected Node dev-runtime factory seam that still carries real runtime behavior.
-- Renamed route-renderer ownership and foreign-child contracts across core so ownership planning, foreign-subtree payloads, and queued foreign-subtree resolution now use the simplified terminology.
-- Introduced a single `RouteRenderFlow` owner for route render preparation and execution, removing the separate execution service seam while keeping boundary planning shared.
-- Narrowed route-render orchestration onto an explicit `RouteRenderFlowAdapter` seam and one structural Html finalization plan, reducing callback-bag plumbing between `RouteRenderFlow` and `IntegrationRenderer`.
-- Renamed renderer-owned page browser asset preparation onto an explicit `buildPageBrowserGraph()` seam so route orchestration no longer treats emitted browser dependencies as a flat route-asset append.
-- Removed the generic HMR runtime-specifier registry and plugin registration seam so core no longer carries import-map-era runtime state that integrations no longer use.
-- Moved foreign-boundary ownership validation out of boundary-plan construction so route root graphs are validated before dependency and data preparation.
-- Moved page-package classification into the asset-processing module so render orchestration no longer carries a dedicated packaging service wrapper.
-- Split file-route page middleware onto its own context contract so page middleware no longer exposes handler-only `ctx.render()` helpers and the pipeline stops carrying fake render traps.
-- Narrowed route-renderer consumers onto explicit resolver contracts, moved filesystem custom 404 rendering back under the filesystem matcher, and shared explicit static render preparation between runtime and static generation.
-
-- Added the `@ecopages/core/dev/host-runtime` seam so host integrations such as the Vite plugin use one explicit development bridge instead of importing host-module-loader and invalidation internals directly.
-- Moved extension-facing merge and assertion helpers behind the integration and processor plugin entrypoints so MDX and image processing no longer depend on raw `utils/deep-merge` or `utils/invariant` package paths.
-- Re-exported shared build-plugin authoring types through the integration and processor plugin entrypoints so extension packages depend on plugin surfaces instead of the raw `build/build-types` module.
-- Removed the legacy `@ecopages/core/errors/locals-access-error` and `@ecopages/core/adapters/bun/client-bridge` exports after moving their remaining consumers to the public `errors` and root type surfaces.
-- Removed the unused `@ecopages/core/utils/parse-cli-args` and `@ecopages/core/services/module-loading/app-server-module-transpiler.service` exports from the published package surface.
-- Removed the unused `@ecopages/core/bun/create-app` and `@ecopages/core/route-renderer/template-serialization` exports to keep the published package surface aligned with the documented entrypoints.
-- Removed the legacy `@ecopages/core/internal-types` export now that the public root package exposes the supported `EcoPagesAppConfig` contract.
-- Removed the duplicate `@ecopages/core/router/client/navigation-coordinator` export in favor of the canonical `@ecopages/core/router/navigation-coordinator` subpath.
-- Bundled page-local component stylesheets and standard file scripts into page-owned assets before processing, reducing per-page asset fan-out in emitted HTML.
-- Grouped Ecopages JSX page and lazy dependency entries into one multi-entry browser build so shared chunks can be emitted once without relying on the runtime alias vendor path.
-- Removed the transitional flat dependency write from render preparation so final HTML injection now follows the structured page-package path only.
-- Consolidated runtime state around shared module-loading services, app-owned build execution, and the universal `createApp()` boundary.
-- Simplified route-renderer orchestration around renderer-owned boundary runtimes, shared string-boundary queue helpers, and a smaller component render context.
-- Centralized shared integration renderer bootstrapping so package integrations only append renderer-specific config instead of duplicating core lifecycle wiring.
-- Moved shared queued boundary resolution to attachment-policy payloads and constructor-injectable planning services.
-- Extracted shared page, layout, and document-shell composition into a narrow `RouteShellComposer` while keeping renderer-owned boundary handoff in `IntegrationRenderer`.
-- Removed marker-era compatibility capture, the shared route-level fallback resolver, deprecated `@ecopages/core/node*` escape hatches, and other dead route-renderer internals.
-- Replaced the split `FSRouter` and `FSRouterScanner` flow with one `RouteRegistry` seam for filesystem route discovery, request matching, and static-generation planning.
-
-### Bug Fixes
-
-- Fixed mixed Ecopages JSX to string-renderer component handoff so delegated foreign children are serialized before Kita or other string-first shells receive them during preview and static rendering.
-- Fixed Bun page-module loading to keep framework-owned page imports on the transpilation path whenever a runtime build root and output directory are configured.
-- Fixed Bun development server-module invalidation to add runtime cache-busting even when Bun dev runs without `NODE_ENV=development`, so shared include changes reload fresh document-shell modules.
-- Fixed Bun development include invalidation so shared `@/includes/...` helpers are folded into rebuilt server modules after graph bumps, keeping document-shell reloads fresh without bundling unrelated mixed-renderer boundaries.
-- Fixed Bun development document-shell reloads to roll rebuilt server-module filenames forward after invalidation, so shared include-only changes do not reuse stale cached module paths.
-- Fixed Bun server-module transpilation naming so page imports that also emit CSS assets no longer fail with output-path collisions during static builds and preview startup.
-- Fixed integration registry typing so `ConfigBuilder.setIntegrations()` accepts heterogeneous framework plugins without rejecting valid JSX or React integrations at type-check time.
-- Fixed page-owned dependency packaging so final Html output suppresses bundled source stylesheet assets that were reintroduced later during shell-time asset merging.
-- Fixed development page dependency packaging so script Dependencies stay source-backed for HMR instead of being collapsed into one page-owned script bundle.
-- Fixed Bun preview builds to start the static preview server only after static generation releases the live build server port, preventing preview mode from double-binding the configured port.
-- Fixed router-owned HMR current-page reloads to clear persisted layout caches so active shared layouts pick up updated implementations during development.
-- Fixed router-owned HMR layout refreshes to reuse the active HMR page entry instead of stale static bootstrap assets during persisted-layout reloads.
-- Fixed fetch-mode static generation to normalize absolute routes onto the active build runtime origin, restoring preview prerendering for routes discovered from absolute router entries.
-- Fixed global lazy-trigger bootstrap emission to inline the full bootstrap runtime in final HTML, removing separate initial injector bootstrap and runtime requests.
-- Fixed Ecopages JSX lazy-trigger finalization to preserve SSR custom-element markup nodes instead of coercing them to `[object Object]` inside parent renders.
-- Fixed legacy scripts-injector wrapping and grouped content-script bundling cleanup so non-string JSX SSR output stays intact and failed grouped builds do not leak temporary entries.
-- Fixed Ecopages JSX dependency resolution so page bundling now follows only declared `dependencies.scripts` entries, preventing SSR-only imports and lazy-declared scripts from being promoted into the page bundle.
-- Fixed Ecopages JSX lazy dependency bundling to keep page and lazy entries separate, preventing lazy scripts from forcing extra shared chunk requests into the page bundle.
-- Fixed Ecopages JSX dependency emission to collapse bundleable component CSS and module scripts into page-owned assets while preserving lazy trigger scripts.
-- Fixed Ecopages JSX page-owned dependency bundles to keep using the shared JSX and Radiant vendor runtimes so lazy chunks do not trigger duplicate runtime downloads.
-- Fixed Ecopages JSX page-owned browser bundles to keep intrinsic custom-element scripts out of final HTML when the current component tree already imports them, reducing docs home page script fan-out to one page bundle.
-- Fixed Node static builds so `ecopages build` no longer fails when the configured serve port is already in use.
-- Fixed mixed-integration page, layout, document, and component rendering to resolve foreign boundaries inside their owning renderer across the built-in integrations.
-- Fixed host/runtime module loading, published build-helper exports, asset output normalization, explicit render flows, and static or preview build stability across Bun, Node, Vite, and Nitro.
-- Fixed development project watcher setup to register chokidar paths and handlers only once per app runtime.
-- Fixed development script-entry registration to build only the requested HMR entrypoint instead of fanning out across all watched script entrypoints during startup.
-- Fixed Node bootstrap runtime package linking to refresh dangling `.eco/node_modules` symlinks instead of failing with `EEXIST` during page transpilation.
-- Fixed request-time and static-generation page inspection to preserve integration-specific page loading without reusing the normal render module identity.
-- Fixed Node preview and static-generation React runtime resolution so app-owned page modules and server rendering share one React module identity.
-- Fixed Bun browser output normalization so batched multi-entrypoint HMR rebuilds match emitted files to their expected served paths instead of Bun output order.
-- Fixed render-preparation graph traversal so sparse component dependency arrays do not break custom 404 rendering or file-system response fallback flows.
-- Fixed browser runtime manifest import rewrites to externalize manifest-owned specifiers during module resolution, including CJS `require()` consumers that do not pass through ESM source rewrite.
+- Consolidated HMR, preview hosts, runtime binding, and route rendering behind shared services; Bun and Node adapters now differ only at transport hooks.
+- Narrowed published package surface: removed legacy `@ecopages/core/internal-types`, duplicate navigation-coordinator export, and unused escape-hatch entrypoints.
+- Re-exported integration and processor plugin types through plugin entrypoints instead of internal build modules.
 
 ### Documentation
 
 - Added architecture and API documentation for config, plugins, services, adapters, HMR, routing, and rendering.
-- Documented that Html-owned dependency assets stay shared while page, layout, and component dependency assets are packaged per route.
 
 ### Tests
 
-- Added regression coverage for app-owned runtime services, Node fallback paths, and cross-runtime invalidation behavior.
-- Strengthened the core ghtml integration tests so route and explicit render paths await real outcomes and cover `renderToResponse` behavior.
-- Added core regression coverage for boundary plans, payload contracts, and typed mixed-boundary context flow.
-- Added router and static-generation regression coverage for `RouteRegistry`, explicit static route expansion, and file-response fallbacks.
+- Added regression coverage for `RouteRegistry`, explicit static routes, mixed boundaries, Node fallback, and cross-runtime invalidation.
 
 ---
 

--- a/packages/integrations/ecopages-jsx/CHANGELOG.md
+++ b/packages/integrations/ecopages-jsx/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Changelog
 
-## [0.2.0-beta.13] — 2026-07-01
+All notable changes to `@ecopages/ecopages-jsx` are documented here.
 
-### Refactoring
+> **Note:** Changelog tracking begins at version `0.2.0`. Changes prior to this release are not recorded here but are available in the git history.
 
-- MDX loader imports now use `@ecopages/mdx/core` instead of internal `@ecopages/mdx-core`.
-
-## [UNRELEASED] -- TBD
+## [UNRELEASED] — TBD
 
 ### Features
 
@@ -39,6 +37,7 @@
 
 ### Refactoring
 
+- MDX loader imports now use `@ecopages/mdx/core` instead of internal `@ecopages/mdx-core`.
 - Removed the shared JSX runtime bundle service and browser import-map asset in favor of per-script browser entries that prepend `@ecopages/radiant/client/install-hydrator` only when Radiant SSR is enabled.
 - Replaced Ecopages JSX renderer static and post-construction configuration with instance-owned renderer wiring and extracted shared plugin and renderer types into a dedicated module.
 - Extracted JSX renderer SSR asset-frame scope handling into a dedicated render-session module.
@@ -46,5 +45,4 @@
 ### Tests
 
 - Added a kitchen-sink preview e2e regression that asserts Ecopages JSX shell tags stay marker-free while nested Radiant hosts still hydrate and remove their local markers.
-
 - Added renderer-level coverage for the foreign-subtree payload compatibility contract.

--- a/packages/integrations/kitajs/CHANGELOG.md
+++ b/packages/integrations/kitajs/CHANGELOG.md
@@ -21,5 +21,5 @@ All notable changes to `@ecopages/kitajs` are documented here.
 
 ### Tests
 
-- Updated integration coverage for explicit foreign-subtree composition and Node and esbuild compatibility.
+- Updated integration coverage for explicit foreign-subtree composition and Node/Rolldown compatibility.
 - Added renderer-level coverage for the foreign-subtree payload compatibility contract.

--- a/packages/integrations/lit/CHANGELOG.md
+++ b/packages/integrations/lit/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to `@ecopages/lit` are documented here.
 
 ### Tests
 
-- Updated integration coverage for explicit foreign-subtree composition and Node and esbuild compatibility.
+- Updated integration coverage for explicit foreign-subtree composition and Node/Rolldown compatibility.
 - Added renderer-level coverage for the foreign-subtree payload compatibility contract.
 
 ### Refactoring

--- a/packages/integrations/mdx/CHANGELOG.md
+++ b/packages/integrations/mdx/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `@ecopages/mdx` are documented here.
 
 > **Note:** Changelog tracking begins at version `0.2.0`. Changes prior to this release are not recorded here but are available in the git history.
 
-## [0.2.0-beta.13] — 2026-07-01
+## [UNRELEASED] — TBD
 
 ### Breaking
 

--- a/packages/integrations/react/CHANGELOG.md
+++ b/packages/integrations/react/CHANGELOG.md
@@ -4,13 +4,11 @@ All notable changes to `@ecopages/react` are documented here.
 
 > **Note:** Changelog tracking begins at version `0.2.0`. Changes prior to this release are not recorded here but are available in the git history.
 
-## [0.2.0-beta.13] — 2026-07-01
+## [UNRELEASED] — TBD
 
 ### Breaking
 
 - `@ecopages/mdx` is now a normal runtime dependency (replaces vendored `@ecopages/mdx-core` / `bundleDependencies`). Consumers do not need to add it manually; npm installs it transitively.
-
-## [UNRELEASED] — TBD
 
 ### Bug Fixes
 

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -20,4 +20,4 @@ All notable changes to `@ecopages/react-router` are documented here.
 
 - Routed browser handoff and current-page reloads through the shared navigation coordinator.
 - Removed the React router adapter `importMapKey` field so the adapter now exposes only the browser bundle import path used by both development and production hydration.
-- Updated package metadata for the current core, esbuild adapter, and React peer dependency surface.
+- Updated package metadata for the current core, Rolldown build adapter, and React peer dependency surface.


### PR DESCRIPTION
## Summary
Lands the remaining v0.2.0 release prep work onto `release/v0.2.0` (stacked PRs #158–#160 merged into this branch).

- **Changelogs:** merge errant beta headers into `## [UNRELEASED] — TBD`; consumer-facing first release notes for `@ecopages/core`
- **Server docs:** `createApp`, `@ecopages/core`, `app.add()`, `EcoMiddleware` (replaces stale `EcopagesApp` / `@ecopages/core/bun` / `BunMiddleware`)
- **Docs site:** core pages aligned with Ecopages JSX default; new `build-and-host` and `vite-plugin` pages; nav updates; architecture/Rolldown section; JSR-only `@ecopages/ecopages-jsx`; `skill.txt` fixes

Complements #157 (release tooling already on `release/v0.2.0`).

## Test plan
- [x] `node scripts/check-changelog-placeholders.ts`
- [x] `pnpm run release:check:versions`
- [x] `pnpm --filter @ecopages/docs run build`
- [x] `pnpm run test:all` (CI / manual — docs-only diff)

**Does not merge to `main`, bump stable, tag, or publish.**