### PR TITLE
refactor(react): layout locals parity and shared render shell

### DIFF
--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -30,7 +30,8 @@
 		"./utils/client-only": "./src/utils/client-only.ts",
 		"./runtime/use-sync-external-store-with-selector": "./src/runtime/use-sync-external-store-with-selector.ts",
 		"./router-adapter": "./src/router-adapter.ts",
-		"./layout-compose": "./src/layout-compose.ts"
+		"./layout-compose": "./src/layout-compose.ts",
+		"./serialize-page-data-script": "./src/serialize-page-data-script.ts"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/integrations/react/src/layout-compose.test.ts
+++ b/packages/integrations/react/src/layout-compose.test.ts
@@ -6,6 +6,7 @@ import {
 	composeLayoutPageTreeFromShell,
 	normalizePageLayoutComponents,
 	resolveLayoutEntryProps,
+	resolveLayoutContextFromShell,
 	type ComposablePage,
 } from './layout-compose.ts';
 
@@ -86,5 +87,23 @@ describe('layout-compose', () => {
 
 		const tree = composeLayoutPageTreeFromShell(pageComponent(Page), {}, [{ component: Outer }]);
 		expect(tree.type).toBe(Outer);
+	});
+
+	it('should derive layout locals from shell props instead of pageProps.locals', () => {
+		const Layout = ({ locals, children }: { locals?: { role: string }; children?: string }) =>
+			createElement('section', null, locals?.role, children);
+		const Page = eco.page({
+			layout: Layout,
+			render: () => 'page',
+		});
+		const routeLocals = { role: 'admin' };
+		const pageLocals = { role: 'guarded' };
+
+		const context = resolveLayoutContextFromShell({ locals: pageLocals }, [
+			{ component: Layout, props: { locals: routeLocals } },
+		]);
+		const tree = composeLayoutPageTree(pageComponent(Page), { locals: pageLocals }, { context });
+
+		expect(tree.props).toEqual({ locals: routeLocals, children: expect.any(Object) });
 	});
 });

--- a/packages/integrations/react/src/layout-compose.ts
+++ b/packages/integrations/react/src/layout-compose.ts
@@ -49,6 +49,32 @@ export function resolveLayoutContext(pageProps: Record<string, unknown>): Layout
 }
 
 /**
+ * Builds layout prop factory context from document-shell layout entries.
+ *
+ * @remarks
+ * Route-scoped `locals` come from shell layout props, not `pageProps.locals` (pageLocals).
+ */
+export function resolveLayoutContextFromShell(
+	pageProps: Record<string, unknown>,
+	shellLayouts: LayoutShellEntry[],
+): LayoutComposeContext {
+	const context: LayoutComposeContext = {};
+	if (pageProps.params !== undefined) {
+		context.params = pageProps.params as Record<string, string>;
+	}
+	if (pageProps.query !== undefined) {
+		context.query = pageProps.query as Record<string, string>;
+	}
+	for (const entry of shellLayouts) {
+		if (entry.props !== undefined && Object.prototype.hasOwnProperty.call(entry.props, 'locals')) {
+			context.locals = entry.props.locals as RequestLocals;
+			break;
+		}
+	}
+	return context;
+}
+
+/**
  * Resolves props for one layout entry, merging shell locals with an optional factory.
  */
 export function resolveLayoutEntryProps(
@@ -80,6 +106,10 @@ export function assertComposablePage(Page: unknown): ComposablePage {
 
 /**
  * Builds the client or SSR React tree for a page and its outer→inner layout stack.
+ *
+ * @remarks
+ * Layout prop factories receive `LayoutPropsContext`. For SSR, pass `options.context` with
+ * route-scoped `locals` when they differ from `pageProps.locals`.
  */
 export function composeLayoutPageTree<P extends Record<string, unknown>>(
 	Page: ComposablePage<P>,
@@ -118,7 +148,11 @@ export function composeLayoutPageTree<P extends Record<string, unknown>>(
 }
 
 /**
- * Builds a layout tree from explicit shell entries when page config is not normalized yet.
+ * Builds a layout tree from explicit document-shell layout entries.
+ *
+ * @remarks
+ * Use when the route renderer passes per-tier props (e.g. route `locals` on the layout tier).
+ * Shell `entry.props` are authoritative; page config normalization is not required.
  */
 export function composeLayoutPageTreeFromShell<P extends Record<string, unknown>>(
 	Page: ComposablePage<P>,

--- a/packages/integrations/react/src/react-renderer.ts
+++ b/packages/integrations/react/src/react-renderer.ts
@@ -49,7 +49,9 @@ import {
 	composeLayoutPageTree,
 	composeLayoutPageTreeFromShell,
 	assertComposablePage,
+	resolveLayoutContextFromShell,
 	type ComposablePage,
+	type LayoutComposeContext,
 } from './layout-compose.ts';
 
 export type { ReactRendererConfig } from './react.types.ts';
@@ -726,7 +728,12 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 		context: DocumentShellComposeChildrenContext,
 	): Promise<DocumentShellComposeChildrenResult> {
 		const pageComponent = assertComposablePage(page.component);
-		const tree = this.resolveReactLayoutPageTree(pageComponent, page.props, context.layouts);
+		const shellEntries = context.layouts.map((layout) => ({
+			component: layout.component,
+			props: layout.props,
+		}));
+		const layoutContext = resolveLayoutContextFromShell(page.props, shellEntries);
+		const tree = this.resolveReactLayoutPageTree(pageComponent, page.props, context.layouts, layoutContext);
 		const { reactDomServer } = this.getReactRuntimeModules();
 		const runtimeInput: ComponentRenderInput = {
 			component: page.component,
@@ -759,6 +766,7 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 		Page: ComposablePage,
 		pageProps: Record<string, unknown>,
 		shellLayouts: DocumentShellLayoutInput[],
+		layoutContext: LayoutComposeContext,
 	): ReactElement {
 		const shellEntries = shellLayouts.map((layout) => ({
 			component: layout.component,
@@ -770,7 +778,7 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 			Boolean(Page.config?.layout);
 
 		if (hasNormalizedLayouts) {
-			return composeLayoutPageTree(Page, pageProps);
+			return composeLayoutPageTree(Page, pageProps, { context: layoutContext });
 		}
 
 		return composeLayoutPageTreeFromShell(Page, pageProps, shellEntries);

--- a/packages/integrations/react/src/react-renderer.ts
+++ b/packages/integrations/react/src/react-renderer.ts
@@ -40,6 +40,7 @@ import { ReactPageModuleService } from './services/react-page-module.service.ts'
 import { ReactPagePayloadService } from './services/react-page-payload.service.ts';
 import { getReactIslandComponentKey, ReactHydrationAssetService } from './services/react-hydration-asset.service.ts';
 import {
+	composeDocumentShell,
 	renderPageDocumentShell,
 	type DocumentShellComposeChildrenContext,
 	type DocumentShellComposeChildrenResult,
@@ -792,7 +793,20 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 			return false;
 		}
 
-		return shellLayouts.every((layout) => this.isReactManagedComponent(layout.component));
+		const composablePage = page as ComposablePage;
+		const configLayouts =
+			composablePage.config?.layouts ??
+			composablePage.config?.layoutEntries?.map((entry) => entry.component) ??
+			(composablePage.config?.layout ? [composablePage.config.layout] : []);
+
+		const layoutComponents =
+			shellLayouts.length > 0 ? shellLayouts.map((layout) => layout.component) : configLayouts;
+
+		if (layoutComponents.length === 0) {
+			return false;
+		}
+
+		return layoutComponents.every((component) => this.isReactManagedComponent(component));
 	}
 
 	protected override async renderPageWithDocumentShell(input: {
@@ -901,6 +915,81 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 		return this.getRouterDocumentAttributes();
 	}
 
+	protected override async renderViewWithDocumentShell<P>(input: {
+		view: EcoComponent<P>;
+		props: P;
+		ctx: RenderToResponseContext;
+		layout?: EcoComponent;
+	}): Promise<Response> {
+		const normalizedProps = (input.props ?? {}) as Record<string, unknown>;
+
+		if (input.ctx.partial) {
+			const { react, reactDomServer } = this.getReactRuntimeModules();
+			const ViewComponent = this.asReactComponent(input.view);
+			return this.renderPartialViewResponse({
+				...input,
+				renderInline: async () =>
+					await reactDomServer.renderToReadableStream(react.createElement(ViewComponent, normalizedProps)),
+			});
+		}
+
+		await this.prepareViewDependencies(input.view, input.layout);
+		if (!input.ctx.partial) {
+			await this.appendHydrationAssetsForFile(input.view.config?.__eco?.file);
+		}
+
+		const HtmlTemplate = await this.getHtmlTemplate();
+		const metadata = await this.resolveViewMetadata(input.view, input.props);
+		const serializedPageProps = this.pagePayloadService.buildSerializedPageProps({
+			pageProps: normalizedProps,
+			params: {},
+			query: {},
+			safeLocals: this.pagePayloadService.getSerializableLocals(undefined, this.getComponentRequires(input.view)),
+		});
+		const shellLayouts: DocumentShellLayoutInput[] = input.layout ? [{ component: input.layout, props: {} }] : [];
+		const composeChildren = this.shouldUseUnifiedReactLayoutComposition(input.view as EcoComponent, shellLayouts)
+			? (context: DocumentShellComposeChildrenContext) =>
+					this.composeReactLayoutPageChildren(
+						{ component: input.view as EcoComponent, props: normalizedProps },
+						context,
+					)
+			: undefined;
+
+		const { documentHtml } = await composeDocumentShell(
+			{
+				renderComponentWithForeignChildren: (renderInput) =>
+					this.renderComponentWithForeignChildren(renderInput),
+				appendProcessedDependencies: (...assetGroups) => this.appendProcessedDependencies(...assetGroups),
+			},
+			{
+				primaryComponent: input.view as EcoComponent,
+				primaryProps: normalizedProps,
+				layout: input.layout
+					? {
+							component: input.layout,
+							props: {},
+						}
+					: undefined,
+				layouts: shellLayouts.length > 0 ? shellLayouts : undefined,
+				composeChildren,
+				htmlTemplate: HtmlTemplate as EcoComponent,
+				documentProps: {
+					metadata,
+					pageProps: serializedPageProps,
+				},
+			},
+		);
+
+		const html = await this.finalizeResolvedHtml({
+			html: `${this.DOC_TYPE}${documentHtml}`,
+			partial: false,
+			documentAttributes: this.getRouterDocumentAttributes(),
+			htmlContributions: this.buildNonReactDocumentContributions(HtmlTemplate, serializedPageProps),
+		});
+
+		return this.createHtmlResponse(html, input.ctx);
+	}
+
 	/**
 	 * Renders an arbitrary React view through the application's HTML shell.
 	 *
@@ -915,60 +1004,12 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 		ctx: RenderToResponseContext,
 	): Promise<Response> {
 		try {
-			const { react, reactDomServer } = this.getReactRuntimeModules();
-			const viewConfig = view.config;
-			const Layout = viewConfig?.layout;
-			const ViewComponent = this.asReactComponent(view);
-			const normalizedProps = (props ?? {}) as SerializableProps;
-
-			if (ctx.partial) {
-				return this.renderPartialViewResponse({
-					view,
-					props,
-					ctx,
-					renderInline: async () =>
-						await reactDomServer.renderToReadableStream(
-							react.createElement(ViewComponent, normalizedProps),
-						),
-				});
-			}
-
-			const HtmlTemplate = await this.getHtmlTemplate();
-			const metadata = await this.resolveViewMetadata(view, props);
-
-			await this.prepareViewDependencies(view, Layout);
-			await this.appendHydrationAssetsForFile(viewConfig?.__eco?.file);
-
-			const viewRender = await this.renderComponentWithForeignChildren({
-				component: view,
-				props: normalizedProps,
+			return await this.renderViewWithDocumentShell({
+				view,
+				props,
+				ctx,
+				layout: view.config?.layout,
 			});
-			const layoutRender = Layout
-				? await this.renderComponentWithForeignChildren({
-						component: Layout,
-						props: {},
-						children: viewRender.html,
-					})
-				: undefined;
-			const documentRender = await this.renderComponentWithForeignChildren({
-				component: HtmlTemplate,
-				props: {
-					metadata,
-					pageProps: normalizedProps,
-				},
-				children: layoutRender?.html ?? viewRender.html,
-			});
-
-			this.appendProcessedDependencies(viewRender.assets, layoutRender?.assets, documentRender.assets);
-
-			const transformedHtml = await this.finalizeResolvedHtml({
-				html: `${this.DOC_TYPE}${documentRender.html}`,
-				partial: false,
-				documentAttributes: this.getRouterDocumentAttributes(),
-				htmlContributions: this.buildNonReactDocumentContributions(HtmlTemplate, normalizedProps),
-			});
-
-			return this.createHtmlResponse(transformedHtml, ctx);
 		} catch (error) {
 			throw this.createRenderError('Failed to render view', error);
 		}

--- a/packages/integrations/react/src/serialize-page-data-script.test.ts
+++ b/packages/integrations/react/src/serialize-page-data-script.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { escapePageDataJson, serializePageDataScript } from './serialize-page-data-script.ts';
+
+describe('serialize-page-data-script', () => {
+	it('should escape less-than in serialized page data', () => {
+		expect(escapePageDataJson({ title: '<script>alert(1)</script>' })).toBe(
+			'{"title":"\\u003cscript>alert(1)\\u003c/script>"}',
+		);
+	});
+
+	it('should emit the canonical page data script tag', () => {
+		expect(serializePageDataScript({ count: 1 })).toBe(
+			'<script id="__ECO_PAGE_DATA__" type="application/json">{"count":1}</script>',
+		);
+	});
+});

--- a/packages/integrations/react/src/serialize-page-data-script.ts
+++ b/packages/integrations/react/src/serialize-page-data-script.ts
@@ -1,0 +1,13 @@
+/**
+ * Escapes page data JSON for safe embedding in HTML script bodies.
+ */
+export function escapePageDataJson(pageProps: Record<string, unknown> | undefined): string {
+	return JSON.stringify(pageProps ?? {}).replace(/</g, '\\u003c');
+}
+
+/**
+ * Emits the canonical `__ECO_PAGE_DATA__` bootstrap script tag.
+ */
+export function serializePageDataScript(pageProps: Record<string, unknown> | undefined): string {
+	return `<script id="__ECO_PAGE_DATA__" type="application/json">${escapePageDataJson(pageProps)}</script>`;
+}

--- a/packages/integrations/react/src/services/react-page-payload.service.ts
+++ b/packages/integrations/react/src/services/react-page-payload.service.ts
@@ -1,4 +1,5 @@
 import { LocalsAccessError } from '@ecopages/core/errors';
+import { serializePageDataScript } from '../serialize-page-data-script.ts';
 import type { HtmlTemplateProps, IntegrationRendererRenderOptions, RequestLocals } from '@ecopages/core';
 import type { ReactNode } from 'react';
 
@@ -24,8 +25,7 @@ export class ReactPagePayloadService {
 	 * can read one shared document payload consistently.
 	 */
 	buildRouterPageDataScript(pageProps: HtmlTemplateProps['pageProps'] | undefined): string {
-		const safeJson = JSON.stringify(pageProps || {}).replace(/</g, '\\u003c');
-		return `<script id="__ECO_PAGE_DATA__" type="application/json">${safeJson}</script>`;
+		return serializePageDataScript(pageProps as Record<string, unknown> | undefined);
 	}
 
 	/**

--- a/packages/react-router/src/props-script.ts
+++ b/packages/react-router/src/props-script.ts
@@ -1,4 +1,5 @@
 import { createElement, type FC } from 'react';
+import { escapePageDataJson } from '@ecopages/react/serialize-page-data-script';
 
 export interface EcoPropsScriptProps {
 	/** The page props to serialize for client-side hydration */
@@ -14,6 +15,6 @@ export const EcoPropsScript: FC<EcoPropsScriptProps> = ({ data }) => {
 	return createElement('script', {
 		id: '__ECO_PAGE_DATA__',
 		type: 'application/json',
-		dangerouslySetInnerHTML: { __html: JSON.stringify(data || {}) },
+		dangerouslySetInnerHTML: { __html: escapePageDataJson(data) },
 	});
 };


### PR DESCRIPTION
## Summary
- Derive layout-tier `locals` from document-shell props on unified SSR (`resolveLayoutContextFromShell`) so `pageLocals` no longer leak into layouts.
- Collapse `renderToResponse` onto `renderViewWithDocumentShell` + `composeDocumentShell`, matching the route render path.
- Consolidate `__ECO_PAGE_DATA__` emission into `serializePageDataScript` / `escapePageDataJson` (EcoPropsScript now escapes `<`).

## Test plan
- [x] `layout-compose.test.ts` — shell locals vs pageLocals
- [x] `serialize-page-data-script.test.ts` — escaping + script tag
- [x] `react-renderer.locals.test.ts` — page/layout locals split
- [x] `react-renderer.test.tsx` — `renderToResponse` + hydration assets
- [x] Full vitest suite (1709 tests)