### PR TITLE
feat(react): unified SSR layout-page composition via composeChildren

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,6 +77,10 @@
 			"types": "./src/route-renderer/orchestration/foreign-subtree-execution.service.ts",
 			"default": "./src/route-renderer/orchestration/foreign-subtree-execution.service.ts"
 		},
+		"./route-renderer/orchestration/document-shell-render.service": {
+			"types": "./src/route-renderer/orchestration/document-shell-render.service.ts",
+			"default": "./src/route-renderer/orchestration/document-shell-render.service.ts"
+		},
 		"./router/navigation-coordinator": {
 			"types": "./src/router/client/navigation-coordinator.ts",
 			"default": "./src/router/client/navigation-coordinator.ts"

--- a/packages/core/src/route-renderer/orchestration/document-shell-render.service.test.ts
+++ b/packages/core/src/route-renderer/orchestration/document-shell-render.service.test.ts
@@ -104,10 +104,17 @@ describe('document-shell-render.service', () => {
 	it('should delegate child composition to composeChildren hook', async () => {
 		const composeChildren = vi.fn(async (context: DocumentShellComposeChildrenContext) => {
 			expect(context.layouts).toHaveLength(1);
-			expect(context.primaryRender.html).toBe('<page />');
+			expect(context.primaryComponent).toBeDefined();
 			return {
 				children: '<hooked />',
 				layoutRenders: [],
+				primaryRender: {
+					html: '<hooked />',
+					assets: [],
+					canAttachAttributes: true,
+					rootTag: 'main',
+					integrationName: 'test',
+				},
 			};
 		});
 		const renderComponentWithForeignChildren = vi.fn(async () => ({
@@ -134,7 +141,8 @@ describe('document-shell-render.service', () => {
 		);
 
 		expect(composeChildren).toHaveBeenCalledOnce();
-		expect(renderComponentWithForeignChildren).toHaveBeenLastCalledWith(
+		expect(renderComponentWithForeignChildren).toHaveBeenCalledOnce();
+		expect(renderComponentWithForeignChildren).toHaveBeenCalledWith(
 			expect.objectContaining({
 				children: '<hooked />',
 			}),
@@ -162,6 +170,8 @@ describe('document-shell-render.service', () => {
 
 		const result = await composeSequentialLayoutChildren({
 			primaryRender,
+			primaryComponent: stubComponent('page'),
+			primaryProps: {},
 			layouts: [{ component: Layout, props: { section: 'docs' } }],
 			rendererCache,
 			renderComponentWithForeignChildren,

--- a/packages/core/src/route-renderer/orchestration/document-shell-render.service.ts
+++ b/packages/core/src/route-renderer/orchestration/document-shell-render.service.ts
@@ -22,11 +22,25 @@ export type DocumentShellComposeChildrenContext = {
 };
 
 export type DocumentShellComposeChildrenResult = {
+	/** Serialized or element children passed to the HTML template shell. */
 	children: unknown;
 	layoutRenders: ComponentRenderResult[];
+	/**
+	 * Primary/page render assets when the hook performs unified composition.
+	 *
+	 * @remarks
+	 * Omit only when the default sequential string path runs (core renders primary first).
+	 */
 	primaryRender?: ComponentRenderResult;
 };
 
+/**
+ * Optional hook that replaces default sequential string layout wrapping.
+ *
+ * @remarks
+ * When provided, core skips the initial primary render and expects the hook to return
+ * `children` for the HTML template. Supply `primaryRender` so dependency assets still merge.
+ */
 export type DocumentShellComposeChildrenHook = (
 	context: DocumentShellComposeChildrenContext,
 ) => Promise<DocumentShellComposeChildrenResult>;
@@ -74,6 +88,10 @@ function resolveDocumentShellLayouts(
 	}
 
 	return input.layout ? [input.layout] : [];
+}
+
+function resolveComponentIntegrationName(component: EcoComponent): string {
+	return component.config?.integration ?? component.config?.__eco?.integration ?? 'ecopages';
 }
 
 /**
@@ -140,7 +158,7 @@ export async function composeDocumentShell(
 			assets: [],
 			canAttachAttributes: true,
 			rootTag: 'main',
-			integrationName: 'unknown',
+			integrationName: resolveComponentIntegrationName(input.primaryComponent),
 		};
 	} else {
 		primaryRender = await dependencies.renderComponentWithForeignChildren({

--- a/packages/core/src/route-renderer/orchestration/document-shell-render.service.ts
+++ b/packages/core/src/route-renderer/orchestration/document-shell-render.service.ts
@@ -13,7 +13,9 @@ export type DocumentShellLayoutInput = {
 };
 
 export type DocumentShellComposeChildrenContext = {
-	primaryRender: ComponentRenderResult;
+	primaryComponent: EcoComponent;
+	primaryProps: Record<string, unknown>;
+	primaryRender?: ComponentRenderResult;
 	layouts: DocumentShellLayoutInput[];
 	rendererCache: BaseIntegrationContext['rendererCache'];
 	renderComponentWithForeignChildren: DocumentShellRenderDependencies['renderComponentWithForeignChildren'];
@@ -22,6 +24,7 @@ export type DocumentShellComposeChildrenContext = {
 export type DocumentShellComposeChildrenResult = {
 	children: unknown;
 	layoutRenders: ComponentRenderResult[];
+	primaryRender?: ComponentRenderResult;
 };
 
 export type DocumentShellComposeChildrenHook = (
@@ -79,6 +82,10 @@ function resolveDocumentShellLayouts(
 export async function composeSequentialLayoutChildren(
 	context: DocumentShellComposeChildrenContext,
 ): Promise<DocumentShellComposeChildrenResult> {
+	if (!context.primaryRender) {
+		throw new Error('[ecopages] composeSequentialLayoutChildren requires primaryRender.');
+	}
+
 	let children: unknown = context.primaryRender.html;
 	const layoutRenders: ComponentRenderResult[] = [];
 
@@ -111,18 +118,47 @@ export async function composeDocumentShell(
 ): Promise<{ documentHtml: string }> {
 	const rendererCache = new Map<string, unknown>() as BaseIntegrationContext['rendererCache'];
 	const layouts = resolveDocumentShellLayouts(input);
-	const primaryRender = await dependencies.renderComponentWithForeignChildren({
-		component: input.primaryComponent,
-		props: input.primaryProps,
-		integrationContext: { rendererCache },
-	});
 	const composeChildren = input.composeChildren ?? composeSequentialLayoutChildren;
-	const { children, layoutRenders } = await composeChildren({
-		primaryRender,
-		layouts,
-		rendererCache,
-		renderComponentWithForeignChildren: dependencies.renderComponentWithForeignChildren,
-	});
+	const usesCustomComposeChildren = input.composeChildren !== undefined;
+
+	let primaryRender: ComponentRenderResult;
+	let children: unknown;
+	let layoutRenders: ComponentRenderResult[];
+
+	if (usesCustomComposeChildren) {
+		const composed = await composeChildren({
+			primaryComponent: input.primaryComponent,
+			primaryProps: input.primaryProps,
+			layouts,
+			rendererCache,
+			renderComponentWithForeignChildren: dependencies.renderComponentWithForeignChildren,
+		});
+		children = composed.children;
+		layoutRenders = composed.layoutRenders;
+		primaryRender = composed.primaryRender ?? {
+			html: typeof composed.children === 'string' ? composed.children : '',
+			assets: [],
+			canAttachAttributes: true,
+			rootTag: 'main',
+			integrationName: 'unknown',
+		};
+	} else {
+		primaryRender = await dependencies.renderComponentWithForeignChildren({
+			component: input.primaryComponent,
+			props: input.primaryProps,
+			integrationContext: { rendererCache },
+		});
+		const composed = await composeChildren({
+			primaryComponent: input.primaryComponent,
+			primaryProps: input.primaryProps,
+			primaryRender,
+			layouts,
+			rendererCache,
+			renderComponentWithForeignChildren: dependencies.renderComponentWithForeignChildren,
+		});
+		children = composed.children;
+		layoutRenders = composed.layoutRenders;
+	}
 	const documentRender = await dependencies.renderComponentWithForeignChildren({
 		component: input.htmlTemplate,
 		props: input.documentProps,

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -656,6 +656,13 @@ export type EcoPageLayoutEntry<E = EcoPagesElement> = {
  */
 export type EcoPageLayoutSpec<E = EcoPagesElement> = EcoDeclaredComponent<any, E> | EcoPageLayoutEntry<E>;
 
+/**
+ * One or more layout tiers for `eco.page({ layout })`.
+ *
+ * @remarks
+ * When an array, order is **outer → inner** (outermost layout wraps all inner tiers).
+ * Normalized at factory time to `config.layouts` and `config.layoutEntries`.
+ */
 export type EcoPageLayouts<E = EcoPagesElement> = EcoPageLayoutSpec<E> | EcoPageLayoutSpec<E>[];
 
 /**

--- a/packages/integrations/react/src/layout-compose.test.ts
+++ b/packages/integrations/react/src/layout-compose.test.ts
@@ -1,10 +1,19 @@
 import { createElement } from 'react';
 import { describe, expect, it } from 'vitest';
-import { eco, type EcoPageComponent } from '@ecopages/core';
-import { composeLayoutPageTree, normalizePageLayoutComponents, resolveLayoutEntryProps } from './layout-compose.ts';
+import { eco } from '@ecopages/core';
+import {
+	composeLayoutPageTree,
+	composeLayoutPageTreeFromShell,
+	normalizePageLayoutComponents,
+	resolveLayoutEntryProps,
+	type ComposablePage,
+} from './layout-compose.ts';
 
-function asLayoutPage(Page: EcoPageComponent<Record<string, unknown>>) {
-	return Page as Parameters<typeof composeLayoutPageTree>[0];
+function pageComponent<P extends Record<string, unknown>>(Page: ComposablePage<P>): ComposablePage<P> {
+	if (typeof Page !== 'function') {
+		throw new TypeError('Expected function page component.');
+	}
+	return Page;
 }
 
 describe('layout-compose', () => {
@@ -15,7 +24,7 @@ describe('layout-compose', () => {
 			render: () => 'page',
 		});
 
-		const tree = composeLayoutPageTree(asLayoutPage(Page), { title: 'Hello' });
+		const tree = composeLayoutPageTree(pageComponent(Page), { title: 'Hello' } as Record<string, unknown>);
 		expect(tree.type).toBe(Layout);
 		expect((tree.props as { children?: { type: typeof Page; props?: { title: string } } }).children?.type).toBe(
 			Page,
@@ -33,7 +42,7 @@ describe('layout-compose', () => {
 			render: () => 'page',
 		});
 
-		const tree = composeLayoutPageTree(asLayoutPage(Page), {});
+		const tree = composeLayoutPageTree(pageComponent(Page), {});
 		expect(tree.type).toBe(Outer);
 		expect((tree.props as { children?: { type: typeof Inner } }).children?.type).toBe(Inner);
 		expect(
@@ -56,7 +65,7 @@ describe('layout-compose', () => {
 			}),
 		).toEqual({ section: 'docs' });
 
-		const tree = composeLayoutPageTree(asLayoutPage(Page), { params: { slug: 'docs' } });
+		const tree = composeLayoutPageTree(pageComponent(Page), { params: { slug: 'docs' } });
 		expect(tree.props).toEqual({ section: 'docs', children: expect.any(Object) });
 	});
 
@@ -69,5 +78,13 @@ describe('layout-compose', () => {
 		});
 
 		expect(normalizePageLayoutComponents(Page.config?.layouts, Page.config?.layout)).toEqual([Outer, Inner]);
+	});
+
+	it('should compose explicit shell layouts outer to inner', () => {
+		const Outer = ({ children }: { children?: string }) => createElement('outer', null, children);
+		const Page = eco.page({ render: () => 'page' });
+
+		const tree = composeLayoutPageTreeFromShell(pageComponent(Page), {}, [{ component: Outer }]);
+		expect(tree.type).toBe(Outer);
 	});
 });

--- a/packages/integrations/react/src/layout-compose.ts
+++ b/packages/integrations/react/src/layout-compose.ts
@@ -1,27 +1,51 @@
-import { createElement, type ComponentType, type ReactElement } from 'react';
+import { createElement, type FunctionComponent, type ReactElement } from 'react';
 import type {
+	EcoComponent,
 	EcoDeclaredComponent,
-	EcoPageComponent,
-	EcoPageLayoutComponent,
 	EcoPageLayoutEntry,
 	LayoutPropsContext,
 	RequestLocals,
 } from '@ecopages/core';
+import type { EcoComponentConfig } from '@ecopages/core';
 
 export type LayoutComposeContext = LayoutPropsContext;
 
-function asReactComponent(
-	component: EcoDeclaredComponent | EcoPageLayoutComponent,
-): ComponentType<Record<string, unknown>> {
-	return component as ComponentType<Record<string, unknown>>;
+export type LayoutShellEntry = {
+	component: EcoComponent;
+	props?: Record<string, unknown>;
+};
+
+export type ComposablePage<P extends Record<string, unknown> = Record<string, unknown>> = FunctionComponent<P> & {
+	config?: Pick<EcoComponentConfig, 'layout' | 'layouts' | 'layoutEntries'>;
+};
+
+/**
+ * @remarks
+ * Eco components are wider than React's `createElement` input; runtime checks narrow callables.
+ */
+function toReactComponent(component: EcoComponent): FunctionComponent<Record<string, unknown>> {
+	if (typeof component !== 'function') {
+		throw new TypeError('[ecopages] Expected a function component for layout composition.');
+	}
+
+	return component as FunctionComponent<Record<string, unknown>>;
 }
 
-function resolveLayoutContext(pageProps: Record<string, unknown>): LayoutComposeContext {
-	return {
-		params: pageProps.params as Record<string, string> | undefined,
-		query: pageProps.query as Record<string, string> | undefined,
-		locals: pageProps.locals as RequestLocals | undefined,
-	};
+/**
+ * Reads request-scoped layout context from serialized page props.
+ */
+export function resolveLayoutContext(pageProps: Record<string, unknown>): LayoutComposeContext {
+	const context: LayoutComposeContext = {};
+	if (pageProps.params !== undefined) {
+		context.params = pageProps.params as Record<string, string>;
+	}
+	if (pageProps.query !== undefined) {
+		context.query = pageProps.query as Record<string, string>;
+	}
+	if (pageProps.locals !== undefined) {
+		context.locals = pageProps.locals as RequestLocals;
+	}
+	return context;
 }
 
 /**
@@ -43,11 +67,23 @@ export function resolveLayoutEntryProps(
 }
 
 /**
+ * @remarks
+ * Eco page components are wider than React layout composition input; runtime checks narrow callables.
+ */
+export function assertComposablePage(Page: unknown): ComposablePage {
+	if (typeof Page !== 'function') {
+		throw new TypeError('[ecopages] Expected a function page component for layout composition.');
+	}
+
+	return Page as ComposablePage;
+}
+
+/**
  * Builds the client or SSR React tree for a page and its outer→inner layout stack.
  */
-export function composeLayoutPageTree(
-	Page: EcoPageComponent<Record<string, unknown>>,
-	pageProps: Record<string, unknown>,
+export function composeLayoutPageTree<P extends Record<string, unknown>>(
+	Page: ComposablePage<P>,
+	pageProps: P,
 	options?: { context?: LayoutComposeContext },
 ): ReactElement {
 	const context = options?.context ?? resolveLayoutContext(pageProps);
@@ -57,7 +93,7 @@ export function composeLayoutPageTree(
 	if (layoutEntries && layoutEntries.length > 0) {
 		return [...layoutEntries].reverse().reduce<ReactElement>((children, entry) => {
 			const layoutProps = resolveLayoutEntryProps(entry, context);
-			return createElement(asReactComponent(entry.component), layoutProps, children);
+			return createElement(toReactComponent(entry.component), layoutProps, children);
 		}, pageElement);
 	}
 
@@ -67,7 +103,7 @@ export function composeLayoutPageTree(
 		return [...layouts]
 			.reverse()
 			.reduce<ReactElement>(
-				(children, Layout) => createElement(asReactComponent(Layout), layoutProps, children),
+				(children, Layout) => createElement(toReactComponent(Layout), layoutProps, children),
 				pageElement,
 			);
 	}
@@ -77,8 +113,28 @@ export function composeLayoutPageTree(
 		return pageElement;
 	}
 
-	const layoutProps = context.locals ? { locals: context.locals } : null;
-	return createElement(asReactComponent(Layout), layoutProps ?? {}, pageElement);
+	const layoutProps = context.locals ? { locals: context.locals } : {};
+	return createElement(toReactComponent(Layout), layoutProps, pageElement);
+}
+
+/**
+ * Builds a layout tree from explicit shell entries when page config is not normalized yet.
+ */
+export function composeLayoutPageTreeFromShell<P extends Record<string, unknown>>(
+	Page: ComposablePage<P>,
+	pageProps: P,
+	shellLayouts: LayoutShellEntry[],
+	options?: { context?: LayoutComposeContext },
+): ReactElement {
+	if (shellLayouts.length === 0) {
+		return composeLayoutPageTree(Page, pageProps, options);
+	}
+
+	const pageElement = createElement(Page, pageProps);
+
+	return [...shellLayouts].reverse().reduce<ReactElement>((children, entry) => {
+		return createElement(toReactComponent(entry.component), entry.props ?? {}, children);
+	}, pageElement);
 }
 
 /**

--- a/packages/integrations/react/src/react-renderer.ts
+++ b/packages/integrations/react/src/react-renderer.ts
@@ -11,6 +11,7 @@ import type {
 	EcoPageFile,
 	EcoPagesElement,
 	IntegrationRendererRenderOptions,
+	PageMetadataProps,
 	RouteRendererBody,
 } from '@ecopages/core';
 import {
@@ -25,7 +26,8 @@ import type { AssetDefinition, ProcessedAsset } from '@ecopages/core/services/as
 import { ECO_DOCUMENT_OWNER_ATTRIBUTE } from '@ecopages/core/router/navigation-coordinator';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import type { FunctionComponent, ReactNode } from 'react';
+import type { FunctionComponent, ReactElement, ReactNode } from 'react';
+import { isValidElement } from 'react';
 import type { CompileOptions } from '@mdx-js/mdx';
 import { REACT_PLUGIN_NAME } from './react.constants.ts';
 import type { ReactRendererConfig } from './react.types.ts';
@@ -37,6 +39,18 @@ import { ReactMdxConfigDependencyService } from './services/react-mdx-config-dep
 import { ReactPageModuleService } from './services/react-page-module.service.ts';
 import { ReactPagePayloadService } from './services/react-page-payload.service.ts';
 import { getReactIslandComponentKey, ReactHydrationAssetService } from './services/react-hydration-asset.service.ts';
+import {
+	renderPageDocumentShell,
+	type DocumentShellComposeChildrenContext,
+	type DocumentShellComposeChildrenResult,
+	type DocumentShellLayoutInput,
+} from '@ecopages/core/route-renderer/orchestration/document-shell-render.service';
+import {
+	composeLayoutPageTree,
+	composeLayoutPageTreeFromShell,
+	assertComposablePage,
+	type ComposablePage,
+} from './layout-compose.ts';
 
 export type { ReactRendererConfig } from './react.types.ts';
 
@@ -327,6 +341,14 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 			);
 		}
 
+		if (isValidElement(input.children)) {
+			return this.normalizeUnresolvedMarkerArtifactHtml(
+				reactDomServer.renderToString(
+					react.createElement(this.asReactComponent(input.component), input.props, input.children),
+				),
+			);
+		}
+
 		const resolvedChildHtml = typeof input.children === 'string' ? input.children : String(input.children ?? '');
 		const rawChildrenToken = `__ECO_RAW_HTML_CHILD_${context.componentInstanceId ?? 'component'}__`;
 		if (runtimeContext) {
@@ -339,8 +361,22 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 		return this.normalizeUnresolvedMarkerArtifactHtml(html.split(rawChildrenToken).join(resolvedChildHtml));
 	}
 
+	private toReactNode(children: unknown): ReactNode {
+		if (
+			children === null ||
+			typeof children === 'string' ||
+			typeof children === 'number' ||
+			typeof children === 'boolean' ||
+			isValidElement(children) ||
+			Array.isArray(children)
+		) {
+			return children;
+		}
+
+		throw new TypeError(`[ecopages] ${this.name} renderer expected a React node child.`);
+	}
+
 	/**
-	 * Restores raw child HTML that was temporarily replaced by a token during React SSR.
 	 *
 	 * Queued foreign-subtree resolution may render children through a fragment path before all
 	 * nested integration tokens are resolved. When that happens, React must never see
@@ -380,7 +416,7 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 		const { react, reactDomServer } = this.getReactRuntimeModules();
 
 		let html = this.normalizeUnresolvedMarkerArtifactHtml(
-			reactDomServer.renderToString(react.createElement(react.Fragment, null, children as ReactNode)),
+			reactDomServer.renderToString(react.createElement(react.Fragment, null, this.toReactNode(children))),
 		);
 		html = this.restoreRuntimeChildHtml(html, runtimeContext);
 
@@ -680,6 +716,107 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 				`Failed to generate hydration script: ${error instanceof Error ? error.message : String(error)}`,
 			);
 		}
+	}
+
+	/**
+	 * Composes page and layout tiers as one React element tree for SSR.
+	 */
+	private async composeReactLayoutPageChildren(
+		page: { component: EcoComponent; props: Record<string, unknown> },
+		context: DocumentShellComposeChildrenContext,
+	): Promise<DocumentShellComposeChildrenResult> {
+		const pageComponent = assertComposablePage(page.component);
+		const tree = this.resolveReactLayoutPageTree(pageComponent, page.props, context.layouts);
+		const { reactDomServer } = this.getReactRuntimeModules();
+		const runtimeInput: ComponentRenderInput = {
+			component: page.component,
+			props: page.props,
+			integrationContext: {
+				rendererCache: context.rendererCache as ReactForeignSubtreeResolutionContext['rendererCache'],
+			},
+		};
+		const runtimeContext = this.getQueuedForeignSubtreeResolutionContext(runtimeInput) as
+			| ReactForeignSubtreeResolutionContext
+			| undefined;
+		let html = this.normalizeUnresolvedMarkerArtifactHtml(reactDomServer.renderToString(tree));
+		const resolved = await this.resolveReactQueuedForeignSubtreeHtml(html, runtimeContext);
+		const primaryRender: ComponentRenderResult = {
+			html: resolved.html,
+			canAttachAttributes: hasSingleRootElement(resolved.html),
+			rootTag: this.getRootTagName(resolved.html),
+			integrationName: this.name,
+			assets: resolved.assets.length > 0 ? resolved.assets : undefined,
+		};
+
+		return {
+			children: resolved.html,
+			layoutRenders: [],
+			primaryRender,
+		};
+	}
+
+	private resolveReactLayoutPageTree(
+		Page: ComposablePage,
+		pageProps: Record<string, unknown>,
+		shellLayouts: DocumentShellLayoutInput[],
+	): ReactElement {
+		const shellEntries = shellLayouts.map((layout) => ({
+			component: layout.component,
+			props: layout.props,
+		}));
+		const hasNormalizedLayouts =
+			Boolean(Page.config?.layoutEntries?.length) ||
+			Boolean(Page.config?.layouts?.length) ||
+			Boolean(Page.config?.layout);
+
+		if (hasNormalizedLayouts) {
+			return composeLayoutPageTree(Page, pageProps);
+		}
+
+		return composeLayoutPageTreeFromShell(Page, pageProps, shellEntries);
+	}
+
+	private shouldUseUnifiedReactLayoutComposition(
+		page: EcoComponent,
+		shellLayouts: DocumentShellLayoutInput[],
+	): boolean {
+		if (!this.isReactManagedComponent(page)) {
+			return false;
+		}
+
+		return shellLayouts.every((layout) => this.isReactManagedComponent(layout.component));
+	}
+
+	protected override async renderPageWithDocumentShell(input: {
+		page: {
+			component: EcoComponent;
+			props: Record<string, unknown>;
+		};
+		layout?: DocumentShellLayoutInput;
+		layouts?: DocumentShellLayoutInput[];
+		htmlTemplate: EcoComponent;
+		metadata: PageMetadataProps;
+		pageProps: Record<string, unknown>;
+		documentProps?: Record<string, unknown>;
+		transformDocumentHtml?: (html: string) => string;
+	}): Promise<string> {
+		const shellLayouts = input.layouts ?? (input.layout ? [input.layout] : []);
+		const composeChildren = this.shouldUseUnifiedReactLayoutComposition(input.page.component, shellLayouts)
+			? (context: DocumentShellComposeChildrenContext) => this.composeReactLayoutPageChildren(input.page, context)
+			: undefined;
+
+		return renderPageDocumentShell(
+			{
+				renderComponentWithForeignChildren: (renderInput) =>
+					this.renderComponentWithForeignChildren(renderInput),
+				appendProcessedDependencies: (...assetGroups) => this.appendProcessedDependencies(...assetGroups),
+			},
+			{
+				...input,
+				composeChildren,
+			},
+			this.DOC_TYPE,
+		);
 	}
 
 	/**

--- a/packages/integrations/react/src/test/react-renderer.test.tsx
+++ b/packages/integrations/react/src/test/react-renderer.test.tsx
@@ -191,6 +191,24 @@ describe('ReactRenderer', () => {
 			expect(result.html).toContain('<h2>React Component</h2>');
 		});
 
+		it('should compose React element children without escaping nested markup', async () => {
+			const testRenderer = createRenderer();
+			const Wrapper = (({ children }: { children?: React.ReactNode }) => (
+				<section>{children}</section>
+			)) as unknown as EcoComponent<{
+				children?: React.ReactNode;
+			}>;
+			const Inner = (() => <p>Nested</p>) as unknown as EcoComponent<object>;
+
+			const result = await testRenderer.renderComponent({
+				component: Wrapper,
+				props: {},
+				children: React.createElement(Inner, {}),
+			});
+
+			expect(result.html).toContain('<section><p>Nested</p></section>');
+		});
+
 		it('should report non-attachable boundaries for fragment output', async () => {
 			const testRenderer = createRenderer();
 			const Component = (() => (

--- a/packages/integrations/react/src/test/react-ssr-unified.test.tsx
+++ b/packages/integrations/react/src/test/react-ssr-unified.test.tsx
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { EcoPagesAppConfig } from '@ecopages/core';
+import type { HtmlTemplateProps, IntegrationRendererRenderOptions } from '@ecopages/core';
+import type { AssetProcessingService } from '@ecopages/core/services/asset-processing-service';
+import React, { createContext, useContext, type ReactNode } from 'react';
+import { ReactRenderer } from '../react-renderer.ts';
+
+const DataContext = createContext('missing');
+
+class TestReactRenderer extends ReactRenderer {
+	protected override async getHtmlTemplate() {
+		return (({ children }: HtmlTemplateProps) => (
+			<html>
+				<body>{children}</body>
+			</html>
+		)) as IntegrationRendererRenderOptions<ReactNode>['HtmlTemplate'];
+	}
+
+	protected override async resolveDependencies() {
+		return [];
+	}
+}
+
+describe('ReactRenderer unified SSR layout composition', () => {
+	const appConfig = {
+		defaultMetadata: {
+			title: 'Test',
+			description: 'Test',
+		},
+		absolutePaths: {
+			htmlTemplatePath: '/tmp/template.tsx',
+			pagesDir: '/tmp/pages',
+		},
+		srcDir: '/tmp/src',
+	} as unknown as EcoPagesAppConfig;
+
+	const assetService = {
+		processDependencies: vi.fn(() => Promise.resolve([])),
+		getHmrManager: vi.fn(() => undefined),
+	} as unknown as AssetProcessingService;
+
+	it('should render layout context providers as ancestors of the page on SSR', async () => {
+		const renderer = new TestReactRenderer({
+			appConfig,
+			assetProcessingService: assetService,
+			runtimeOrigin: 'http://localhost:3000',
+		});
+
+		const Layout = ({ children }: { children?: ReactNode }) => (
+			<DataContext.Provider value="from-layout">{children}</DataContext.Provider>
+		);
+		const Page = () => {
+			const value = useContext(DataContext);
+			return <p>{value}</p>;
+		};
+
+		const body = await renderer.render({
+			file: '/tmp/pages/test.tsx',
+			params: {},
+			query: {},
+			props: {},
+			locals: undefined,
+			pageLocals: undefined,
+			metadata: appConfig.defaultMetadata,
+			Page: Page as IntegrationRendererRenderOptions<ReactNode>['Page'],
+			Layout: Layout as IntegrationRendererRenderOptions<ReactNode>['Layout'],
+			HtmlTemplate: (({ children }: HtmlTemplateProps) =>
+				children) as IntegrationRendererRenderOptions<ReactNode>['HtmlTemplate'],
+			resolvedDependencies: [],
+			pageProps: {},
+		});
+
+		expect(String(body)).toContain('<p>from-layout</p>');
+		expect(String(body)).not.toContain('missing');
+	});
+
+	it('should nest multiple React layouts outer to inner during SSR', async () => {
+		const renderer = new TestReactRenderer({
+			appConfig,
+			assetProcessingService: assetService,
+			runtimeOrigin: 'http://localhost:3000',
+		});
+
+		const Outer = ({ children }: { children?: ReactNode }) => <div data-layout="outer">{children}</div>;
+		const Inner = ({ children }: { children?: ReactNode }) => <div data-layout="inner">{children}</div>;
+		const Page = () => <div data-layout="page">content</div>;
+		Page.config = {
+			layouts: [Outer, Inner],
+			layout: Inner,
+			layoutEntries: [{ component: Outer }, { component: Inner }],
+		};
+
+		const body = await renderer.render({
+			file: '/tmp/pages/nested.tsx',
+			params: {},
+			query: {},
+			props: {},
+			locals: undefined,
+			pageLocals: undefined,
+			metadata: appConfig.defaultMetadata,
+			Page: Page as IntegrationRendererRenderOptions<ReactNode>['Page'],
+			HtmlTemplate: (({ children }: HtmlTemplateProps) =>
+				children) as IntegrationRendererRenderOptions<ReactNode>['HtmlTemplate'],
+			resolvedDependencies: [],
+			pageProps: {},
+		});
+
+		const html = String(body);
+		expect(html.indexOf('data-layout="outer"')).toBeLessThan(html.indexOf('data-layout="inner"'));
+		expect(html.indexOf('data-layout="inner"')).toBeLessThan(html.indexOf('data-layout="page"'));
+	});
+});

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -44,7 +44,7 @@ import {
 	type EcoReloadRequest,
 } from '@ecopages/core/router/navigation-coordinator';
 import { clearLayoutCache, resolvePersistedLayout, type LayoutComponent } from './layout-cache.ts';
-import { composeLayoutPageTree } from '@ecopages/react/layout-compose';
+import { composeLayoutPageTree, assertComposablePage } from '@ecopages/react/layout-compose';
 import {
 	getAnchorFromNavigationEvent,
 	recoverPendingNavigationHref,
@@ -148,7 +148,11 @@ export const PageContent: FC = () => {
 		return createElement(CachedLayout, { key: layoutKey, ...(layoutProps ?? {}) }, pageElement);
 	}
 
-	return composeLayoutPageTree(Page as Parameters<typeof composeLayoutPageTree>[0], props);
+	if (typeof Page !== 'function') {
+		return null;
+	}
+
+	return composeLayoutPageTree(assertComposablePage(Page), props);
 };
 
 function createDeferred<T>() {


### PR DESCRIPTION
## Summary
- Extend document shell `composeChildren` to skip duplicate primary render when a custom hook owns composition
- React route renders compose React-managed page+layout tiers as one element tree (context providers visible on SSR)
- `renderComponentHtml` accepts React element children; non-React layouts keep sequential string shell path

## Depends on
- #167 (composeChildren hook)

## Hygiene note
Cast boundaries are centralized at integration edges (`assertComposablePage`, `toReactComponent`, existing `asReactComponent`) — flagged for final review to tighten further.

## Test plan
- [x] `react-ssr-unified.test.tsx` (context + nested layouts)
- [x] `react-renderer.test.tsx` element children + deferred foreign layout regression
- [x] `react-renderer.locals.test.ts` unchanged behavior for route vs page locals
- [x] Full vitest + typecheck (pre-commit)