### PR TITLE
feat(core): add composeChildren hook for document shell composition

### DIFF
--- a/packages/core/src/route-renderer/orchestration/document-shell-render.service.test.ts
+++ b/packages/core/src/route-renderer/orchestration/document-shell-render.service.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { EcoComponent } from '../../types/public-types.ts';
+import { eco } from '../../eco/eco.ts';
+import {
+	composeDocumentShell,
+	composeSequentialLayoutChildren,
+	type DocumentShellComposeChildrenContext,
+} from './document-shell-render.service.ts';
+
+function stubComponent(id: string): EcoComponent {
+	const component = (() => '') as EcoComponent;
+	component.config = { __eco: { id, file: `/app/${id}.tsx`, integration: 'test' } };
+	return component;
+}
+
+describe('document-shell-render.service', () => {
+	it('should compose page, layout, and document shells with shared renderer cache', async () => {
+		const rendererCaches: Array<Map<string, unknown> | undefined> = [];
+		const renderComponentWithForeignChildren = vi.fn(
+			async (input: {
+				component: EcoComponent;
+				children?: unknown;
+				integrationContext?: { rendererCache?: Map<string, unknown> };
+			}) => {
+				rendererCaches.push(input.integrationContext?.rendererCache);
+				const id = input.component.config?.__eco?.id ?? 'unknown';
+				return {
+					html: input.children ? `<${id}>${String(input.children)}</${id}>` : `<${id} />`,
+					assets: [],
+					canAttachAttributes: true,
+					rootTag: id,
+					integrationName: 'test',
+				};
+			},
+		);
+
+		const Page = eco.page({
+			__eco: { id: 'page', file: '/app/pages/index.kita.tsx', integration: 'kitajs' },
+			render: () => '<page />',
+		});
+		const Layout = eco.layout({
+			__eco: { id: 'layout', file: '/app/layouts/root.kita.tsx', integration: 'kitajs' },
+			render: ({ children }) => `<layout>${children}</layout>`,
+		});
+		const HtmlTemplate = eco.html({
+			__eco: { id: 'html', file: '/app/html.kita.tsx', integration: 'kitajs' },
+			render: ({ children }) => `<html>${children}</html>`,
+		});
+
+		const { documentHtml } = await composeDocumentShell(
+			{
+				renderComponentWithForeignChildren,
+				appendProcessedDependencies: () => [],
+			},
+			{
+				primaryComponent: Page,
+				primaryProps: { title: 'Hello' },
+				layout: { component: Layout, props: { section: 'docs' } },
+				htmlTemplate: HtmlTemplate,
+				documentProps: { metadata: { title: 'Hello', description: 'Hello' }, pageProps: {} },
+			},
+		);
+
+		expect(documentHtml).toBe('<html><layout><page /></layout></html>');
+		expect(renderComponentWithForeignChildren).toHaveBeenCalledTimes(3);
+		expect(rendererCaches.every((cache) => cache === rendererCaches[0])).toBe(true);
+	});
+
+	it('should nest multiple layouts outer to inner by default', async () => {
+		const renderComponentWithForeignChildren = vi.fn(
+			async (input: { component: EcoComponent; children?: unknown }) => {
+				const id = input.component.config?.__eco?.id ?? 'node';
+				return {
+					html: `<${id}>${input.children ?? ''}</${id}>`,
+					assets: [],
+					canAttachAttributes: true,
+					rootTag: 'div',
+					integrationName: 'test',
+				};
+			},
+		);
+		const Outer = stubComponent('outer');
+		const Inner = stubComponent('inner');
+		const Page = stubComponent('page');
+		const HtmlTemplate = stubComponent('html');
+
+		const { documentHtml } = await composeDocumentShell(
+			{
+				renderComponentWithForeignChildren,
+				appendProcessedDependencies: () => [],
+			},
+			{
+				primaryComponent: Page,
+				primaryProps: {},
+				layouts: [{ component: Outer }, { component: Inner }],
+				htmlTemplate: HtmlTemplate,
+				documentProps: {},
+			},
+		);
+
+		expect(documentHtml).toBe('<html><outer><inner><page></page></inner></outer></html>');
+	});
+
+	it('should delegate child composition to composeChildren hook', async () => {
+		const composeChildren = vi.fn(async (context: DocumentShellComposeChildrenContext) => {
+			expect(context.layouts).toHaveLength(1);
+			expect(context.primaryRender.html).toBe('<page />');
+			return {
+				children: '<hooked />',
+				layoutRenders: [],
+			};
+		});
+		const renderComponentWithForeignChildren = vi.fn(async () => ({
+			html: '<page />',
+			assets: [],
+			canAttachAttributes: true,
+			rootTag: 'main',
+			integrationName: 'test',
+		}));
+
+		await composeDocumentShell(
+			{
+				renderComponentWithForeignChildren,
+				appendProcessedDependencies: () => [],
+			},
+			{
+				primaryComponent: stubComponent('page'),
+				primaryProps: {},
+				layout: { component: stubComponent('layout') },
+				composeChildren,
+				htmlTemplate: stubComponent('html'),
+				documentProps: {},
+			},
+		);
+
+		expect(composeChildren).toHaveBeenCalledOnce();
+		expect(renderComponentWithForeignChildren).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				children: '<hooked />',
+			}),
+		);
+	});
+
+	it('should export composeSequentialLayoutChildren as the default hook implementation', async () => {
+		const rendererCache = new Map<string, unknown>();
+		const primaryRender = {
+			html: '<page />',
+			assets: [],
+			canAttachAttributes: true,
+			rootTag: 'main',
+			integrationName: 'test',
+		};
+		const layoutRender = {
+			html: '<layout><page /></layout>',
+			assets: [],
+			canAttachAttributes: true,
+			rootTag: 'div',
+			integrationName: 'test',
+		};
+		const renderComponentWithForeignChildren = vi.fn(async () => layoutRender);
+		const Layout = stubComponent('layout');
+
+		const result = await composeSequentialLayoutChildren({
+			primaryRender,
+			layouts: [{ component: Layout, props: { section: 'docs' } }],
+			rendererCache,
+			renderComponentWithForeignChildren,
+		});
+
+		expect(result).toEqual({
+			children: '<layout><page /></layout>',
+			layoutRenders: [layoutRender],
+		});
+		expect(renderComponentWithForeignChildren).toHaveBeenCalledWith({
+			component: Layout,
+			props: { section: 'docs' },
+			children: '<page />',
+			integrationContext: { rendererCache },
+		});
+	});
+});

--- a/packages/core/src/route-renderer/orchestration/document-shell-render.service.ts
+++ b/packages/core/src/route-renderer/orchestration/document-shell-render.service.ts
@@ -12,10 +12,28 @@ export type DocumentShellLayoutInput = {
 	props?: Record<string, unknown>;
 };
 
+export type DocumentShellComposeChildrenContext = {
+	primaryRender: ComponentRenderResult;
+	layouts: DocumentShellLayoutInput[];
+	rendererCache: BaseIntegrationContext['rendererCache'];
+	renderComponentWithForeignChildren: DocumentShellRenderDependencies['renderComponentWithForeignChildren'];
+};
+
+export type DocumentShellComposeChildrenResult = {
+	children: unknown;
+	layoutRenders: ComponentRenderResult[];
+};
+
+export type DocumentShellComposeChildrenHook = (
+	context: DocumentShellComposeChildrenContext,
+) => Promise<DocumentShellComposeChildrenResult>;
+
 export type DocumentShellComposeInput = {
 	primaryComponent: EcoComponent;
 	primaryProps: Record<string, unknown>;
 	layout?: DocumentShellLayoutInput;
+	layouts?: DocumentShellLayoutInput[];
+	composeChildren?: DocumentShellComposeChildrenHook;
 	htmlTemplate: EcoComponent;
 	documentProps: Record<string, unknown>;
 };
@@ -26,6 +44,8 @@ export type DocumentShellPageRenderInput = {
 		props: Record<string, unknown>;
 	};
 	layout?: DocumentShellLayoutInput;
+	layouts?: DocumentShellLayoutInput[];
+	composeChildren?: DocumentShellComposeChildrenHook;
 	htmlTemplate: EcoComponent;
 	metadata: PageMetadataProps;
 	pageProps: Record<string, unknown>;
@@ -43,6 +63,42 @@ export type DocumentShellAttributeStamping = {
 	applyAttributesToHtmlElement(html: string, attributes: Record<string, string>): string;
 };
 
+function resolveDocumentShellLayouts(
+	input: Pick<DocumentShellComposeInput, 'layout' | 'layouts'>,
+): DocumentShellLayoutInput[] {
+	if (input.layouts && input.layouts.length > 0) {
+		return input.layouts;
+	}
+
+	return input.layout ? [input.layout] : [];
+}
+
+/**
+ * Default sequential string-child composition for document shell layers.
+ */
+export async function composeSequentialLayoutChildren(
+	context: DocumentShellComposeChildrenContext,
+): Promise<DocumentShellComposeChildrenResult> {
+	let children: unknown = context.primaryRender.html;
+	const layoutRenders: ComponentRenderResult[] = [];
+
+	for (const layout of [...context.layouts].reverse()) {
+		const layoutRender = await context.renderComponentWithForeignChildren({
+			component: layout.component,
+			props: layout.props ?? {},
+			children,
+			integrationContext: { rendererCache: context.rendererCache },
+		});
+		layoutRenders.push(layoutRender);
+		children = layoutRender.html;
+	}
+
+	return {
+		children,
+		layoutRenders,
+	};
+}
+
 /**
  * Composes page or view content through optional layout and document shells.
  *
@@ -54,27 +110,31 @@ export async function composeDocumentShell(
 	input: DocumentShellComposeInput,
 ): Promise<{ documentHtml: string }> {
 	const rendererCache = new Map<string, unknown>() as BaseIntegrationContext['rendererCache'];
+	const layouts = resolveDocumentShellLayouts(input);
 	const primaryRender = await dependencies.renderComponentWithForeignChildren({
 		component: input.primaryComponent,
 		props: input.primaryProps,
 		integrationContext: { rendererCache },
 	});
-	const layoutRender = input.layout
-		? await dependencies.renderComponentWithForeignChildren({
-				component: input.layout.component,
-				props: input.layout.props ?? {},
-				children: primaryRender.html,
-				integrationContext: { rendererCache },
-			})
-		: undefined;
+	const composeChildren = input.composeChildren ?? composeSequentialLayoutChildren;
+	const { children, layoutRenders } = await composeChildren({
+		primaryRender,
+		layouts,
+		rendererCache,
+		renderComponentWithForeignChildren: dependencies.renderComponentWithForeignChildren,
+	});
 	const documentRender = await dependencies.renderComponentWithForeignChildren({
 		component: input.htmlTemplate,
 		props: input.documentProps,
-		children: layoutRender?.html ?? primaryRender.html,
+		children,
 		integrationContext: { rendererCache },
 	});
 
-	dependencies.appendProcessedDependencies(primaryRender.assets, layoutRender?.assets, documentRender.assets);
+	dependencies.appendProcessedDependencies(
+		primaryRender.assets,
+		...layoutRenders.map((layoutRender) => layoutRender.assets),
+		documentRender.assets,
+	);
 
 	return {
 		documentHtml: documentRender.html,
@@ -118,6 +178,8 @@ export async function renderPageDocumentShell(
 		primaryComponent: input.page.component,
 		primaryProps: input.page.props,
 		layout: input.layout,
+		layouts: input.layouts,
+		composeChildren: input.composeChildren,
 		htmlTemplate: input.htmlTemplate,
 		documentProps: {
 			metadata: input.metadata,

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -29,7 +29,8 @@
 		"./utils/dynamic": "./src/utils/dynamic.ts",
 		"./utils/client-only": "./src/utils/client-only.ts",
 		"./runtime/use-sync-external-store-with-selector": "./src/runtime/use-sync-external-store-with-selector.ts",
-		"./router-adapter": "./src/router-adapter.ts"
+		"./router-adapter": "./src/router-adapter.ts",
+		"./layout-compose": "./src/layout-compose.ts"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/integrations/react/src/layout-compose.test.ts
+++ b/packages/integrations/react/src/layout-compose.test.ts
@@ -1,0 +1,73 @@
+import { createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+import { eco, type EcoPageComponent } from '@ecopages/core';
+import { composeLayoutPageTree, normalizePageLayoutComponents, resolveLayoutEntryProps } from './layout-compose.ts';
+
+function asLayoutPage(Page: EcoPageComponent<Record<string, unknown>>) {
+	return Page as Parameters<typeof composeLayoutPageTree>[0];
+}
+
+describe('layout-compose', () => {
+	it('should wrap a page with a single legacy layout', () => {
+		const Layout = ({ children }: { children?: string }) => createElement('main', null, children);
+		const Page = eco.page({
+			layout: Layout,
+			render: () => 'page',
+		});
+
+		const tree = composeLayoutPageTree(asLayoutPage(Page), { title: 'Hello' });
+		expect(tree.type).toBe(Layout);
+		expect((tree.props as { children?: { type: typeof Page; props?: { title: string } } }).children?.type).toBe(
+			Page,
+		);
+		expect((tree.props as { children?: { props?: { title: string } } }).children?.props).toEqual({
+			title: 'Hello',
+		});
+	});
+
+	it('should nest multiple layouts outer to inner', () => {
+		const Outer = ({ children }: { children?: string }) => createElement('outer', null, children);
+		const Inner = ({ children }: { children?: string }) => createElement('inner', null, children);
+		const Page = eco.page({
+			layout: [Outer, Inner],
+			render: () => 'page',
+		});
+
+		const tree = composeLayoutPageTree(asLayoutPage(Page), {});
+		expect(tree.type).toBe(Outer);
+		expect((tree.props as { children?: { type: typeof Inner } }).children?.type).toBe(Inner);
+		expect(
+			(tree.props as { children?: { props?: { children?: { type: typeof Page } } } }).children?.props?.children
+				?.type,
+		).toBe(Page);
+	});
+
+	it('should merge layout entry prop factories', () => {
+		const Layout = ({ section }: { section?: string; children?: string }) =>
+			createElement('section', null, section);
+		const Page = eco.page({
+			layout: [{ component: Layout, props: ({ params }) => ({ section: params?.slug }) }],
+			render: () => 'page',
+		});
+
+		expect(
+			resolveLayoutEntryProps(Page.config!.layoutEntries![0]!, {
+				params: { slug: 'docs' },
+			}),
+		).toEqual({ section: 'docs' });
+
+		const tree = composeLayoutPageTree(asLayoutPage(Page), { params: { slug: 'docs' } });
+		expect(tree.props).toEqual({ section: 'docs', children: expect.any(Object) });
+	});
+
+	it('should normalize layout arrays from page config', () => {
+		const Outer = () => null;
+		const Inner = () => null;
+		const Page = eco.page({
+			layout: [Outer, Inner],
+			render: () => null,
+		});
+
+		expect(normalizePageLayoutComponents(Page.config?.layouts, Page.config?.layout)).toEqual([Outer, Inner]);
+	});
+});

--- a/packages/integrations/react/src/layout-compose.ts
+++ b/packages/integrations/react/src/layout-compose.ts
@@ -1,0 +1,96 @@
+import { createElement, type ComponentType, type ReactElement } from 'react';
+import type {
+	EcoDeclaredComponent,
+	EcoPageComponent,
+	EcoPageLayoutComponent,
+	EcoPageLayoutEntry,
+	LayoutPropsContext,
+	RequestLocals,
+} from '@ecopages/core';
+
+export type LayoutComposeContext = LayoutPropsContext;
+
+function asReactComponent(
+	component: EcoDeclaredComponent | EcoPageLayoutComponent,
+): ComponentType<Record<string, unknown>> {
+	return component as ComponentType<Record<string, unknown>>;
+}
+
+function resolveLayoutContext(pageProps: Record<string, unknown>): LayoutComposeContext {
+	return {
+		params: pageProps.params as Record<string, string> | undefined,
+		query: pageProps.query as Record<string, string> | undefined,
+		locals: pageProps.locals as RequestLocals | undefined,
+	};
+}
+
+/**
+ * Resolves props for one layout entry, merging shell locals with an optional factory.
+ */
+export function resolveLayoutEntryProps(
+	entry: EcoPageLayoutEntry,
+	context: LayoutComposeContext,
+): Record<string, unknown> {
+	const shellProps = context.locals ? { locals: context.locals } : {};
+	if (!entry.props) {
+		return shellProps;
+	}
+
+	return {
+		...shellProps,
+		...entry.props(context),
+	};
+}
+
+/**
+ * Builds the client or SSR React tree for a page and its outer→inner layout stack.
+ */
+export function composeLayoutPageTree(
+	Page: EcoPageComponent<Record<string, unknown>>,
+	pageProps: Record<string, unknown>,
+	options?: { context?: LayoutComposeContext },
+): ReactElement {
+	const context = options?.context ?? resolveLayoutContext(pageProps);
+	const pageElement = createElement(Page, pageProps);
+	const layoutEntries = Page.config?.layoutEntries;
+
+	if (layoutEntries && layoutEntries.length > 0) {
+		return [...layoutEntries].reverse().reduce<ReactElement>((children, entry) => {
+			const layoutProps = resolveLayoutEntryProps(entry, context);
+			return createElement(asReactComponent(entry.component), layoutProps, children);
+		}, pageElement);
+	}
+
+	const layouts = Page.config?.layouts;
+	if (layouts && layouts.length > 0) {
+		const layoutProps = context.locals ? { locals: context.locals } : {};
+		return [...layouts]
+			.reverse()
+			.reduce<ReactElement>(
+				(children, Layout) => createElement(asReactComponent(Layout), layoutProps, children),
+				pageElement,
+			);
+	}
+
+	const Layout = Page.config?.layout;
+	if (!Layout) {
+		return pageElement;
+	}
+
+	const layoutProps = context.locals ? { locals: context.locals } : null;
+	return createElement(asReactComponent(Layout), layoutProps ?? {}, pageElement);
+}
+
+/**
+ * Normalizes page config layout metadata to an outer→inner component list.
+ */
+export function normalizePageLayoutComponents(
+	layouts?: EcoDeclaredComponent[],
+	legacyLayout?: EcoDeclaredComponent,
+): EcoDeclaredComponent[] {
+	if (layouts && layouts.length > 0) {
+		return layouts;
+	}
+
+	return legacyLayout ? [legacyLayout] : [];
+}

--- a/packages/integrations/react/src/utils/hydration-scripts.test.ts
+++ b/packages/integrations/react/src/utils/hydration-scripts.test.ts
@@ -28,8 +28,8 @@ describe('createHydrationScript', () => {
 		expect(script).toContain('const props = getPageData();');
 		expect(script).toContain('window.__ECO_PAGES__.page = {');
 		expect(script).toContain('root.render(createTree(Page, props));');
-		expect(script).toContain('const layoutProps = props?.locals ? { locals: props.locals } : null;');
-		expect(script).toContain('return Layout ? createElement(Layout, layoutProps, pageElement) : pageElement;');
+		expect(script).toContain('import { composeLayoutPageTree } from "@ecopages/react/layout-compose";');
+		expect(script).toContain('const createTree = (Component, props) => composeLayoutPageTree(Component, props);');
 	});
 
 	test('development output passes serialized locals to layout hydration for non-router MDX pages', () => {
@@ -39,8 +39,8 @@ describe('createHydrationScript', () => {
 			isMdx: true,
 		});
 
-		expect(script).toContain('const layoutProps = props?.locals ? { locals: props.locals } : null;');
-		expect(script).toContain('return Layout ? createElement(Layout, layoutProps, pageElement) : pageElement;');
+		expect(script).toContain('import { composeLayoutPageTree } from "@ecopages/react/layout-compose";');
+		expect(script).toContain('const createTree = (Component, props) => composeLayoutPageTree(Component, props);');
 	});
 
 	test('production output passes serialized locals to layout hydration for non-router pages', () => {
@@ -60,8 +60,8 @@ describe('createHydrationScript', () => {
 		expect(script).toContain(
 			'if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}',
 		);
-		expect(script).toContain('const lp=p?.locals?{locals:p.locals}:null;');
-		expect(script).toContain('return L?ce(L,lp,pe):pe');
+		expect(script).toContain('import{composeLayoutPageTree as clp}from"@ecopages/react/layout-compose"');
+		expect(script).toContain('const ct=(C,p)=>clp(C,p)');
 	});
 
 	test('router development output exposes page-root cleanup before reuse', () => {
@@ -108,8 +108,8 @@ describe('createHydrationScript', () => {
 			isMdx: true,
 		});
 
-		expect(script).toContain('const lp=p?.locals?{locals:p.locals}:null;');
-		expect(script).toContain('return L?ce(L,lp,pe):pe');
+		expect(script).toContain('import{composeLayoutPageTree as clp}from"@ecopages/react/layout-compose"');
+		expect(script).toContain('const ct=(C,p)=>clp(C,p)');
 	});
 
 	test('router production output reuses an active router-owned root during rerun bootstraps', () => {

--- a/packages/integrations/react/src/utils/hydration-scripts.ts
+++ b/packages/integrations/react/src/utils/hydration-scripts.ts
@@ -6,6 +6,12 @@
 
 import type { ReactRouterAdapter } from '../router-adapter.ts';
 
+const DEFAULT_LAYOUT_COMPOSE_IMPORT_PATH = '@ecopages/react/layout-compose';
+
+function resolveLayoutComposeImportPath(options: HydrationScriptOptions): string {
+	return options.layoutComposeImportPath ?? DEFAULT_LAYOUT_COMPOSE_IMPORT_PATH;
+}
+
 /**
  * Options for generating a hydration script.
  */
@@ -28,6 +34,8 @@ export type HydrationScriptOptions = {
 	isMdx: boolean;
 	/** Optional router adapter for SPA navigation */
 	router?: ReactRouterAdapter;
+	/** Import path for shared layout composition helper */
+	layoutComposeImportPath?: string;
 };
 
 export type IslandHydrationScriptOptions = {
@@ -305,10 +313,12 @@ if (document.readyState === "loading") {
 function createDevScriptWithoutRouter(options: HydrationScriptOptions): string {
 	const { importPath, isMdx, reactImportPath, reactDomClientImportPath, scriptId } = options;
 	const pageModuleUrlExpression = options.pageModuleUrlExpression ?? 'import.meta.url';
+	const layoutComposeImportPath = resolveLayoutComposeImportPath(options);
 
 	return `
 import { hydrateRoot } from "${reactDomClientImportPath}";
 import { createElement } from "${reactImportPath}";
+import { composeLayoutPageTree } from "${layoutComposeImportPath}";
 ${getImportStatement(importPath, isMdx)}
 const pageModuleUrl = ${pageModuleUrlExpression};
 export default Page;
@@ -339,12 +349,7 @@ window.__ECO_PAGES__.page = {
   props
 };
 
-const createTree = (Component, props) => {
-  const Layout = Component.config?.layout;
-  const pageElement = createElement(Component, props);
-  const layoutProps = props?.locals ? { locals: props.locals } : null;
-  return Layout ? createElement(Layout, layoutProps, pageElement) : pageElement;
-};
+const createTree = (Component, props) => composeLayoutPageTree(Component, props);
 
 const mount = () => {
   const props = getPageData();
@@ -420,12 +425,13 @@ function createProdScriptWithRouter(options: HydrationScriptOptions): string {
 function createProdScriptWithoutRouter(options: HydrationScriptOptions): string {
 	const { importPath, isMdx, reactImportPath, reactDomClientImportPath, scriptId } = options;
 	const pageModuleUrlExpression = options.pageModuleUrlExpression ?? 'import.meta.url';
+	const layoutComposeImportPath = resolveLayoutComposeImportPath(options);
 
 	if (isMdx) {
-		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import*as M from"${importPath}";const P=M.default;if(M.config)P.config=M.config;const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const gd=()=>{const e=document.getElementById("__ECO_PAGE_DATA__");if(e?.textContent){try{return JSON.parse(e.textContent)}catch{}}return{}};const ct=(C,p)=>{const L=C.config?.layout;const pe=ce(C,p);const lp=p?.locals?{locals:p.locals}:null;return L?ce(L,lp,pe):pe};const m=()=>{const pr=gd();window.__ECO_PAGES__.page={module:u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import*as M from"${importPath}";const P=M.default;if(M.config)P.config=M.config;const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const gd=()=>{const e=document.getElementById("__ECO_PAGE_DATA__");if(e?.textContent){try{return JSON.parse(e.textContent)}catch{}}return{}};const ct=(C,p)=>clp(C,p);const m=()=>{const pr=gd();window.__ECO_PAGES__.page={module:u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 	}
 
-	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import P from"${importPath}";const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const gd=()=>{const e=document.getElementById("__ECO_PAGE_DATA__");if(e?.textContent){try{return JSON.parse(e.textContent)}catch{}}return{}};const ct=(C,p)=>{const L=C.config?.layout;const pe=ce(C,p);const lp=p?.locals?{locals:p.locals}:null;return L?ce(L,lp,pe):pe};const m=()=>{const pr=gd();window.__ECO_PAGES__.page={module:u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import P from"${importPath}";const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const gd=()=>{const e=document.getElementById("__ECO_PAGE_DATA__");if(e?.textContent){try{return JSON.parse(e.textContent)}catch{}}return{}};const ct=(C,p)=>clp(C,p);const m=()=>{const pr=gd();window.__ECO_PAGES__.page={module:u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 }
 
 /**

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -44,6 +44,7 @@ import {
 	type EcoReloadRequest,
 } from '@ecopages/core/router/navigation-coordinator';
 import { clearLayoutCache, resolvePersistedLayout, type LayoutComponent } from './layout-cache.ts';
+import { composeLayoutPageTree } from '@ecopages/react/layout-compose';
 import {
 	getAnchorFromNavigationEvent,
 	recoverPendingNavigationHref,
@@ -129,15 +130,16 @@ export const PageContent: FC = () => {
 	}
 
 	const { Component: Page, props, refreshPersistedLayout } = pageContext;
+	const pageWithConfig = Page as ComponentType & {
+		config?: { layout?: LayoutComponent; layouts?: LayoutComponent[] };
+	};
+	const layouts = pageWithConfig.config?.layouts;
 	const Layout = getLayoutFromPage(Page);
-	const pageElement = createElement(Page, props);
-	const layoutProps = props?.locals ? { locals: props.locals } : null;
+	const shouldUsePersistedSingleLayout = persistLayouts && Layout && (!layouts || layouts.length <= 1);
 
-	if (!Layout) {
-		return pageElement;
-	}
-
-	if (persistLayouts) {
+	if (shouldUsePersistedSingleLayout) {
+		const pageElement = createElement(Page, props);
+		const layoutProps = props?.locals ? { locals: props.locals } : null;
 		const { layout: CachedLayout, key: layoutKey } = resolvePersistedLayout(
 			Layout,
 			Boolean(refreshPersistedLayout),
@@ -146,7 +148,7 @@ export const PageContent: FC = () => {
 		return createElement(CachedLayout, { key: layoutKey, ...(layoutProps ?? {}) }, pageElement);
 	}
 
-	return createElement(Layout, layoutProps, pageElement);
+	return composeLayoutPageTree(Page as Parameters<typeof composeLayoutPageTree>[0], props);
 };
 
 function createDeferred<T>() {


### PR DESCRIPTION
## Summary
- Extend `composeDocumentShell` with optional `composeChildren`, `layouts[]`, and exported `composeSequentialLayoutChildren` default (outer→inner via inner-first wrapping)
- Add `@ecopages/react/layout-compose` with `composeLayoutPageTree` for nested client trees
- Wire `PageContent` and non-router hydration scripts to the shared layout-compose helper

## Depends on
- #166 (nested layout API)

## Test plan
- [x] `document-shell-render.service.test.ts`
- [x] `layout-compose.test.ts`
- [x] `hydration-scripts.test.ts`
- [x] Full vitest + typecheck (pre-commit)