### PR TITLE
feat(core): nested layout arrays on eco.page

### DIFF
--- a/packages/core/src/eco/eco.browser.test.ts
+++ b/packages/core/src/eco/eco.browser.test.ts
@@ -26,7 +26,7 @@ describe('browser eco facade', () => {
 
 		expect(Page({})).toBe('<article>Docs</article>');
 		expect(Page.config?.layout).toBe(Layout);
-		expect(Page.config?.dependencies?.components).toEqual([Layout, Layout]);
+		expect(Page.config?.dependencies?.components).toEqual([Layout]);
 		expect(Page.staticPaths).toBe(staticPaths);
 		expect(Page.metadata).toBe(metadata);
 		expect(Page.middleware).toBe(middleware);

--- a/packages/core/src/eco/eco.browser.ts
+++ b/packages/core/src/eco/eco.browser.ts
@@ -12,6 +12,7 @@ import type {
 } from '../types/public-types.ts';
 import type { CacheStrategy } from '../services/cache/cache.types.ts';
 import type { ComponentOptions, Eco, HtmlOptions, LayoutOptions, PageOptionsBase, PagePropsFor } from './eco.types.ts';
+import { applyPageLayoutConfig, mergeLayoutDependencies, normalizePageLayouts } from './page-layout-normalization.ts';
 
 function createComponentFactory<P, E>(options: ComponentOptions<P, E>): EcoComponent<P, E> {
 	const component = ((props: P) => options.render(props)) as EcoComponent<P, E>;
@@ -70,20 +71,17 @@ function page<T, E>(
 		middleware,
 	} = options;
 
+	const layoutEntries = normalizePageLayouts(pageLayout);
+
 	const pageComponent = createComponentFactory({
 		__eco: options.__eco,
 		integration: options.integration,
-		dependencies: pageLayout
-			? {
-					...dependencies,
-					components: [...(dependencies?.components ?? []), pageLayout],
-				}
-			: dependencies,
+		dependencies: mergeLayoutDependencies(dependencies, layoutEntries),
 		render,
 	} as ComponentOptions<PagePropsFor<T> & Partial<RequestPageContext>, E>) as EcoPageComponent<T>;
 
-	if (pageLayout && pageComponent.config) {
-		pageComponent.config.layout = pageLayout;
+	if (pageComponent.config) {
+		applyPageLayoutConfig(pageComponent.config, layoutEntries);
 	}
 
 	if (staticPaths) {

--- a/packages/core/src/eco/eco.test.ts
+++ b/packages/core/src/eco/eco.test.ts
@@ -4,13 +4,7 @@
 
 import { describe, expect, test } from 'vitest';
 import { eco } from './eco.ts';
-import type {
-	EcoComponent,
-	GetMetadataContext,
-	HtmlTemplateProps,
-	LayoutProps,
-	StaticPath,
-} from '../types/public-types.ts';
+import type { GetMetadataContext, HtmlTemplateProps, LayoutProps, StaticPath } from '../types/public-types.ts';
 import type { EcoPagesAppConfig } from '../types/internal-types.ts';
 import {
 	type ForeignChildRuntime,
@@ -661,6 +655,41 @@ describe('eco namespace', () => {
 			});
 
 			expect(Card.config?.dependencies?.components).toContain(Button);
+		});
+
+		test('should normalize nested page layouts onto config.layouts', () => {
+			const OuterLayout = eco.layout({
+				__eco: {
+					id: 'outer',
+					file: '/app/layouts/outer.kita.tsx',
+					integration: 'kitajs',
+				},
+				render: ({ children }) => `<outer>${children}</outer>`,
+			});
+			const InnerLayout = eco.layout({
+				__eco: {
+					id: 'inner',
+					file: '/app/layouts/inner.kita.tsx',
+					integration: 'kitajs',
+				},
+				render: ({ children }) => `<inner>${children}</inner>`,
+			});
+
+			const Page = eco.page({
+				layout: [OuterLayout, { component: InnerLayout, props: ({ params }) => ({ section: params?.slug }) }],
+				render: () => '<page />',
+			});
+
+			expect(Page.config?.layouts).toEqual([OuterLayout, InnerLayout]);
+			expect(Page.config?.layout).toBe(InnerLayout);
+			expect(Page.config?.layoutEntries).toEqual([
+				{ component: OuterLayout },
+				{
+					component: InnerLayout,
+					props: expect.any(Function),
+				},
+			]);
+			expect(Page.config?.dependencies?.components).toEqual([OuterLayout, InnerLayout]);
 		});
 	});
 

--- a/packages/core/src/eco/eco.ts
+++ b/packages/core/src/eco/eco.ts
@@ -35,6 +35,7 @@ import {
 	interceptForeignChild,
 } from '../route-renderer/orchestration/component-render-context.ts';
 import { isThenable } from '../route-renderer/orchestration/render-output.utils.ts';
+import { applyPageLayoutConfig, mergeLayoutDependencies, normalizePageLayouts } from './page-layout-normalization.ts';
 
 /**
  * Creates a component factory with lazy-trigger support and foreign-child-runtime
@@ -190,22 +191,19 @@ function page<T, E>(
 ): EcoPageComponent<T> {
 	const { layout, dependencies, render, staticPaths, staticProps, metadata, cache, requires, middleware } = options;
 
+	const layoutEntries = normalizePageLayouts(layout);
+
 	const componentOptions: ComponentOptions<PagePropsFor<T> & Partial<RequestPageContext>, E> = {
 		__eco: options.__eco,
 		integration: options.integration,
-		dependencies: layout
-			? {
-					...dependencies,
-					components: [...(dependencies?.components || []), layout],
-				}
-			: dependencies,
+		dependencies: mergeLayoutDependencies(dependencies, layoutEntries),
 		render,
 	};
 
 	const pageComponent = createComponentFactory(componentOptions) as EcoPageComponent<T>;
 
-	if (layout && pageComponent.config) {
-		pageComponent.config.layout = layout;
+	if (pageComponent.config) {
+		applyPageLayoutConfig(pageComponent.config, layoutEntries);
 	}
 
 	if (staticPaths) pageComponent.staticPaths = staticPaths;

--- a/packages/core/src/eco/eco.types.ts
+++ b/packages/core/src/eco/eco.types.ts
@@ -10,7 +10,7 @@ import type {
 	EcoHtmlComponent,
 	EcoInjectedMeta,
 	EcoLayoutComponent,
-	EcoPageLayoutComponent,
+	EcoPageLayouts,
 	EcoPagesElement,
 	FileRouteMiddleware,
 	GetMetadata,
@@ -119,7 +119,7 @@ export interface PageOptionsBase<T, E = EcoPagesElement> {
 	__eco?: EcoInjectedMeta;
 	integration?: string;
 	dependencies?: EcoComponentDependencies;
-	layout?: EcoPageLayoutComponent<E>;
+	layout?: EcoPageLayouts<E>;
 
 	/**
 	 * Define static paths for dynamic routes (e.g., [slug].tsx).

--- a/packages/core/src/eco/page-layout-normalization.test.ts
+++ b/packages/core/src/eco/page-layout-normalization.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import type { EcoComponentConfig } from '../types/public-types.ts';
+import { eco } from './eco.ts';
+import { applyPageLayoutConfig, mergeLayoutDependencies, normalizePageLayouts } from './page-layout-normalization.ts';
+
+describe('page-layout-normalization', () => {
+	const OuterLayout = eco.layout({
+		__eco: { id: 'outer', file: '/app/layouts/outer.kita.tsx', integration: 'kitajs' },
+		render: ({ children }) => `<outer>${children}</outer>`,
+	});
+	const InnerLayout = eco.layout({
+		__eco: { id: 'inner', file: '/app/layouts/inner.kita.tsx', integration: 'kitajs' },
+		render: ({ children }) => `<inner>${children}</inner>`,
+	});
+
+	it('should normalize a single layout to a one-item stack', () => {
+		expect(normalizePageLayouts(OuterLayout)).toEqual([{ component: OuterLayout }]);
+	});
+
+	it('should preserve outer→inner order for layout arrays', () => {
+		expect(normalizePageLayouts([OuterLayout, InnerLayout])).toEqual([
+			{ component: OuterLayout },
+			{ component: InnerLayout },
+		]);
+	});
+
+	it('should retain layout prop factories on normalized entries', () => {
+		const props = (context: { params?: Record<string, string> }) => ({
+			section: context.params?.slug ?? 'default',
+		});
+
+		expect(normalizePageLayouts([OuterLayout, { component: InnerLayout, props }])).toEqual([
+			{ component: OuterLayout },
+			{ component: InnerLayout, props },
+		]);
+	});
+
+	it('should merge layout components into dependencies without duplicates', () => {
+		const Button = eco.component({
+			__eco: { id: 'button', file: '/app/components/button.kita.tsx', integration: 'kitajs' },
+			render: () => '<button />',
+		});
+
+		const merged = mergeLayoutDependencies(
+			{ components: [Button, OuterLayout] },
+			normalizePageLayouts([OuterLayout, InnerLayout]),
+		);
+
+		expect(merged?.components).toEqual([Button, OuterLayout, InnerLayout]);
+	});
+
+	it('should write layouts, layoutEntries, and innermost layout alias onto page config', () => {
+		const config = {} as EcoComponentConfig;
+		const entries = normalizePageLayouts([OuterLayout, InnerLayout]);
+
+		applyPageLayoutConfig(config, entries);
+
+		expect(config.layouts).toEqual([OuterLayout, InnerLayout]);
+		expect(config.layoutEntries).toEqual(entries);
+		expect(config.layout).toBe(InnerLayout);
+	});
+});

--- a/packages/core/src/eco/page-layout-normalization.ts
+++ b/packages/core/src/eco/page-layout-normalization.ts
@@ -1,0 +1,77 @@
+import type {
+	EcoComponentConfig,
+	EcoComponentDependencies,
+	EcoDeclaredComponent,
+	EcoPageLayoutEntry,
+	EcoPageLayoutSpec,
+	EcoPageLayouts,
+} from '../types/public-types.ts';
+
+function isLayoutSpecObject<E>(spec: EcoPageLayoutSpec<E>): spec is EcoPageLayoutEntry<E> {
+	return typeof spec === 'object' && spec !== null && 'component' in spec;
+}
+
+/**
+ * Normalizes `layout` page options to an outer→inner stack of layout entries.
+ */
+export function normalizePageLayouts<E>(layout?: EcoPageLayouts<E>): EcoPageLayoutEntry<E>[] {
+	if (!layout) {
+		return [];
+	}
+
+	const specs = Array.isArray(layout) ? layout : [layout];
+
+	return specs.map((spec) => {
+		if (isLayoutSpecObject(spec)) {
+			return {
+				component: spec.component,
+				props: spec.props,
+			};
+		}
+
+		return {
+			component: spec as EcoDeclaredComponent<any, E>,
+		};
+	});
+}
+
+/**
+ * Merges layout components into `dependencies.components` without duplicates.
+ */
+export function mergeLayoutDependencies(
+	dependencies: EcoComponentDependencies | undefined,
+	layoutEntries: EcoPageLayoutEntry[],
+): EcoComponentDependencies | undefined {
+	if (layoutEntries.length === 0) {
+		return dependencies;
+	}
+
+	const mergedComponents = [...(dependencies?.components ?? [])];
+	for (const entry of layoutEntries) {
+		if (!mergedComponents.includes(entry.component)) {
+			mergedComponents.push(entry.component);
+		}
+	}
+
+	return {
+		...dependencies,
+		components: mergedComponents,
+	};
+}
+
+/**
+ * Writes normalized layout metadata onto a page `config`.
+ *
+ * @remarks
+ * `config.layout` remains the innermost layout alias for legacy call sites.
+ */
+export function applyPageLayoutConfig(pageConfig: EcoComponentConfig, layoutEntries: EcoPageLayoutEntry[]): void {
+	if (layoutEntries.length === 0) {
+		return;
+	}
+
+	const layoutComponents = layoutEntries.map((entry) => entry.component);
+	pageConfig.layouts = layoutComponents;
+	pageConfig.layoutEntries = layoutEntries;
+	pageConfig.layout = layoutComponents[layoutComponents.length - 1];
+}

--- a/packages/core/src/route-renderer/orchestration/component-graph.ts
+++ b/packages/core/src/route-renderer/orchestration/component-graph.ts
@@ -69,8 +69,16 @@ export function walkComponentGraph(input: {
 			}
 		}
 
-		if (input.visitLayout && ecoComponent.config?.layout?.config) {
-			visitConfig(ecoComponent.config.layout.config, integrationName);
+		if (input.visitLayout) {
+			for (const layout of ecoComponent.config?.layouts ?? []) {
+				if (layout?.config) {
+					visitConfig(layout.config, integrationName);
+				}
+			}
+
+			if (!ecoComponent.config?.layouts?.length && ecoComponent.config?.layout?.config) {
+				visitConfig(ecoComponent.config.layout.config, integrationName);
+			}
 		}
 
 		for (const child of ecoComponent.config?.dependencies?.components ?? []) {
@@ -89,8 +97,16 @@ export function walkComponentGraph(input: {
 			input.onConfig(config);
 		}
 
-		if (input.visitLayout && config.layout?.config) {
-			visitConfig(config.layout.config, parentIntegrationName);
+		if (input.visitLayout) {
+			for (const layout of config.layouts ?? []) {
+				if (layout?.config) {
+					visitConfig(layout.config, parentIntegrationName);
+				}
+			}
+
+			if (!config.layouts?.length && config.layout?.config) {
+				visitConfig(config.layout.config, parentIntegrationName);
+			}
 		}
 
 		for (const child of config.dependencies?.components ?? []) {

--- a/packages/core/src/route-renderer/orchestration/integration-renderer.ts
+++ b/packages/core/src/route-renderer/orchestration/integration-renderer.ts
@@ -59,6 +59,7 @@ import {
 	composeDocumentShell,
 	renderPageDocumentShell,
 } from './document-shell-render.service.ts';
+import { resolvePageLayoutComponents } from './layout-shell-props.service.ts';
 
 /**
  * Controls how one route module is loaded outside the normal render path.
@@ -839,7 +840,8 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 		});
 		const { Page, integrationSpecificProps } = pageModule;
 		const HtmlTemplate = await this.getHtmlTemplate();
-		const Layout = Page.config?.layout;
+		const Layouts = resolvePageLayoutComponents(Page.config?.layouts, Page.config?.layout);
+		const Layout = Layouts[Layouts.length - 1];
 		const { props, metadata } = await this.pageModuleLoaderService.resolvePageData({
 			pageModule,
 			routeOptions,
@@ -848,7 +850,9 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 		return {
 			Page,
 			HtmlTemplate: HtmlTemplate as EcoComponent<HtmlTemplateProps>,
+			Layouts,
 			Layout,
+			layoutEntries: Page.config?.layoutEntries,
 			props,
 			metadata,
 			integrationSpecificProps,

--- a/packages/core/src/route-renderer/orchestration/layout-shell-props.service.test.ts
+++ b/packages/core/src/route-renderer/orchestration/layout-shell-props.service.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { eco } from '../../eco/eco.ts';
+import {
+	resolveLayoutEntryProps,
+	resolveLayoutShellProps,
+	resolvePageLayoutComponents,
+} from './layout-shell-props.service.ts';
+
+describe('layout-shell-props.service', () => {
+	const Layout = eco.layout({
+		__eco: { id: 'layout', file: '/app/layouts/base.kita.tsx', integration: 'kitajs' },
+		render: ({ children }) => `<layout>${children}</layout>`,
+	});
+
+	it('should resolve default layout shell props from locals', () => {
+		expect(
+			resolveLayoutShellProps({
+				params: { slug: 'post' },
+				query: { q: 'test' },
+				locals: { user: 'Ada' },
+			}),
+		).toEqual({
+			locals: { user: 'Ada' },
+		});
+	});
+
+	it('should merge layout entry prop factories over shell props', () => {
+		const entry = {
+			component: Layout,
+			props: (context: { params?: Record<string, string> }) => ({
+				section: context.params?.slug,
+			}),
+		};
+
+		expect(
+			resolveLayoutEntryProps(entry, {
+				params: { slug: 'admin' },
+				query: {},
+				locals: { user: 'Ada' },
+			}),
+		).toEqual({
+			locals: { user: 'Ada' },
+			section: 'admin',
+		});
+	});
+
+	it('should fall back to legacy single layout config', () => {
+		expect(resolvePageLayoutComponents(undefined, Layout)).toEqual([Layout]);
+	});
+});

--- a/packages/core/src/route-renderer/orchestration/layout-shell-props.service.ts
+++ b/packages/core/src/route-renderer/orchestration/layout-shell-props.service.ts
@@ -1,0 +1,50 @@
+import type { EcoPageLayoutEntry, LayoutPropsContext, RequestLocals } from '../../types/public-types.ts';
+
+export type LayoutShellPropsContext = LayoutPropsContext & {
+	pageProps?: Record<string, unknown>;
+};
+
+/**
+ * Resolves the default shell props passed to a layout tier during route render.
+ */
+export function resolveLayoutShellProps(context: LayoutShellPropsContext): Record<string, unknown> {
+	return context.locals ? { locals: context.locals } : {};
+}
+
+/**
+ * Resolves props for one layout entry, merging shell props with an optional factory.
+ */
+export function resolveLayoutEntryProps(
+	entry: EcoPageLayoutEntry,
+	context: LayoutShellPropsContext,
+): Record<string, unknown> {
+	const shellProps = resolveLayoutShellProps(context);
+	if (!entry.props) {
+		return shellProps;
+	}
+
+	const layoutPropsContext: LayoutPropsContext = {
+		params: context.params,
+		query: context.query,
+		locals: context.locals as RequestLocals | undefined,
+	};
+
+	return {
+		...shellProps,
+		...entry.props(layoutPropsContext),
+	};
+}
+
+/**
+ * Reads the normalized layout stack from a page component config.
+ */
+export function resolvePageLayoutComponents(
+	layouts?: EcoPageLayoutEntry['component'][],
+	legacyLayout?: EcoPageLayoutEntry['component'],
+): EcoPageLayoutEntry['component'][] {
+	if (layouts && layouts.length > 0) {
+		return layouts;
+	}
+
+	return legacyLayout ? [legacyLayout] : [];
+}

--- a/packages/core/src/route-renderer/orchestration/route-prepared-options.builder.ts
+++ b/packages/core/src/route-renderer/orchestration/route-prepared-options.builder.ts
@@ -8,6 +8,7 @@ import type {
 	IntegrationRendererRenderOptions,
 	PageBrowserGraphResult,
 	PageMetadataProps,
+	EcoPageLayoutEntry,
 	PageProps,
 	RouteRendererOptions,
 } from '../../types/public-types.ts';
@@ -18,7 +19,9 @@ import { createPageLocalsProxy } from './route-prepared-options.utils.ts';
 type PreparedRenderInputs = {
 	Page: EcoPageFile['default'] | EcoPageComponent<any>;
 	HtmlTemplate: EcoComponent<HtmlTemplateProps>;
+	Layouts: EcoComponent[];
 	Layout?: EcoComponent;
+	layoutEntries?: EcoPageLayoutEntry[];
 	props: Record<string, unknown>;
 	metadata: PageMetadataProps;
 	integrationSpecificProps: Record<string, unknown>;
@@ -45,7 +48,8 @@ export function buildPreparedRenderOptions<C = unknown>(input: {
 		componentRender,
 		appConfig,
 	} = input;
-	const { Page, HtmlTemplate, Layout, props, metadata, integrationSpecificProps } = resolvedInputs;
+	const { Page, HtmlTemplate, Layouts, Layout, layoutEntries, props, metadata, integrationSpecificProps } =
+		resolvedInputs;
 
 	const dedupedDependencies = dedupeProcessedAssets(allDependencies);
 	const pagePackage = createPagePackage(dedupedDependencies, { pageBrowserGraph });
@@ -70,7 +74,9 @@ export function buildPreparedRenderOptions<C = unknown>(input: {
 		pagePackage,
 		componentRender,
 		HtmlTemplate: HtmlTemplate as EcoComponent<HtmlTemplateProps, C>,
+		Layouts,
 		Layout,
+		layoutEntries,
 		props,
 		Page: Page as EcoComponent<PageProps, C>,
 		metadata,

--- a/packages/core/src/route-renderer/orchestration/route-render-orchestrator.prepare-render-options.test.ts
+++ b/packages/core/src/route-renderer/orchestration/route-render-orchestrator.prepare-render-options.test.ts
@@ -18,6 +18,7 @@ import type {
 } from '../../services/assets/asset-processing-service/index.ts';
 import type { GroupedScriptBundle } from '../../services/assets/asset-processing-service/assets.types.ts';
 import { OwnershipValidationService } from './ownership-validation.service.ts';
+import { resolvePageLayoutComponents } from './layout-shell-props.service.ts';
 import { type RouteRenderOrchestratorAdapter, RouteRenderOrchestrator } from './route-render-orchestrator.ts';
 
 declare module '../../types/public-types.ts' {
@@ -61,13 +62,19 @@ function createFlowAdapter<C>(input: {
 		resolveRouteRenderInputs: async (routeOptions) => {
 			const pageModule = await input.resolvePageModule(routeOptions.file);
 			const HtmlTemplate = await input.getHtmlTemplate();
-			const Layout = pageModule.Page.config?.layout;
+			const Layouts = resolvePageLayoutComponents(
+				pageModule.Page.config?.layouts,
+				pageModule.Page.config?.layout,
+			);
+			const Layout = Layouts[Layouts.length - 1];
 			const { props, metadata } = await input.resolvePageData(pageModule, routeOptions);
 
 			return {
 				Page: pageModule.Page,
 				HtmlTemplate,
+				Layouts,
 				Layout,
+				layoutEntries: pageModule.Page.config?.layoutEntries,
 				props,
 				metadata,
 				integrationSpecificProps: pageModule.integrationSpecificProps,
@@ -1383,5 +1390,67 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 		).rejects.toThrow(
 			'[ecopages] Foreign child "missing-foreign-component" references unknown integration owner "missing-renderer".',
 		);
+	});
+
+	it('resolves dependencies for every layout tier in the stack', async () => {
+		const assetProcessingService = {
+			processDependencies: vi.fn(async () => []),
+		} as unknown as AssetProcessingService;
+		const appConfig = {
+			cache: { defaultStrategy: 'static' },
+			integrations: [
+				{
+					name: 'react',
+					initializeRenderer: vi.fn(),
+					getResolvedIntegrationDependencies: () => [],
+				},
+			],
+		} as unknown as EcoPagesAppConfig;
+		const flow = new RouteRenderOrchestrator(appConfig, assetProcessingService);
+		const HtmlTemplate = (() => '<html></html>') as EcoComponent<HtmlTemplateProps>;
+		const OuterLayout = (() => '<outer></outer>') as EcoComponent;
+		OuterLayout.config = {
+			integration: 'react',
+			__eco: { id: 'outer', file: '/app/layouts/outer.tsx', integration: 'react' },
+		};
+		const InnerLayout = (() => '<inner></inner>') as EcoComponent;
+		InnerLayout.config = {
+			integration: 'react',
+			__eco: { id: 'inner', file: '/app/layouts/inner.tsx', integration: 'react' },
+		};
+		const Page = (() => '<main>Page</main>') as unknown as EcoPageComponent<any>;
+		Page.config = {
+			layouts: [OuterLayout, InnerLayout],
+			layout: InnerLayout,
+			layoutEntries: [{ component: OuterLayout }, { component: InnerLayout }],
+		};
+		const resolvedComponents: EcoComponent[] = [];
+
+		await flow.prepareRenderOptions(
+			{ file: '/app/pages/index.tsx', params: {}, query: {} } as unknown as RouteRendererOptions,
+			{
+				...createFlowAdapter({
+					resolvePageModule: async () => ({
+						Page,
+						integrationSpecificProps: {},
+					}),
+					getHtmlTemplate: async () => HtmlTemplate,
+					resolvePageData: async () => ({
+						props: {},
+						metadata: { title: 'Page', description: 'Page description' },
+					}),
+					resolveDependencies: async (components) => {
+						resolvedComponents.push(...(components as EcoComponent[]));
+						return [];
+					},
+					collectPageBrowserGraphContribution: async () => ({ assets: [] }),
+					shouldRenderPageComponent: () => false,
+					renderPageComponent: vi.fn(),
+				}),
+				name: 'react',
+			},
+		);
+
+		expect(resolvedComponents).toEqual([HtmlTemplate, OuterLayout, InnerLayout, Page]);
 	});
 });

--- a/packages/core/src/route-renderer/orchestration/route-render-orchestrator.test.ts
+++ b/packages/core/src/route-renderer/orchestration/route-render-orchestrator.test.ts
@@ -12,6 +12,7 @@ import {
 	type RouteRenderOrchestratorAdapter,
 	RouteRenderOrchestrator,
 } from './route-render-orchestrator.ts';
+import { resolvePageLayoutComponents } from './layout-shell-props.service.ts';
 
 function createFlowAdapter(input: {
 	resolvePageModule: (file: string) => Promise<{
@@ -50,13 +51,19 @@ function createFlowAdapter(input: {
 		resolveRouteRenderInputs: async (routeOptions) => {
 			const pageModule = await input.resolvePageModule(routeOptions.file);
 			const HtmlTemplate = await input.getHtmlTemplate();
-			const Layout = pageModule.Page.config?.layout;
+			const Layouts = resolvePageLayoutComponents(
+				pageModule.Page.config?.layouts,
+				pageModule.Page.config?.layout,
+			);
+			const Layout = Layouts[Layouts.length - 1];
 			const { props, metadata } = await input.resolvePageData(pageModule, routeOptions);
 
 			return {
 				Page: pageModule.Page,
 				HtmlTemplate,
+				Layouts,
 				Layout,
+				layoutEntries: pageModule.Page.config?.layoutEntries,
 				props,
 				metadata,
 				integrationSpecificProps: pageModule.integrationSpecificProps,

--- a/packages/core/src/route-renderer/orchestration/route-render-orchestrator.ts
+++ b/packages/core/src/route-renderer/orchestration/route-render-orchestrator.ts
@@ -12,6 +12,7 @@ import type {
 	RouteRendererBody,
 	RouteRendererOptions,
 	RouteRenderResult,
+	EcoPageLayoutEntry,
 } from '../../types/public-types.ts';
 import type { AssetProcessingService, ProcessedAsset } from '../../services/assets/asset-processing-service/index.ts';
 import type { HtmlDocumentContribution } from '../../services/html/html-transformer.service.ts';
@@ -29,7 +30,9 @@ import { buildPreparedRenderOptions } from './route-prepared-options.builder.ts'
 export type RouteRenderOrchestratorResolvedInputs = {
 	Page: EcoPageFile['default'] | EcoPageComponent<any>;
 	HtmlTemplate: EcoComponent<HtmlTemplateProps>;
+	Layouts: EcoComponent[];
 	Layout?: EcoComponent;
+	layoutEntries?: EcoPageLayoutEntry[];
 	props: Record<string, unknown>;
 	metadata: PageMetadataProps;
 	integrationSpecificProps: Record<string, unknown>;
@@ -151,18 +154,18 @@ export class RouteRenderOrchestrator {
 		adapter: RouteRenderOrchestratorAdapter<C>,
 	): Promise<IntegrationRendererRenderOptions<C>> {
 		const resolvedInputs = await adapter.resolveRouteRenderInputs(routeOptions);
-		const { Page, HtmlTemplate, Layout } = resolvedInputs;
+		const { Page, HtmlTemplate, Layouts, Layout } = resolvedInputs;
 		const validationErrors = this.ownershipValidationService.validate({
 			currentIntegrationName: adapter.name,
 			roots: [
 				{ component: HtmlTemplate as EcoComponent, source: 'html-template' },
-				...(Layout ? [{ component: Layout as EcoComponent, source: 'layout' as const }] : []),
+				...Layouts.map((layout) => ({ component: layout as EcoComponent, source: 'layout' as const })),
 				{ component: Page as EcoComponent, source: 'page' },
 			],
 		});
 		throwIfOwnershipInvalid(validationErrors);
 
-		const componentsToResolve = Layout ? [HtmlTemplate, Layout, Page] : [HtmlTemplate, Page];
+		const componentsToResolve = [HtmlTemplate, ...Layouts, Page];
 		const [{ resolvedDependencies }, pageBrowserGraph, componentRender] = await Promise.all([
 			adapter.resolveRouteDependencies({
 				components: componentsToResolve,

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -482,6 +482,15 @@ export type EcoComponentConfig = {
 	 * MyPage.config = { layout: Layout };
 	 * ```
 	 */
+	/** Normalized outer→inner layout stack from `eco.page({ layout: [...] })`. */
+	layouts?: EcoDeclaredComponent[];
+	/** Layout entries retained for per-tier prop factories. */
+	layoutEntries?: EcoPageLayoutEntry[];
+	/**
+	 * Innermost layout alias for legacy call sites.
+	 *
+	 * @deprecated Prefer `layouts` or `layoutEntries`.
+	 */
 	layout?: EcoPageLayoutComponent<any>;
 	dependencies?: EcoComponentDependencies;
 	/**
@@ -621,6 +630,33 @@ export interface HtmlTemplateProps<T = EcoPagesElement> extends PageHeadProps<T>
 	headContent?: T;
 	pageProps: Record<string, unknown>;
 }
+
+/**
+ * Request-scoped context available to layout prop factories on `eco.page`.
+ */
+export type LayoutPropsContext = {
+	params?: Record<string, string>;
+	query?: Record<string, string>;
+	locals?: RequestLocals;
+};
+
+/**
+ * One layout tier in a page layout stack (outer→inner).
+ */
+export type EcoPageLayoutEntry<E = EcoPagesElement> = {
+	component: EcoDeclaredComponent<any, E>;
+	props?: (context: LayoutPropsContext) => Record<string, unknown>;
+};
+
+/**
+ * Layout declaration accepted by `eco.page()`.
+ *
+ * @remarks
+ * Array order is outer→inner, matching Next.js App Router segment nesting.
+ */
+export type EcoPageLayoutSpec<E = EcoPagesElement> = EcoDeclaredComponent<any, E> | EcoPageLayoutEntry<E>;
+
+export type EcoPageLayouts<E = EcoPagesElement> = EcoPageLayoutSpec<E> | EcoPageLayoutSpec<E>[];
 
 /**
  * Layout components accepted by pages.
@@ -865,7 +901,9 @@ export type IntegrationRendererRenderOptions<C = EcoPagesElement> = RouteRendere
 	metadata: PageMetadataProps;
 	HtmlTemplate: EcoHtmlComponent<C>;
 	Page: EcoComponent<PageProps, C>;
+	Layouts?: EcoDeclaredComponent[];
 	Layout?: EcoPageLayoutComponent<any>;
+	layoutEntries?: EcoPageLayoutEntry[];
 	dependencies?: EcoComponentDependencies;
 	resolvedDependencies: ProcessedAsset[];
 	pagePackage?: PagePackageResult;


### PR DESCRIPTION
## Summary
- Add `EcoPageLayouts` / `EcoPageLayoutEntry` types and normalize outer→inner layout stacks at `eco.page()` factory time
- Thread `Layouts[]` and `layoutEntries` through route preparation, ownership validation, dependency resolution, and component graph collection
- Add `layout-shell-props.service` for per-tier layout prop factories; keep `config.layout` as innermost legacy alias

## Depends on
- #165 (declared components)

## Test plan
- [x] `page-layout-normalization.test.ts`
- [x] `layout-shell-props.service.test.ts`
- [x] `eco.test.ts` nested layout normalization
- [x] `route-render-orchestrator.prepare-render-options.test.ts` multi-layout dependency resolution
- [x] Core typecheck + full vitest suite (pre-commit)