### PR TITLE
refactor: consolidate layout composition casts at integration boundaries

### DIFF
--- a/e2e/fixtures/react-router/src/layouts/base-layout.tsx
+++ b/e2e/fixtures/react-router/src/layouts/base-layout.tsx
@@ -1,4 +1,4 @@
-import type { EcoComponent } from '@ecopages/core';
+import { eco } from '@ecopages/core';
 import type { ReactNode } from 'react';
 import { markSharedLayoutClientProbe } from './shared-layout-client-probe';
 
@@ -6,7 +6,9 @@ export type BaseLayoutProps = {
 	children: ReactNode;
 };
 
-export const BaseLayout: EcoComponent<BaseLayoutProps, ReactNode> = ({ children }) => {
-	markSharedLayoutClientProbe();
-	return <main data-testid="base-layout">{children}</main>;
-};
+export const BaseLayout = eco.layout<BaseLayoutProps, ReactNode>({
+	render: ({ children }) => {
+		markSharedLayoutClientProbe();
+		return <main data-testid="base-layout">{children}</main>;
+	},
+});

--- a/e2e/fixtures/react-router/src/layouts/docs-layout.tsx
+++ b/e2e/fixtures/react-router/src/layouts/docs-layout.tsx
@@ -1,4 +1,4 @@
-import type { EcoComponent } from '@ecopages/core';
+import { eco } from '@ecopages/core';
 import type { ReactNode } from 'react';
 import { DocsLayoutSidebarLink } from './docs-layout-sidebar-link';
 
@@ -23,28 +23,27 @@ const sidebarItems = [
 	{ href: '/docs/examples', label: 'Examples' },
 ];
 
-export const DocsLayout: EcoComponent<DocsLayoutProps, ReactNode> = ({ children }) => {
-	return (
-		<div className="docs-layout" data-testid="docs-layout">
-			<aside className="docs-sidebar" data-testid="docs-sidebar" data-eco-persist="scroll">
-				<nav>
-					<ul>
-						{sidebarItems.map((item) => (
-							<li key={item.href}>
-								<DocsLayoutSidebarLink href={item.href}>{item.label}</DocsLayoutSidebarLink>
-							</li>
-						))}
-					</ul>
-				</nav>
-			</aside>
-			<main className="docs-content">{children}</main>
-		</div>
-	);
-};
-
-DocsLayout.config = {
+export const DocsLayout = eco.layout<DocsLayoutProps, ReactNode>({
 	dependencies: {
 		stylesheets: ['./docs.css'],
 		components: [DocsLayoutSidebarLink],
 	},
-};
+	render: ({ children }) => {
+		return (
+			<div className="docs-layout" data-testid="docs-layout">
+				<aside className="docs-sidebar" data-testid="docs-sidebar" data-eco-persist="scroll">
+					<nav>
+						<ul>
+							{sidebarItems.map((item) => (
+								<li key={item.href}>
+									<DocsLayoutSidebarLink href={item.href}>{item.label}</DocsLayoutSidebarLink>
+								</li>
+							))}
+						</ul>
+					</nav>
+				</aside>
+				<main className="docs-content">{children}</main>
+			</div>
+		);
+	},
+});

--- a/packages/integrations/react/src/react-renderer.ts
+++ b/packages/integrations/react/src/react-renderer.ts
@@ -793,7 +793,7 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 			return false;
 		}
 
-		const composablePage = page as ComposablePage;
+		const composablePage = assertComposablePage(page);
 		const configLayouts =
 			composablePage.config?.layouts ??
 			composablePage.config?.layoutEntries?.map((entry) => entry.component) ??
@@ -947,12 +947,9 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 			safeLocals: this.pagePayloadService.getSerializableLocals(undefined, this.getComponentRequires(input.view)),
 		});
 		const shellLayouts: DocumentShellLayoutInput[] = input.layout ? [{ component: input.layout, props: {} }] : [];
-		const composeChildren = this.shouldUseUnifiedReactLayoutComposition(input.view as EcoComponent, shellLayouts)
+		const composeChildren = this.shouldUseUnifiedReactLayoutComposition(input.view, shellLayouts)
 			? (context: DocumentShellComposeChildrenContext) =>
-					this.composeReactLayoutPageChildren(
-						{ component: input.view as EcoComponent, props: normalizedProps },
-						context,
-					)
+					this.composeReactLayoutPageChildren({ component: input.view, props: normalizedProps }, context)
 			: undefined;
 
 		const { documentHtml } = await composeDocumentShell(
@@ -962,7 +959,7 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 				appendProcessedDependencies: (...assetGroups) => this.appendProcessedDependencies(...assetGroups),
 			},
 			{
-				primaryComponent: input.view as EcoComponent,
+				primaryComponent: input.view,
 				primaryProps: normalizedProps,
 				layout: input.layout
 					? {
@@ -972,7 +969,7 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 					: undefined,
 				layouts: shellLayouts.length > 0 ? shellLayouts : undefined,
 				composeChildren,
-				htmlTemplate: HtmlTemplate as EcoComponent,
+				htmlTemplate: HtmlTemplate,
 				documentProps: {
 					metadata,
 					pageProps: serializedPageProps,

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -44,7 +44,12 @@ import {
 	type EcoReloadRequest,
 } from '@ecopages/core/router/navigation-coordinator';
 import { clearLayoutCache, resolvePersistedLayoutStack, type LayoutComponent } from './layout-cache.ts';
-import { composeLayoutPageTree, assertComposablePage } from '@ecopages/react/layout-compose';
+import {
+	composeLayoutPageTree,
+	assertComposablePage,
+	normalizePageLayoutComponents,
+	type ComposablePage,
+} from '@ecopages/react/layout-compose';
 import {
 	getAnchorFromNavigationEvent,
 	recoverPendingNavigationHref,
@@ -69,15 +74,12 @@ const PageContext = createContext<PageContextValue>(null);
 
 const PersistLayoutsContext = createContext<boolean>(false);
 
-function resolvePageLayoutStack(pageConfig?: {
-	layout?: LayoutComponent;
-	layouts?: LayoutComponent[];
-}): LayoutComponent[] {
-	if (pageConfig?.layouts && pageConfig.layouts.length > 0) {
-		return pageConfig.layouts;
-	}
-
-	return pageConfig?.layout ? [pageConfig.layout] : [];
+/**
+ * @remarks
+ * Eco declared layouts widen to React callables for the persistence cache.
+ */
+function resolvePageLayoutStack(pageConfig?: ComposablePage['config']): LayoutComponent[] {
+	return normalizePageLayoutComponents(pageConfig?.layouts, pageConfig?.layout) as LayoutComponent[];
 }
 
 /**
@@ -125,10 +127,13 @@ export const PageContent: FC = () => {
 	}
 
 	const { Component: Page, props, refreshPersistedLayout } = pageContext;
-	const pageWithConfig = Page as ComponentType & {
-		config?: { layout?: LayoutComponent; layouts?: LayoutComponent[] };
-	};
-	const layoutComponents = resolvePageLayoutStack(pageWithConfig.config);
+
+	if (typeof Page !== 'function') {
+		return null;
+	}
+
+	const composablePage = assertComposablePage(Page);
+	const layoutComponents = resolvePageLayoutStack(composablePage.config);
 	const shouldRefreshPersistedLayout = Boolean(refreshPersistedLayout);
 
 	if (persistLayouts && layoutComponents.length > 0) {
@@ -143,11 +148,7 @@ export const PageContent: FC = () => {
 		return tree;
 	}
 
-	if (typeof Page !== 'function') {
-		return null;
-	}
-
-	return composeLayoutPageTree(assertComposablePage(Page), props);
+	return composeLayoutPageTree(composablePage, props);
 };
 
 function createDeferred<T>() {


### PR DESCRIPTION
## Summary

- Route `PageContent` through a single `assertComposablePage` path instead of ad-hoc `Page as ComponentType` casts
- Resolve persistable layout stacks via `normalizePageLayoutComponents` with one documented widen to `LayoutComponent[]`
- Remove redundant `input.view as EcoComponent` casts in `renderViewWithDocumentShell` and use `assertComposablePage` in unified composition gate

## Test plan

- [x] Full vitest suite (1716 tests)
- [x] `@ecopages/react` and `@ecopages/react-router` typecheck