### PR TITLE
feat(core): validate dependencies.components as declared eco components

### DIFF
--- a/packages/core/src/eco/eco-declared-component.test.ts
+++ b/packages/core/src/eco/eco-declared-component.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { eco } from './eco.ts';
+import {
+	assertEcoDeclaredComponent,
+	getUndeclaredComponentDependencyMessage,
+	isEcoDeclaredComponent,
+} from './eco-declared-component.ts';
+
+describe('eco-declared-component', () => {
+	it('should accept eco.component results with __eco metadata', () => {
+		const Button = eco.component({
+			__eco: {
+				id: 'button',
+				file: '/app/components/button.kita.tsx',
+				integration: 'kitajs',
+			},
+			render: () => '<button />',
+		});
+
+		expect(isEcoDeclaredComponent(Button)).toBe(true);
+		expect(() => assertEcoDeclaredComponent(Button)).not.toThrow();
+	});
+
+	it('should reject plain functions and components without __eco metadata', () => {
+		const plainFunction = () => '<div />';
+
+		expect(isEcoDeclaredComponent(plainFunction)).toBe(false);
+		expect(() => assertEcoDeclaredComponent(plainFunction)).toThrow(getUndeclaredComponentDependencyMessage());
+	});
+});

--- a/packages/core/src/eco/eco-declared-component.test.ts
+++ b/packages/core/src/eco/eco-declared-component.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { eco } from './eco.ts';
-import {
-	assertEcoDeclaredComponent,
-	getUndeclaredComponentDependencyMessage,
-	isEcoDeclaredComponent,
-} from './eco-declared-component.ts';
+import { assertEcoDeclaredComponent, isEcoDeclaredComponent } from './eco-declared-component.ts';
 import { UndeclaredComponentDependencyError } from '../errors/undeclared-component-dependency-error.ts';
 
 describe('eco-declared-component', () => {

--- a/packages/core/src/eco/eco-declared-component.test.ts
+++ b/packages/core/src/eco/eco-declared-component.test.ts
@@ -5,6 +5,7 @@ import {
 	getUndeclaredComponentDependencyMessage,
 	isEcoDeclaredComponent,
 } from './eco-declared-component.ts';
+import { UndeclaredComponentDependencyError } from '../errors/undeclared-component-dependency-error.ts';
 
 describe('eco-declared-component', () => {
 	it('should accept eco.component results with __eco metadata', () => {
@@ -25,6 +26,6 @@ describe('eco-declared-component', () => {
 		const plainFunction = () => '<div />';
 
 		expect(isEcoDeclaredComponent(plainFunction)).toBe(false);
-		expect(() => assertEcoDeclaredComponent(plainFunction)).toThrow(getUndeclaredComponentDependencyMessage());
+		expect(() => assertEcoDeclaredComponent(plainFunction)).toThrow(UndeclaredComponentDependencyError);
 	});
 });

--- a/packages/core/src/eco/eco-declared-component.ts
+++ b/packages/core/src/eco/eco-declared-component.ts
@@ -1,0 +1,35 @@
+import type { EcoComponent, EcoDeclaredComponent } from '../types/public-types.ts';
+
+/**
+ * @remarks
+ * Declared components are produced by `eco.component()`, `eco.layout()`, and
+ * `eco.html()` after the component-meta plugin injects `config.__eco`.
+ */
+export function isEcoDeclaredComponent(component: unknown): component is EcoDeclaredComponent {
+	return (
+		typeof component === 'function' &&
+		typeof (component as EcoComponent).config?.__eco?.file === 'string' &&
+		typeof (component as EcoComponent).config?.__eco?.integration === 'string'
+	);
+}
+
+export function getUndeclaredComponentDependencyMessage(parentComponentFile?: string): string {
+	const parentHint = parentComponentFile ? ` (declared by ${parentComponentFile})` : '';
+	return `[ecopages] dependencies.components entries must be eco.component(), eco.layout(), or eco.html() components with __eco metadata${parentHint}. Plain functions and untyped components are not valid dependency entries.`;
+}
+
+/**
+ * @remarks
+ * Dependency collection and ownership validation call this instead of silently
+ * skipping entries that lack `config.__eco`.
+ */
+export function assertEcoDeclaredComponent(
+	component: unknown,
+	context: { parentComponentFile?: string } = {},
+): asserts component is EcoDeclaredComponent {
+	if (isEcoDeclaredComponent(component)) {
+		return;
+	}
+
+	throw new Error(getUndeclaredComponentDependencyMessage(context.parentComponentFile));
+}

--- a/packages/core/src/eco/eco-declared-component.ts
+++ b/packages/core/src/eco/eco-declared-component.ts
@@ -17,9 +17,7 @@ export function isEcoDeclaredComponent(component: unknown): component is EcoDecl
 }
 
 /**
- * @remarks
- * Dependency collection and ownership validation call this instead of silently
- * skipping entries that lack `config.__eco`.
+ * @throws {UndeclaredComponentDependencyError} When the value lacks `config.__eco`.
  */
 export function assertEcoDeclaredComponent(
 	component: unknown,

--- a/packages/core/src/eco/eco-declared-component.ts
+++ b/packages/core/src/eco/eco-declared-component.ts
@@ -1,4 +1,7 @@
 import type { EcoComponent, EcoDeclaredComponent } from '../types/public-types.ts';
+import { UndeclaredComponentDependencyError } from '../errors/undeclared-component-dependency-error.ts';
+
+export { getUndeclaredComponentDependencyMessage } from '../errors/undeclared-component-dependency-error.ts';
 
 /**
  * @remarks
@@ -11,11 +14,6 @@ export function isEcoDeclaredComponent(component: unknown): component is EcoDecl
 		typeof (component as EcoComponent).config?.__eco?.file === 'string' &&
 		typeof (component as EcoComponent).config?.__eco?.integration === 'string'
 	);
-}
-
-export function getUndeclaredComponentDependencyMessage(parentComponentFile?: string): string {
-	const parentHint = parentComponentFile ? ` (declared by ${parentComponentFile})` : '';
-	return `[ecopages] dependencies.components entries must be eco.component(), eco.layout(), or eco.html() components with __eco metadata${parentHint}. Plain functions and untyped components are not valid dependency entries.`;
 }
 
 /**
@@ -31,5 +29,5 @@ export function assertEcoDeclaredComponent(
 		return;
 	}
 
-	throw new Error(getUndeclaredComponentDependencyMessage(context.parentComponentFile));
+	throw new UndeclaredComponentDependencyError(context.parentComponentFile);
 }

--- a/packages/core/src/eco/eco.test.ts
+++ b/packages/core/src/eco/eco.test.ts
@@ -630,6 +630,11 @@ describe('eco namespace', () => {
 	describe('integration', () => {
 		test('should work with nested components', () => {
 			const Button = eco.component<{ label: string }>({
+				__eco: {
+					id: 'button',
+					file: '/app/components/button.kita.tsx',
+					integration: 'kitajs',
+				},
 				dependencies: {
 					scripts: [
 						{
@@ -644,8 +649,13 @@ describe('eco namespace', () => {
 			});
 
 			const Card = eco.component<{ title: string; children: string }>({
+				__eco: {
+					id: 'card',
+					file: '/app/components/card.kita.tsx',
+					integration: 'kitajs',
+				},
 				dependencies: {
-					components: [Button as EcoComponent],
+					components: [Button],
 				},
 				render: ({ title, children }) => `<div class="card"><h2>${title}</h2>${children}</div>`,
 			});

--- a/packages/core/src/eco/eco.test.ts
+++ b/packages/core/src/eco/eco.test.ts
@@ -5,7 +5,6 @@
 import { describe, expect, test } from 'vitest';
 import { eco } from './eco.ts';
 import type {
-	EcoComponent,
 	GetMetadataContext,
 	HtmlTemplateProps,
 	LayoutProps,

--- a/packages/core/src/eco/eco.ts
+++ b/packages/core/src/eco/eco.ts
@@ -5,6 +5,7 @@
 
 import type {
 	EcoComponent,
+	EcoDeclaredComponent,
 	EcoHtmlComponent,
 	EcoLayoutComponent,
 	EcoPagesElement,
@@ -49,9 +50,9 @@ import { isThenable } from '../route-renderer/orchestration/render-output.utils.
  * @param options Component options for rendering and dependency declaration.
  * @returns Configured eco component.
  */
-function createComponentFactory<P, E>(options: ComponentOptions<P, E>): EcoComponent<P, E> {
+function createComponentFactory<P, E>(options: ComponentOptions<P, E>): EcoDeclaredComponent<P, E> {
 	const integrationName = options.integration ?? options.__eco?.integration;
-	const comp: EcoComponent<P, E> = ((props: P) => {
+	const comp: EcoDeclaredComponent<P, E> = ((props: P) => {
 		const componentProps = (props ?? {}) as Record<string, unknown>;
 		const renderInline = (nextProps: P = props) => finalizeComponentRender(comp, options.render(nextProps)) as E;
 		const activeRenderContext = getComponentRenderContext();
@@ -91,7 +92,7 @@ function createComponentFactory<P, E>(options: ComponentOptions<P, E>): EcoCompo
 		}
 
 		return renderInline();
-	}) as EcoComponent<P, E>;
+	}) as EcoDeclaredComponent<P, E>;
 
 	comp.config = {
 		__eco: options.__eco,
@@ -108,7 +109,7 @@ function createComponentFactory<P, E>(options: ComponentOptions<P, E>): EcoCompo
  * @param options Component definition options.
  * @returns Eco component function.
  */
-function component<P = {}, E = EcoPagesElement>(options: ComponentOptions<P, E>): EcoComponent<P, E> {
+function component<P = {}, E = EcoPagesElement>(options: ComponentOptions<P, E>): EcoDeclaredComponent<P, E> {
 	return createComponentFactory(options);
 }
 

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -1,3 +1,7 @@
 export { HttpError } from './http-error.ts';
 export type { HttpErrorDetails, HttpErrorJson } from './http-error.ts';
 export { LocalsAccessError } from './locals-access-error.ts';
+export {
+	UndeclaredComponentDependencyError,
+	getUndeclaredComponentDependencyMessage,
+} from './undeclared-component-dependency-error.ts';

--- a/packages/core/src/errors/undeclared-component-dependency-error.ts
+++ b/packages/core/src/errors/undeclared-component-dependency-error.ts
@@ -10,6 +10,7 @@ export function getUndeclaredComponentDependencyMessage(parentComponentFile?: st
 export class UndeclaredComponentDependencyError extends Error {
 	override name = 'UndeclaredComponentDependencyError';
 
+	/** Parent component file path when the invalid entry was declared. */
 	readonly parentComponentFile?: string;
 
 	constructor(parentComponentFile?: string) {

--- a/packages/core/src/errors/undeclared-component-dependency-error.ts
+++ b/packages/core/src/errors/undeclared-component-dependency-error.ts
@@ -1,0 +1,19 @@
+export function getUndeclaredComponentDependencyMessage(parentComponentFile?: string): string {
+	const parentHint = parentComponentFile ? ` (declared by ${parentComponentFile})` : '';
+	return `[ecopages] dependencies.components entries must be eco.component(), eco.layout(), or eco.html() components with __eco metadata${parentHint}. Plain functions and untyped components are not valid dependency entries.`;
+}
+
+/**
+ * Thrown when `dependencies.components` contains a plain function or component
+ * without plugin-injected `config.__eco` metadata.
+ */
+export class UndeclaredComponentDependencyError extends Error {
+	override name = 'UndeclaredComponentDependencyError';
+
+	readonly parentComponentFile?: string;
+
+	constructor(parentComponentFile?: string) {
+		super(getUndeclaredComponentDependencyMessage(parentComponentFile));
+		this.parentComponentFile = parentComponentFile;
+	}
+}

--- a/packages/core/src/route-renderer/orchestration/ownership-validation.service.test.ts
+++ b/packages/core/src/route-renderer/orchestration/ownership-validation.service.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
+import type { EcoComponent } from '../../types/public-types.ts';
+import { OwnershipValidationService, throwIfOwnershipInvalid } from './ownership-validation.service.ts';
+
+describe('OwnershipValidationService', () => {
+	const appConfig = {
+		integrations: [{ name: 'kitajs' }, { name: 'react' }],
+	} as EcoPagesAppConfig;
+
+	it('should reject plain functions in dependencies.components', () => {
+		const plainChild = (() => '<child />') as EcoComponent;
+		const page = (() => '<page />') as EcoComponent;
+		page.config = {
+			__eco: {
+				id: 'page',
+				file: '/app/pages/index.kita.tsx',
+				integration: 'kitajs',
+			},
+			dependencies: {
+				components: [plainChild],
+			},
+		};
+
+		const service = new OwnershipValidationService(appConfig);
+		const errors = service.validate({
+			currentIntegrationName: 'kitajs',
+			roots: [{ component: page, source: 'page' }],
+		});
+
+		expect(errors).toEqual([
+			expect.objectContaining({
+				code: 'UNDECLARED_COMPONENT_DEPENDENCY',
+			}),
+		]);
+		expect(() => throwIfOwnershipInvalid(errors)).toThrow(
+			/dependencies\.components entries must be eco\.component\(\)/,
+		);
+	});
+});

--- a/packages/core/src/route-renderer/orchestration/ownership-validation.service.test.ts
+++ b/packages/core/src/route-renderer/orchestration/ownership-validation.service.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 import type { EcoComponent } from '../../types/public-types.ts';
-import { OwnershipValidationService, throwIfOwnershipInvalid } from './ownership-validation.service.ts';
+import { UndeclaredComponentDependencyError } from '../../errors/undeclared-component-dependency-error.ts';
+import { OwnershipValidationService } from './ownership-validation.service.ts';
 
 describe('OwnershipValidationService', () => {
 	const appConfig = {
 		integrations: [{ name: 'kitajs' }, { name: 'react' }],
 	} as EcoPagesAppConfig;
 
-	it('should reject plain functions in dependencies.components', () => {
+	it('should throw when dependencies.components contains a plain function', () => {
 		const plainChild = (() => '<child />') as EcoComponent;
 		const page = (() => '<page />') as EcoComponent;
 		page.config = {
@@ -23,18 +24,12 @@ describe('OwnershipValidationService', () => {
 		};
 
 		const service = new OwnershipValidationService(appConfig);
-		const errors = service.validate({
-			currentIntegrationName: 'kitajs',
-			roots: [{ component: page, source: 'page' }],
-		});
 
-		expect(errors).toEqual([
-			expect.objectContaining({
-				code: 'UNDECLARED_COMPONENT_DEPENDENCY',
+		expect(() =>
+			service.validate({
+				currentIntegrationName: 'kitajs',
+				roots: [{ component: page, source: 'page' }],
 			}),
-		]);
-		expect(() => throwIfOwnershipInvalid(errors)).toThrow(
-			/dependencies\.components entries must be eco\.component\(\)/,
-		);
+		).toThrow(UndeclaredComponentDependencyError);
 	});
 });

--- a/packages/core/src/route-renderer/orchestration/ownership-validation.service.ts
+++ b/packages/core/src/route-renderer/orchestration/ownership-validation.service.ts
@@ -1,6 +1,8 @@
 import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 import type { OwnershipPlanNodeSource, OwnershipValidationError, EcoComponent } from '../../types/public-types.ts';
+import { getUndeclaredComponentDependencyMessage, isEcoDeclaredComponent } from '../../eco/eco-declared-component.ts';
 import { mapDeclaredOwnershipGraph } from './declared-ownership-graph.ts';
+import { walkComponentGraph } from './component-graph.ts';
 
 type OwnershipValidationInput = {
 	currentIntegrationName: string;
@@ -31,7 +33,8 @@ export class OwnershipValidationService {
 	 * Validates foreign ownership edges reachable from the supplied route roots.
 	 */
 	validate(input: OwnershipValidationInput): OwnershipValidationError[] {
-		return mapDeclaredOwnershipGraph<OwnershipValidationError[]>({
+		const declaredDependencyErrors = this.validateDeclaredDependencies(input);
+		const foreignOwnershipErrors = mapDeclaredOwnershipGraph<OwnershipValidationError[]>({
 			roots: input.roots,
 			currentIntegrationName: input.currentIntegrationName,
 			mapNode: ({ component, integrationName, componentId, isForeignToParent }, children) => {
@@ -68,6 +71,33 @@ export class OwnershipValidationService {
 				return errors;
 			},
 		}).flat();
+
+		return [...declaredDependencyErrors, ...foreignOwnershipErrors];
+	}
+
+	private validateDeclaredDependencies(input: OwnershipValidationInput): OwnershipValidationError[] {
+		const errors: OwnershipValidationError[] = [];
+
+		walkComponentGraph({
+			roots: input.roots,
+			currentIntegrationName: input.currentIntegrationName,
+			onComponent: ({ component }) => {
+				const parentFile = component.config?.__eco?.file;
+				for (const child of component.config?.dependencies?.components ?? []) {
+					if (!child || isEcoDeclaredComponent(child)) {
+						continue;
+					}
+
+					errors.push({
+						code: 'UNDECLARED_COMPONENT_DEPENDENCY',
+						message: getUndeclaredComponentDependencyMessage(parentFile),
+						componentFile: parentFile,
+					});
+				}
+			},
+		});
+
+		return errors;
 	}
 
 	private isRegisteredIntegration(integrationName: string, currentIntegrationName: string): boolean {

--- a/packages/core/src/route-renderer/orchestration/ownership-validation.service.ts
+++ b/packages/core/src/route-renderer/orchestration/ownership-validation.service.ts
@@ -1,6 +1,6 @@
 import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 import type { OwnershipPlanNodeSource, OwnershipValidationError, EcoComponent } from '../../types/public-types.ts';
-import { getUndeclaredComponentDependencyMessage, isEcoDeclaredComponent } from '../../eco/eco-declared-component.ts';
+import { assertEcoDeclaredComponent } from '../../eco/eco-declared-component.ts';
 import { mapDeclaredOwnershipGraph } from './declared-ownership-graph.ts';
 import { walkComponentGraph } from './component-graph.ts';
 
@@ -33,8 +33,9 @@ export class OwnershipValidationService {
 	 * Validates foreign ownership edges reachable from the supplied route roots.
 	 */
 	validate(input: OwnershipValidationInput): OwnershipValidationError[] {
-		const declaredDependencyErrors = this.validateDeclaredDependencies(input);
-		const foreignOwnershipErrors = mapDeclaredOwnershipGraph<OwnershipValidationError[]>({
+		this.assertDeclaredComponentDependencies(input);
+
+		return mapDeclaredOwnershipGraph<OwnershipValidationError[]>({
 			roots: input.roots,
 			currentIntegrationName: input.currentIntegrationName,
 			mapNode: ({ component, integrationName, componentId, isForeignToParent }, children) => {
@@ -71,33 +72,23 @@ export class OwnershipValidationService {
 				return errors;
 			},
 		}).flat();
-
-		return [...declaredDependencyErrors, ...foreignOwnershipErrors];
 	}
 
-	private validateDeclaredDependencies(input: OwnershipValidationInput): OwnershipValidationError[] {
-		const errors: OwnershipValidationError[] = [];
-
+	private assertDeclaredComponentDependencies(input: OwnershipValidationInput): void {
 		walkComponentGraph({
 			roots: input.roots,
 			currentIntegrationName: input.currentIntegrationName,
 			onComponent: ({ component }) => {
 				const parentFile = component.config?.__eco?.file;
 				for (const child of component.config?.dependencies?.components ?? []) {
-					if (!child || isEcoDeclaredComponent(child)) {
+					if (!child) {
 						continue;
 					}
 
-					errors.push({
-						code: 'UNDECLARED_COMPONENT_DEPENDENCY',
-						message: getUndeclaredComponentDependencyMessage(parentFile),
-						componentFile: parentFile,
-					});
+					assertEcoDeclaredComponent(child, { parentComponentFile: parentFile });
 				}
 			},
 		});
-
-		return errors;
 	}
 
 	private isRegisteredIntegration(integrationName: string, currentIntegrationName: string): boolean {

--- a/packages/core/src/route-renderer/page-loading/component-dependency-collection.ts
+++ b/packages/core/src/route-renderer/page-loading/component-dependency-collection.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import type { DependencyLazyTrigger, EcoComponent } from '../../types/public-types.ts';
+import { assertEcoDeclaredComponent } from '../../eco/eco-declared-component.ts';
 import type { AssetDefinition } from '../../services/assets/asset-processing-service/index.ts';
 import { AssetFactory } from '../../services/assets/asset-processing-service/index.ts';
 import { extractEcopagesVirtualImports } from './ecopages-virtual-imports.ts';
@@ -170,9 +171,12 @@ export function collectComponentDependencies(
 
 			if (dependenciesConfig?.components) {
 				for (const nestedComponent of dependenciesConfig.components) {
-					if (nestedComponent?.config) {
-						collect(nestedComponent.config);
+					if (!nestedComponent) {
+						continue;
 					}
+
+					assertEcoDeclaredComponent(nestedComponent, { parentComponentFile: file });
+					collect(nestedComponent.config);
 				}
 			}
 		};

--- a/packages/core/src/route-renderer/page-loading/dependency-resolver.test.ts
+++ b/packages/core/src/route-renderer/page-loading/dependency-resolver.test.ts
@@ -12,6 +12,7 @@ import type {
 	InlineContentScriptAsset,
 } from '../../services/assets/asset-processing-service/index.ts';
 import type { EcoComponent } from '../../types/public-types.ts';
+import { UndeclaredComponentDependencyError } from '../../errors/undeclared-component-dependency-error.ts';
 
 describe('DependencyResolverService', () => {
 	const appConfig = {
@@ -778,7 +779,7 @@ describe('DependencyResolverService', () => {
 		};
 
 		await expect(service.processComponentDependencies([component], 'kitajs')).rejects.toThrow(
-			/dependencies\.components entries must be eco\.component\(\)/,
+			UndeclaredComponentDependencyError,
 		);
 	});
 });

--- a/packages/core/src/route-renderer/page-loading/dependency-resolver.test.ts
+++ b/packages/core/src/route-renderer/page-loading/dependency-resolver.test.ts
@@ -758,4 +758,27 @@ describe('DependencyResolverService', () => {
 			}),
 		]);
 	});
+
+	it('should throw when dependencies.components contains a plain function', async () => {
+		const assetProcessingService = {
+			processDependencies: vi.fn(async () => []),
+		} as unknown as AssetProcessingService;
+		const service = new DependencyResolverService(appConfig, assetProcessingService);
+		const plainChild = (() => '<child />') as EcoComponent;
+		const component = ((_) => '<parent></parent>') as EcoComponent<Record<string, unknown>>;
+		component.config = {
+			__eco: {
+				id: 'parent',
+				integration: 'kitajs',
+				file: '/app/components/parent.kita.tsx',
+			},
+			dependencies: {
+				components: [plainChild],
+			},
+		};
+
+		await expect(service.processComponentDependencies([component], 'kitajs')).rejects.toThrow(
+			/dependencies\.components entries must be eco\.component\(\)/,
+		);
+	});
 });

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -378,20 +378,22 @@ export type EcoComponentDependencies = {
 	 * to express explicit module imports for client bundles.
 	 */
 	modules?: string[];
+	/**
+	 * Child components whose assets and foreign-child graph are collected transitively.
+	 * Each entry must be an `eco.component()`, `eco.layout()`, or `eco.html()` result
+	 * with plugin-injected `config.__eco` metadata.
+	 */
 	components?: EcoDeclaredComponent[];
 };
 
 /**
- * Eco component created through `eco.component()`, `eco.layout()`, or `eco.html()`.
+ * Component returned from `eco.component()`, `eco.layout()`, or `eco.html()`.
  *
  * @remarks
- * `config.__eco` is injected by the component-meta plugin at build time. The brand
- * keeps `dependencies.components` narrow at authoring time; use
- * `isEcoDeclaredComponent()` for runtime checks.
+ * Used for `dependencies.components` and eco factory return types. Plugin-injected
+ * `config.__eco` is enforced at runtime via `isEcoDeclaredComponent()`, not by this alias.
  */
-export type EcoDeclaredComponent<P = any, R = any> = EcoComponent<P, R> & {
-	readonly __ecoDeclaredBrand?: unique symbol;
-};
+export type EcoDeclaredComponent<P = any, R = any> = EcoComponent<P, R>;
 
 export type EcoPagesElement = string | Promise<string>;
 
@@ -945,10 +947,7 @@ export interface PageBrowserGraphContribution {
 	assets?: ProcessedAsset[];
 }
 
-export type OwnershipValidationErrorCode =
-	| 'UNKNOWN_INTEGRATION_OWNER'
-	| 'MISSING_COMPONENT_METADATA'
-	| 'UNDECLARED_COMPONENT_DEPENDENCY';
+export type OwnershipValidationErrorCode = 'UNKNOWN_INTEGRATION_OWNER' | 'MISSING_COMPONENT_METADATA';
 
 export interface OwnershipValidationError {
 	code: OwnershipValidationErrorCode;

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -378,7 +378,19 @@ export type EcoComponentDependencies = {
 	 * to express explicit module imports for client bundles.
 	 */
 	modules?: string[];
-	components?: EcoComponent[];
+	components?: EcoDeclaredComponent[];
+};
+
+/**
+ * Eco component created through `eco.component()`, `eco.layout()`, or `eco.html()`.
+ *
+ * @remarks
+ * `config.__eco` is injected by the component-meta plugin at build time. The brand
+ * keeps `dependencies.components` narrow at authoring time; use
+ * `isEcoDeclaredComponent()` for runtime checks.
+ */
+export type EcoDeclaredComponent<P = any, R = any> = EcoComponent<P, R> & {
+	readonly __ecoDeclaredBrand?: unique symbol;
 };
 
 export type EcoPagesElement = string | Promise<string>;
@@ -933,7 +945,10 @@ export interface PageBrowserGraphContribution {
 	assets?: ProcessedAsset[];
 }
 
-export type OwnershipValidationErrorCode = 'UNKNOWN_INTEGRATION_OWNER' | 'MISSING_COMPONENT_METADATA';
+export type OwnershipValidationErrorCode =
+	| 'UNKNOWN_INTEGRATION_OWNER'
+	| 'MISSING_COMPONENT_METADATA'
+	| 'UNDECLARED_COMPONENT_DEPENDENCY';
 
 export interface OwnershipValidationError {
 	code: OwnershipValidationErrorCode;


### PR DESCRIPTION
## Summary
- Add `EcoDeclaredComponent` brand and `isEcoDeclaredComponent` / `assertEcoDeclaredComponent` helpers
- Narrow `dependencies.components` typing; eco factories return declared components
- Fail loud in dependency collection and ownership validation when entries lack `config.__eco`
- Regression tests for collection, ownership, and eco-declared-component guard

## Test plan
- [x] `eco-declared-component.test.ts`
- [x] `dependency-resolver.test.ts`
- [x] `ownership-validation.service.test.ts`
- [x] `eco.test.ts`
- [x] `@ecopages/core` typecheck

## Dependencies
None (independent of FSM error-surface PR)