### PR TITLE
docs: nested layouts, ADRs, and SSR hydration parity

### DIFF
--- a/docs/adr/one-composition-primitive.md
+++ b/docs/adr/one-composition-primitive.md
@@ -1,0 +1,18 @@
+# ADR: One composition primitive for document shells
+
+**Status:** Accepted (v0.2 program)  
+**Date:** 2026-07-05
+
+## Context
+
+Route rendering, explicit `renderToResponse()` views, and mixed-integration shells all needed to wrap a primary component with optional layout tiers and an HTML template. Parallel ad-hoc composition paths diverged in asset merging, locals handling, and SSR/client parity.
+
+## Decision
+
+Use `composeDocumentShell` in core as the single string-shell primitive. Integrations may supply an optional `composeChildren` hook to replace sequential string wrapping with a unified tree (React element children) while still delegating foreign subtrees through `renderComponentWithForeignChildren`.
+
+## Consequences
+
+- String-markup integrations keep the default sequential path unchanged.
+- React SSR and hydration share `@ecopages/react/layout-compose` for layout trees.
+- Custom hooks must return `primaryRender` assets when they skip the default primary render.

--- a/docs/adr/segment-layout-inheritance.md
+++ b/docs/adr/segment-layout-inheritance.md
@@ -1,0 +1,23 @@
+# ADR: Segment layout inheritance (draft for v2)
+
+**Status:** Draft  
+**Date:** 2026-07-05
+
+## Context
+
+v0.2 ships nested layouts via explicit `eco.page({ layout: [Outer, Inner] })` arrays normalized at factory time. File-system segment layouts (e.g. `layouts/docs.tsx` wrapping `pages/docs/*`) are a separate inheritance model used by other frameworks.
+
+## Decision (proposed)
+
+Defer file-segment auto-layout inheritance to v2. v0.2 keeps layout assignment explicit on each page factory so ownership validation, dependency collection, and client graph boundaries remain deterministic.
+
+## Open questions
+
+- How segment layouts interact with `persistLayouts` per tier.
+- Whether segment layouts merge with explicit `layout` arrays or override them.
+- Static analysis rules for layout segment boundaries in the client graph plugin.
+
+## Consequences
+
+- Current API documents outer→inner arrays on `eco.page()` only.
+- Routers and SSR paths do not infer layouts from directory structure in v0.2.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to `@ecopages/core` are documented here.
 
 ### Features
 
+- Added nested `layout` arrays on `eco.page()` with normalization to `config.layouts` / `config.layoutEntries`.
+- Added `composeChildren` hook on `composeDocumentShell` for integration-owned unified layout+page composition.
+- Added `EcoDeclaredComponent` validation for `dependencies.components` entries.
 - Added `createApp()` as the recommended runtime entrypoint with Bun-first execution and Node fallback.
 - Added app-owned build and runtime ownership: host module loading, browser-safe `eco` export, `eco.html()`, `eco.layout()`, and published `EcoPagesAppConfig`.
 - Added Page Browser Graph orchestration so integrations declare browser graph contributions and routes share grouped browser assets where appropriate.

--- a/packages/core/src/eco/README.md
+++ b/packages/core/src/eco/README.md
@@ -279,6 +279,17 @@ export default eco.page({
 });
 ```
 
+**Nested layouts (outer → inner):**
+
+```tsx
+export default eco.page({
+	layout: [MarketingShell, DocsShell],
+	render: () => <h1>Hello</h1>,
+});
+```
+
+A single layout remains equivalent to a one-element array. Normalization stores the stack on `config.layouts` and `config.layoutEntries` at factory time.
+
 ### `eco.component()`
 
 Define a reusable component with dependencies.

--- a/packages/integrations/react/CHANGELOG.md
+++ b/packages/integrations/react/CHANGELOG.md
@@ -36,6 +36,9 @@ All notable changes to `@ecopages/react` are documented here.
 
 ### Features
 
+- Added nested layout arrays on `eco.page()` with unified React SSR composition via `composeDocumentShell` `composeChildren`.
+- Added `composeLayoutPageTree` and `serializePageDataScript` exports for shared client/SSR layout and hydration payloads.
+- Added per-tier `persistLayouts` support in `@ecopages/react-router` for nested layout stacks.
 - Added built-in React MDX support and reachability-based hydration analysis for React page bundles.
 - Added the `@ecopages/react/eco-embed` helper for React-owned mixed-integration authoring on top of `eco.embed()`.
 

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -206,3 +206,13 @@ The main regression coverage lives in:
 - [../../react-router/test/hmr-reload.test.browser.ts](../../react-router/test/hmr-reload.test.browser.ts): verifies router-backed layout hydration receives `locals` with `persistLayouts` both enabled and disabled.
 
 If you change the AST transform or hydration flow, update the corresponding tests in the same change.
+
+### Nested layouts and unified SSR
+
+Pages may declare `layout` as a single component or an **outer → inner** array on `eco.page()`. On the server, React-managed layout stacks compose through `composeDocumentShell` + `composeLayoutPageTree` so provider context reaches nested pages during SSR. On the client, `@ecopages/react-router` `PageContent` uses the same `composeLayoutPageTree` helper unless `persistLayouts` is enabled (then each tier is cached independently).
+
+Layout prop factories receive `LayoutPropsContext` (`params`, `query`, `locals`). Route-scoped `locals` are passed to layout tiers via document-shell props during SSR; serialized `pageProps.locals` follow `Page.requires` and are intended for the page component.
+
+- [src/layout-compose.ts](src/layout-compose.ts): shared client/SSR tree builder.
+- [src/test/react-ssr-hydration-parity.test.tsx](src/test/react-ssr-hydration-parity.test.tsx): nested tier order parity between SSR and `composeLayoutPageTree`.
+- [src/test/react-ssr-unified.test.tsx](src/test/react-ssr-unified.test.tsx): provider context through nested SSR layouts.

--- a/packages/integrations/react/src/test/react-ssr-hydration-parity.test.tsx
+++ b/packages/integrations/react/src/test/react-ssr-hydration-parity.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { EcoPagesAppConfig } from '@ecopages/core';
+import type { HtmlTemplateProps, IntegrationRendererRenderOptions } from '@ecopages/core';
+import type { AssetProcessingService } from '@ecopages/core/services/asset-processing-service';
+import React, { type ReactNode } from 'react';
+import { renderToString } from 'react-dom/server';
+import { composeLayoutPageTree, assertComposablePage } from '../layout-compose.ts';
+import { ReactRenderer } from '../react-renderer.ts';
+
+class TestReactRenderer extends ReactRenderer {
+	protected override async getHtmlTemplate() {
+		return (({ children }: HtmlTemplateProps) =>
+			children) as IntegrationRendererRenderOptions<ReactNode>['HtmlTemplate'];
+	}
+
+	protected override async resolveDependencies() {
+		return [];
+	}
+}
+
+function extractLayoutMarkerOrder(html: string): string[] {
+	const matches = [...html.matchAll(/data-layout="([^"]+)"/g)];
+	return matches.map((match) => match[1] ?? '');
+}
+
+describe('React SSR and hydration layout parity', () => {
+	const appConfig = {
+		defaultMetadata: { title: 'Test', description: 'Test' },
+		absolutePaths: { htmlTemplatePath: '/tmp/template.tsx', pagesDir: '/tmp/pages' },
+		srcDir: '/tmp/src',
+	} as unknown as EcoPagesAppConfig;
+
+	const assetService = {
+		processDependencies: vi.fn(() => Promise.resolve([])),
+		getHmrManager: vi.fn(() => undefined),
+	} as unknown as AssetProcessingService;
+
+	it('should match nested layout tier order between SSR and composeLayoutPageTree', async () => {
+		const renderer = new TestReactRenderer({
+			appConfig,
+			assetProcessingService: assetService,
+			runtimeOrigin: 'http://localhost:3000',
+		});
+
+		const Outer = ({ children }: { children?: ReactNode }) => <div data-layout="outer">{children}</div>;
+		const Inner = ({ children }: { children?: ReactNode }) => <div data-layout="inner">{children}</div>;
+		const Page = () => <div data-layout="page">content</div>;
+		Page.config = {
+			layouts: [Outer, Inner],
+			layout: Inner,
+			layoutEntries: [{ component: Outer }, { component: Inner }],
+		};
+
+		const clientTree = composeLayoutPageTree(assertComposablePage(Page), {});
+		const clientHtml = renderToString(clientTree);
+
+		const serverHtml = String(
+			await renderer.render({
+				file: '/tmp/pages/nested.tsx',
+				params: {},
+				query: {},
+				props: {},
+				locals: undefined,
+				pageLocals: undefined,
+				metadata: appConfig.defaultMetadata,
+				Page: Page as IntegrationRendererRenderOptions<ReactNode>['Page'],
+				HtmlTemplate: (({ children }: HtmlTemplateProps) =>
+					children) as IntegrationRendererRenderOptions<ReactNode>['HtmlTemplate'],
+				resolvedDependencies: [],
+				pageProps: {},
+			}),
+		);
+
+		expect(extractLayoutMarkerOrder(serverHtml)).toEqual(['outer', 'inner', 'page']);
+		expect(extractLayoutMarkerOrder(clientHtml)).toEqual(extractLayoutMarkerOrder(serverHtml));
+	});
+});

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -74,6 +74,28 @@ HomePage.config = { layout: BaseLayout };
 export default HomePage;
 ```
 
+#### Nested layouts and shared parents
+
+Pages can declare an outer→inner stack with `layouts: [Outer, Inner]`. Each tier is cached independently by Eco metadata (`config.__eco.file` or `id`). Two routes such as `[AppShell, DocsSection]` and `[AppShell, SettingsSection]` therefore share one mounted **AppShell** instance when `persistLayouts` is enabled (the default with `ecoRouter()`): React state in the shell survives SPA navigation while the inner tier swaps.
+
+A full document reload, HMR, or bootstrap that sets `refreshPersistedLayout` may replace a cached tier when the imported layout function reference changes, even when the cache key is unchanged.
+
+```tsx
+// src/pages/docs/index.tsx
+import { AppShell } from '../../layouts/app-shell';
+import { DocsSection } from '../../layouts/docs-section';
+
+const DocsPage = () => <h1>Docs</h1>;
+DocsPage.config = { layouts: [AppShell, DocsSection] };
+
+// src/pages/settings/index.tsx — reuses the same AppShell cache key
+import { AppShell } from '../../layouts/app-shell';
+import { SettingsSection } from '../../layouts/settings-section';
+
+const SettingsPage = () => <h1>Settings</h1>;
+SettingsPage.config = { layouts: [AppShell, SettingsSection] };
+```
+
 ### Links
 
 Standard relative links are intercepted natively. To bypass the router and force a hard reload, use the `data-eco-reload` attribute.

--- a/packages/react-router/src/layout-cache.test.ts
+++ b/packages/react-router/src/layout-cache.test.ts
@@ -170,4 +170,35 @@ describe('resolvePersistedLayoutStack', () => {
 			expect(getLayoutCache().size).toBe(2);
 		});
 	});
+
+	it('reuses the same cached parent when stacks share an outer layout key', () => {
+		withLayoutCacheWindow(() => {
+			clearLayoutCache();
+			const parentFirstImport = createLayout({
+				displayName: 'AppShell',
+				__eco: { file: '/app/layouts/app-shell.tsx', id: 'app-shell', integration: 'react' },
+			});
+			const parentSecondImport = createLayout({
+				displayName: 'AppShell',
+				renderLabel: 'reimported',
+				__eco: { file: '/app/layouts/app-shell.tsx', id: 'app-shell', integration: 'react' },
+			});
+			const docsInner = createLayout({
+				displayName: 'DocsInner',
+				__eco: { file: '/app/layouts/docs-inner.tsx', id: 'docs-inner', integration: 'react' },
+			});
+			const settingsInner = createLayout({
+				displayName: 'SettingsInner',
+				__eco: { file: '/app/layouts/settings-inner.tsx', id: 'settings-inner', integration: 'react' },
+			});
+
+			const docsStack = resolvePersistedLayoutStack([parentFirstImport, docsInner], false);
+			const settingsStack = resolvePersistedLayoutStack([parentSecondImport, settingsInner], false);
+
+			expect(docsStack[0]?.key).toBe('/app/layouts/app-shell.tsx');
+			expect(settingsStack[0]?.layout).toBe(docsStack[0]?.layout);
+			expect(settingsStack[1]?.layout).not.toBe(docsStack[1]?.layout);
+			expect(getLayoutCache().size).toBe(3);
+		});
+	});
 });

--- a/packages/react-router/src/layout-cache.ts
+++ b/packages/react-router/src/layout-cache.ts
@@ -133,6 +133,11 @@ export function resolvePersistedLayout(
 
 /**
  * Resolves one persisted layout instance per tier in an outer→inner stack.
+ *
+ * @remarks
+ * Each tier is cached independently by {@link getLayoutCacheKey}. Routes that share
+ * an outer layout (e.g. `[A, B]` and `[A, C]`) reuse the same cached `A` instance
+ * while inner tiers mount and unmount with the active page.
  */
 export function resolvePersistedLayoutStack(
 	layouts: LayoutComponent[],

--- a/packages/react-router/test/hmr-reload.test.browser.ts
+++ b/packages/react-router/test/hmr-reload.test.browser.ts
@@ -336,6 +336,40 @@ describe('EcoRouter HMR Integration', () => {
 			expect(container.textContent).toContain('Andee');
 		});
 
+		it('refreshes cached persisted layouts when HMR provides a new layout implementation', async () => {
+			const FirstPage = createPageWithNamedLayout('PersistentPageA', 'Layout v1', 'shared-docs-layout');
+			const UpdatedPage = createPageWithNamedLayout('PersistentPageB', 'Layout v2', 'shared-docs-layout');
+
+			root = createRoot(container);
+			root.render(
+				createElement(EcoRouter, {
+					page: FirstPage,
+					pageProps: {},
+					options: { persistLayouts: true },
+					// oxlint-disable-next-line no-children-prop
+					children: createElement(PageContent),
+				}),
+			);
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			expect(container.textContent).toContain('Layout v1');
+
+			root.render(
+				createElement(EcoRouter, {
+					page: UpdatedPage,
+					pageProps: {},
+					options: { persistLayouts: true },
+					// oxlint-disable-next-line no-children-prop
+					children: createElement(PageContent),
+				}),
+			);
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			expect(container.textContent).toContain('Layout v2');
+			const layout = container.querySelector('[data-testid="PersistentPageB-layout"]') as HTMLDivElement | null;
+			expect(layout?.textContent).toContain('Layout v2');
+		});
+
 		it('does not refresh persisted layouts on the initial bootstrap prop sync', async () => {
 			let layoutMountCount = 0;
 			const Layout = ({ children }: { children: ReactNode }) => {
@@ -369,40 +403,6 @@ describe('EcoRouter HMR Integration', () => {
 			root.render(createElement(EcoRouter, routerProps));
 			await new Promise((resolve) => setTimeout(resolve, 100));
 			expect(layoutMountCount).toBe(1);
-		});
-
-		it('refreshes cached persisted layouts when HMR provides a new layout implementation', async () => {
-			const FirstPage = createPageWithNamedLayout('PersistentPageA', 'Layout v1', 'shared-docs-layout');
-			const UpdatedPage = createPageWithNamedLayout('PersistentPageB', 'Layout v2', 'shared-docs-layout');
-
-			root = createRoot(container);
-			root.render(
-				createElement(EcoRouter, {
-					page: FirstPage,
-					pageProps: {},
-					options: { persistLayouts: true },
-					// oxlint-disable-next-line no-children-prop
-					children: createElement(PageContent),
-				}),
-			);
-
-			await new Promise((resolve) => setTimeout(resolve, 100));
-			expect(container.textContent).toContain('Layout v1');
-
-			root.render(
-				createElement(EcoRouter, {
-					page: UpdatedPage,
-					pageProps: {},
-					options: { persistLayouts: true },
-					// oxlint-disable-next-line no-children-prop
-					children: createElement(PageContent),
-				}),
-			);
-
-			await new Promise((resolve) => setTimeout(resolve, 100));
-			expect(container.textContent).toContain('Layout v2');
-			const layout = container.querySelector('[data-testid="PersistentPageB-layout"]') as HTMLDivElement | null;
-			expect(layout?.textContent).toContain('Layout v2');
 		});
 
 		it('does not reuse a persisted layout when plain layouts share the same display name', async () => {

--- a/packages/react-router/test/nested-layout-persist.test.browser.ts
+++ b/packages/react-router/test/nested-layout-persist.test.browser.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { fireEvent } from '@testing-library/react';
+import { createElement, useEffect, useState, type FC, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const loadPageModuleFromDocumentMock = vi.fn();
+
+vi.mock('../src/navigation.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../src/navigation.ts')>();
+	return {
+		...actual,
+		loadPageModuleFromDocument: (...args: Parameters<typeof actual.loadPageModuleFromDocument>) =>
+			loadPageModuleFromDocumentMock(...args),
+	};
+});
+
+import { EcoRouter, PageContent, clearLayoutCache } from '../src/router.ts';
+
+type NestedLayoutComponent = FC<{ children?: ReactNode }> & {
+	config?: { __eco?: { id: string; file: string; integration: string } };
+};
+
+type StatefulLayoutTestHandle = {
+	mountCount: number;
+};
+
+function createStatefulEcoLayout(
+	testId: string,
+	eco: { id: string; file: string },
+): NestedLayoutComponent & { testState: StatefulLayoutTestHandle } {
+	const testState: StatefulLayoutTestHandle = { mountCount: 0 };
+	const Layout = ({ children }: { children?: ReactNode }) => {
+		const [tick, setTick] = useState(0);
+		useEffect(() => {
+			testState.mountCount += 1;
+			return () => {
+				testState.mountCount -= 1;
+			};
+		}, []);
+
+		return createElement(
+			'div',
+			{
+				'data-testid': testId,
+				'data-tick': String(tick),
+				onClick: () => setTick((value) => value + 1),
+			},
+			`tick:${tick}`,
+			children,
+		);
+	};
+
+	Layout.displayName = testId;
+	Layout.config = { __eco: { ...eco, integration: 'react' } };
+	const StatefulLayout = Layout as NestedLayoutComponent & { testState: StatefulLayoutTestHandle };
+	StatefulLayout.testState = testState;
+	return StatefulLayout;
+}
+
+function createNestedEcoLayout(testId: string, eco: { id: string; file: string }): NestedLayoutComponent {
+	const Layout = ({ children }: { children?: ReactNode }) =>
+		createElement('div', { 'data-testid': testId }, testId, children);
+
+	Layout.displayName = testId;
+	Layout.config = { __eco: { ...eco, integration: 'react' } };
+	return Layout;
+}
+
+function createNestedLayoutPageWithLink(
+	name: string,
+	layouts: NestedLayoutComponent[],
+	link: { href: string; testId: string },
+) {
+	const Page = () =>
+		createElement(
+			'div',
+			null,
+			createElement(
+				'a',
+				{
+					href: link.href,
+					'data-testid': link.testId,
+					onClick: (event: { stopPropagation: () => void }) => event.stopPropagation(),
+				},
+				'navigate',
+			),
+			createElement('div', { 'data-testid': `${name}-page` }, name),
+		);
+	(Page as FC & { config?: { layouts: NestedLayoutComponent[] }; displayName?: string }).displayName = name;
+	(Page as FC & { config?: { layouts: NestedLayoutComponent[] } }).config = { layouts };
+	return Page as FC & { config?: { layouts: NestedLayoutComponent[] } };
+}
+
+function createNestedLayoutPage(name: string, layouts: NestedLayoutComponent[]) {
+	const Page = () => createElement('div', { 'data-testid': `${name}-page` }, name);
+	(Page as FC & { config?: { layouts: NestedLayoutComponent[] }; displayName?: string }).displayName = name;
+	(Page as FC & { config?: { layouts: NestedLayoutComponent[] } }).config = { layouts };
+	return Page as FC & { config?: { layouts: NestedLayoutComponent[] } };
+}
+
+describe('nested layout persistence', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	const user = userEvent.setup();
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		loadPageModuleFromDocumentMock.mockReset();
+	});
+
+	afterEach(() => {
+		root?.unmount();
+		container.remove();
+		vi.restoreAllMocks();
+	});
+
+	it('preserves shared outer layout state across [A,B] and [A,C] SPA navigation', async () => {
+		const sharedEco = { id: 'app-shell', file: '/app/layouts/app-shell.tsx' };
+		const shellDocsImport = createStatefulEcoLayout('shared-shell', sharedEco);
+		const shellSettingsImport = createStatefulEcoLayout('shared-shell', sharedEco);
+		const docsInner = createNestedEcoLayout('docs-inner', {
+			id: 'docs-inner',
+			file: '/app/layouts/docs-inner.tsx',
+		});
+		const settingsInner = createNestedEcoLayout('settings-inner', {
+			id: 'settings-inner',
+			file: '/app/layouts/settings-inner.tsx',
+		});
+
+		const DocsPage = createNestedLayoutPageWithLink('DocsPage', [shellDocsImport, docsInner], {
+			href: '/settings',
+			testId: 'go-settings',
+		});
+		const SettingsPage = createNestedLayoutPage('SettingsPage', [shellSettingsImport, settingsInner]);
+
+		clearLayoutCache();
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response('<html><head></head><body></body></html>', { status: 200 }),
+		);
+		loadPageModuleFromDocumentMock.mockResolvedValue({
+			Component: SettingsPage,
+			props: {},
+			doc: document,
+			finalPath: '/settings',
+			moduleUrl: 'virtual:settings-page',
+		});
+
+		root = createRoot(container);
+		root.render(
+			createElement(EcoRouter, {
+				page: DocsPage,
+				pageProps: {},
+				options: { persistLayouts: true, viewTransitions: false },
+				// oxlint-disable-next-line no-children-prop
+				children: createElement(PageContent),
+			}),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		const shell = container.querySelector('[data-testid="shared-shell"]') as HTMLDivElement;
+		expect(shell).not.toBeNull();
+		expect(container.querySelector('[data-testid="docs-inner"]')).not.toBeNull();
+		expect(shellDocsImport.testState.mountCount).toBe(1);
+
+		fireEvent.click(shell);
+		expect(shell.getAttribute('data-tick')).toBe('1');
+
+		await user.click(container.querySelector('[data-testid="go-settings"]') as HTMLAnchorElement);
+
+		await vi.waitFor(() => {
+			expect(loadPageModuleFromDocumentMock).toHaveBeenCalled();
+			expect(container.querySelector('[data-testid="settings-inner"]')).not.toBeNull();
+		});
+
+		expect(shellDocsImport.testState.mountCount).toBe(1);
+		expect(container.querySelector('[data-testid="shared-shell"]')?.getAttribute('data-tick')).toBe('1');
+		expect(container.querySelector('[data-testid="docs-inner"]')).toBeNull();
+		expect(container.querySelector('[data-testid="SettingsPage-page"]')).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- Nested layout arrays on `eco.page` with outer→inner `layouts: [A, B, …]` normalization across core, React SSR, and react-router
- Unified React SSR composition via `composeChildren` / `composeLayoutPageTree` with layout locals derived from document shell props
- `persistLayouts` per-tier cache: routes sharing an outer layout (e.g. `[A,B]` and `[A,C]`) reuse the same mounted **A** on SPA navigation
- ADRs, integration README updates, SSR/hydration parity harness, and shared-parent persistence tests

## Test plan

- [x] `layout-cache.test.ts` — per-tier keys and shared outer parent reuse
- [x] `nested-layout-persist.test.browser.ts` — SPA nav preserves outer layout state across mixed stacks
- [x] `hmr-reload.test.browser.ts` — persisted layout refresh on HMR
- [x] `react-ssr-hydration-parity.test.tsx` — SSR/client tree parity
- [x] Full vitest suite (1716 tests)