### PR TITLE
fix(kitchen-sink): declare ReactPlaygroundLayout with eco.layout

### DIFF
--- a/e2e/scripts/playwright/clean-e2e-artifacts.mjs
+++ b/e2e/scripts/playwright/clean-e2e-artifacts.mjs
@@ -1,6 +1,6 @@
 /**
- * Removes scoped e2e fixture build outputs so Playwright static builds do not
- * reuse stale incremental caches after workspace package changes.
+ * Removes e2e fixture and kitchen-sink build outputs so Playwright static builds
+ * do not reuse stale incremental caches after source or workspace package changes.
  */
 import { readdirSync, rmSync, statSync } from 'node:fs';
 import path from 'node:path';
@@ -8,14 +8,15 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const fixturesRoot = path.join(repoRoot, 'e2e', 'fixtures');
+const kitchenSinkDir = path.join(repoRoot, 'playground', 'kitchen-sink');
 
 const SCOPED_ARTIFACT_PATTERN = /^(?:dist(?:-.+)?|\.eco(?:-.+)?)$/;
 
-function removeScopedArtifacts(fixtureDir) {
+function removeScopedArtifacts(appDir) {
 	let entries;
 
 	try {
-		entries = readdirSync(fixtureDir);
+		entries = readdirSync(appDir);
 	} catch {
 		return;
 	}
@@ -25,7 +26,7 @@ function removeScopedArtifacts(fixtureDir) {
 			continue;
 		}
 
-		const artifactPath = path.join(fixtureDir, entry);
+		const artifactPath = path.join(appDir, entry);
 
 		try {
 			if (!statSync(artifactPath).isDirectory()) {
@@ -46,9 +47,11 @@ try {
 		.filter((entry) => entry.isDirectory())
 		.map((entry) => path.join(fixturesRoot, entry.name));
 } catch {
-	process.exit(0);
+	fixtureDirs = [];
 }
 
 for (const fixtureDir of fixtureDirs) {
 	removeScopedArtifacts(fixtureDir);
 }
+
+removeScopedArtifacts(kitchenSinkDir);

--- a/playground/kitchen-sink/bench/heavy-bench.bench.ts
+++ b/playground/kitchen-sink/bench/heavy-bench.bench.ts
@@ -35,7 +35,7 @@ import { createRoot } from 'react-dom/client';
 import * as ReactDOM from 'react-dom';
 import { eco } from '@ecopages/core';
 import { ReactCounter } from '@/components/react-counter.react';
-import { ReactPlaygroundLayout } from '@/layouts/react-playground-layout';
+import { ReactPlaygroundLayout } from '@/layouts/react-playground-layout.react';
 import { getRouteLinkTestId } from '@/data/primary-links';
 
 export default eco.page({

--- a/playground/kitchen-sink/src/layouts/react-playground-layout.react.tsx
+++ b/playground/kitchen-sink/src/layouts/react-playground-layout.react.tsx
@@ -1,17 +1,10 @@
 /** @jsxImportSource react */
 import { eco } from '@ecopages/core';
-import type { RequestLocals } from '@ecopages/core';
 import { ThemeToggleReact } from '@/components/theme-toggle.react';
 import { getPrimaryLinkTestId, kitchenSinkShell, kitchenSinkShellTestId, primaryLinks } from '@/data/primary-links';
 import type { ReactNode } from 'react';
 
-type ReactPlaygroundLayoutProps = {
-	children?: ReactNode;
-	locals?: RequestLocals;
-};
-
-export const ReactPlaygroundLayout = eco.component<ReactPlaygroundLayoutProps, ReactNode>({
-	integration: 'react',
+export const ReactPlaygroundLayout = eco.layout<ReactNode>({
 	dependencies: {
 		components: [ThemeToggleReact],
 		scripts: ['./base-layout/base-layout.script.ts'],

--- a/playground/kitchen-sink/src/pages/react-content.mdx
+++ b/playground/kitchen-sink/src/pages/react-content.mdx
@@ -1,4 +1,4 @@
-import { ReactPlaygroundLayout } from '../layouts/react-playground-layout';
+import { ReactPlaygroundLayout } from '../layouts/react-playground-layout.react';
 import { LitCounter } from '../components/lit-counter.lit';
 import { ReactCounter } from '../components/react-counter.react';
 

--- a/playground/kitchen-sink/src/pages/react-lab.react.tsx
+++ b/playground/kitchen-sink/src/pages/react-lab.react.tsx
@@ -2,7 +2,7 @@
 import { eco } from '@ecopages/core';
 import { ReactCounter } from '@/components/react-counter.react';
 import { getRouteLinkTestId } from '@/data/primary-links';
-import { ReactPlaygroundLayout } from '@/layouts/react-playground-layout';
+import { ReactPlaygroundLayout } from '@/layouts/react-playground-layout.react';
 import { ReactShell } from '@ecopages/testing/kitchen-sink/react-shell';
 import type { ReactNode } from 'react';
 

--- a/playground/kitchen-sink/src/pages/react-notes.react.tsx
+++ b/playground/kitchen-sink/src/pages/react-notes.react.tsx
@@ -2,7 +2,7 @@
 import { eco } from '@ecopages/core';
 import { ReactCounter } from '@/components/react-counter.react';
 import { getRouteLinkTestId } from '@/data/primary-links';
-import { ReactPlaygroundLayout } from '@/layouts/react-playground-layout';
+import { ReactPlaygroundLayout } from '@/layouts/react-playground-layout.react';
 import { ReactShell } from '@ecopages/testing/kitchen-sink/react-shell';
 import type { ReactNode } from 'react';
 

--- a/playground/kitchen-sink/src/pages/react-server-files/index.react.tsx
+++ b/playground/kitchen-sink/src/pages/react-server-files/index.react.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import { eco } from '@ecopages/core';
 import { buildPagesTreeSnapshot } from './tree.server';
-import { ReactPlaygroundLayout } from '@/layouts/react-playground-layout';
+import { ReactPlaygroundLayout } from '@/layouts/react-playground-layout.react';
 import { getPageTestId } from '@/data/primary-links';
 import type { ReactNode } from 'react';
 

--- a/playground/kitchen-sink/src/pages/react-server-metadata.react.tsx
+++ b/playground/kitchen-sink/src/pages/react-server-metadata.react.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import { eco } from '@ecopages/core';
 import { getReactServerMetadataSummary } from './react-server-metadata.server';
-import { ReactPlaygroundLayout } from '@/layouts/react-playground-layout';
+import { ReactPlaygroundLayout } from '@/layouts/react-playground-layout.react';
 import type { ReactNode } from 'react';
 
 export default eco.page<{}, ReactNode>({


### PR DESCRIPTION
## Summary
- Convert kitchen-sink `ReactPlaygroundLayout` from plain `.tsx` `eco.component()` to `.react.tsx` `eco.layout()` so component-meta injects `__eco` metadata
- Fixes `UndeclaredComponentDependencyError` on `/react-lab` and other react routes during dev SSR and static export
- Extend `clean-e2e-artifacts` to clear kitchen-sink `dist`/`.eco` caches so e2e builds do not reuse stale unified-graph output after layout changes

## Test plan
- [x] `pnpm run test:vitest` (pre-commit)
- [x] Kitchen-sink production build succeeds after clean `.eco`/`dist`
- [x] `pnpm test:all` or `pnpm run build:e2e:kitchen-sink` on CI