### PR TITLE
fix(core): return 500 for matched-route render errors, not 404

### DIFF
--- a/packages/core/src/adapters/shared/fs-server-response-matcher.test.ts
+++ b/packages/core/src/adapters/shared/fs-server-response-matcher.test.ts
@@ -40,11 +40,16 @@ const routeRendererFactory = new RouteRendererFactory({
 function createRouteRendererFactoryWithStub404(
 	realFactory: PageRendererResolver,
 	error404TemplatePath: string,
+	options?: { executeError?: Error },
 ): PageRendererResolver {
 	const stub404Renderer = {
-		execute: vi.fn(async () => ({
-			body: '<h1>404 - Page Not Found</h1>',
-		})),
+		execute: options?.executeError
+			? vi.fn(async () => {
+					throw options.executeError;
+				})
+			: vi.fn(async () => ({
+					body: '<h1>404 - Page Not Found</h1>',
+				})),
 		loadPageModule: vi.fn(async () => ({
 			default: () => null,
 		})),
@@ -57,6 +62,41 @@ function createRouteRendererFactoryWithStub404(
 			}
 
 			return realFactory.getPageRenderer(filePath);
+		},
+	};
+}
+
+function createRouteRendererFactoryWithThrowingPage(
+	realFactory: PageRendererResolver,
+	pageFilePath: string,
+	error: Error,
+): PageRendererResolver {
+	return {
+		getPageRenderer(filePath: string) {
+			if (filePath === pageFilePath) {
+				return {
+					execute: vi.fn(async () => {
+						throw error;
+					}),
+					loadPageModule: vi.fn(async () => ({
+						default: () => null,
+					})),
+				};
+			}
+
+			return realFactory.getPageRenderer(filePath);
+		},
+	};
+}
+
+function createRouteRendererFactoryWithMissing404Template(error404TemplatePath: string): PageRendererResolver {
+	return {
+		getPageRenderer(filePath: string) {
+			if (filePath === error404TemplatePath) {
+				throw new Error('404 template not found');
+			}
+
+			throw new Error(`Unexpected page renderer request: ${filePath}`);
 		},
 	};
 }
@@ -310,6 +350,78 @@ describe('FileSystemResponseMatcher', () => {
 			const response = await matcher.handleNoMatch('/non-existent.txt');
 			const body = await response.text();
 			expect(body).toContain('<h1>404 - Page Not Found</h1>');
+		});
+	});
+
+	describe('error taxonomy', () => {
+		it('should return 500 when a matched route render throws', async () => {
+			const renderError = new Error('page render failed');
+			const throwingFactory = createRouteRendererFactoryWithThrowingPage(
+				routeRendererFactory,
+				INDEX_TEMPLATE_FILE,
+				renderError,
+			);
+			const matcher = new FileSystemResponseMatcher({
+				appConfig,
+				assetPrefix: path.join(appConfig.rootDir, appConfig.distDir),
+				router,
+				routeRendererFactory: throwingFactory,
+				fileSystemResponseFactory,
+			});
+			const match: MatchResult = {
+				requestedPathname: APP_TEST_ROUTES.index,
+				templateRoute: {
+					kind: 'exact',
+					pathname: APP_TEST_ROUTES.index,
+					filePath: INDEX_TEMPLATE_FILE,
+				},
+				params: {},
+				query: {},
+			};
+
+			const response = await matcher.handleMatch(match);
+
+			expect(response.status).toBe(500);
+			expect(await response.text()).toBe('Internal Server Error');
+		});
+
+		it('should return 500 when the custom 404 template render throws', async () => {
+			const templateError = new Error('404 template render failed');
+			const throwing404Factory = createRouteRendererFactoryWithStub404(
+				routeRendererFactory,
+				appConfig.absolutePaths.error404TemplatePath,
+				{ executeError: templateError },
+			);
+			const matcher = new FileSystemResponseMatcher({
+				appConfig,
+				assetPrefix: path.join(appConfig.rootDir, appConfig.distDir),
+				router,
+				routeRendererFactory: throwing404Factory,
+				fileSystemResponseFactory,
+			});
+
+			const response = await matcher.handleNoMatch('/missing-page');
+
+			expect(response.status).toBe(500);
+			expect(await response.text()).toBe('Internal Server Error');
+		});
+
+		it('should fall back to default 404 when the custom 404 template cannot be resolved', async () => {
+			const missing404Factory = createRouteRendererFactoryWithMissing404Template(
+				appConfig.absolutePaths.error404TemplatePath,
+			);
+			const matcher = new FileSystemResponseMatcher({
+				appConfig,
+				assetPrefix: path.join(appConfig.rootDir, appConfig.distDir),
+				router,
+				routeRendererFactory: missing404Factory,
+				fileSystemResponseFactory,
+			});
+
+			const response = await matcher.handleNoMatch('/missing-page');
+
+			expect(response.status).toBe(404);
+			expect(await response.text()).not.toContain('<h1>404 - Page Not Found</h1>');
 		});
 	});
 

--- a/packages/core/src/adapters/shared/fs-server-response-matcher.ts
+++ b/packages/core/src/adapters/shared/fs-server-response-matcher.ts
@@ -79,7 +79,7 @@ export class FileSystemResponseMatcher {
 		const isStaticFileRequest = ServerUtils.hasKnownExtension(requestUrl);
 
 		if (!isStaticFileRequest) {
-			return this.renderCustomNotFoundResponse();
+			return this.renderCustomNotFoundResponseOrServerError(requestUrl);
 		}
 
 		const relativeUrl = requestUrl.startsWith('/') ? requestUrl.slice(1) : requestUrl;
@@ -87,7 +87,7 @@ export class FileSystemResponseMatcher {
 		const contentType = ServerUtils.getContentType(filePath);
 
 		const response = await this.fileSystemResponseFactory.createFileResponse(filePath, contentType);
-		return response ?? this.renderCustomNotFoundResponse();
+		return response ?? this.renderCustomNotFoundResponseOrServerError(requestUrl);
 	}
 
 	/**
@@ -147,17 +147,13 @@ export class FileSystemResponseMatcher {
 				return error;
 			}
 			if (error instanceof LocalsAccessError) {
-				return new Response(error.message, {
-					status: 500,
-					headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-				});
+				return this.createInternalServerErrorResponse(error.message, match.requestedPathname, error);
 			}
-			if (error instanceof Error) {
-				if (isDevelopmentRuntime() || appLogger.isDebugEnabled()) {
-					appLogger.error(`[FileSystemResponseMatcher] ${error.message} at ${match.requestedPathname}`);
-				}
-			}
-			return this.renderCustomNotFoundResponse();
+			return this.createInternalServerErrorResponse(
+				error instanceof Error ? error.message : 'Internal Server Error',
+				match.requestedPathname,
+				error,
+			);
 		}
 	}
 
@@ -168,13 +164,9 @@ export class FileSystemResponseMatcher {
 	private async renderCustomNotFoundResponse(): Promise<Response> {
 		const error404TemplatePath = this.appConfig.absolutePaths.error404TemplatePath;
 
+		let routeRenderer;
 		try {
-			const routeRenderer = this.routeRendererFactory.getPageRenderer(error404TemplatePath);
-			const result = await routeRenderer.execute({
-				file: error404TemplatePath,
-			});
-
-			return this.fileSystemResponseFactory.createHtmlNotFoundResponse(result.body);
+			routeRenderer = this.routeRendererFactory.getPageRenderer(error404TemplatePath);
 		} catch {
 			appLogger.debug(
 				'Custom 404 template not found, falling back to default 404 response',
@@ -182,6 +174,40 @@ export class FileSystemResponseMatcher {
 			);
 			return this.fileSystemResponseFactory.createDefaultNotFoundResponse();
 		}
+
+		const result = await routeRenderer.execute({
+			file: error404TemplatePath,
+		});
+
+		return this.fileSystemResponseFactory.createHtmlNotFoundResponse(result.body);
+	}
+
+	private async renderCustomNotFoundResponseOrServerError(pathname: string): Promise<Response> {
+		try {
+			return await this.renderCustomNotFoundResponse();
+		} catch (error) {
+			if (error instanceof Response) {
+				return error;
+			}
+			return this.createInternalServerErrorResponse(
+				error instanceof Error ? error.message : 'Internal Server Error',
+				pathname,
+				error,
+			);
+		}
+	}
+
+	private createInternalServerErrorResponse(message: string, pathname: string, error: unknown): Response {
+		if (isDevelopmentRuntime() || appLogger.isDebugEnabled()) {
+			appLogger.error(`[FileSystemResponseMatcher] ${message} at ${pathname}`, error);
+		} else {
+			appLogger.error(`[FileSystemResponseMatcher] Render error at ${pathname}`, error);
+		}
+
+		return new Response('Internal Server Error', {
+			status: 500,
+			headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+		});
 	}
 
 	private async createExecutionPlan(match: MatchResult, request?: Request): Promise<FileRouteExecutionPlan> {


### PR DESCRIPTION
## Summary
- Distinguish render failures from genuine not-found in `FileSystemResponseMatcher`
- Matched-route render errors return 500 instead of the custom 404 page
- Custom 404 template render failures return 500; missing template still falls back to default 404
- Regression tests for both masking layers (BUG-H1)

## Test plan
- [x] `packages/core/src/adapters/shared/fs-server-response-matcher.test.ts`
- [x] Full vitest + typecheck (pre-commit)

## Dependencies
None