### PR TITLE
fix(ecopages-jsx): resolve Radiant hydrator and render-tree HMR ownership

### DIFF
--- a/packages/core/src/adapters/shared/hmr-manager.dispatch.test.ts
+++ b/packages/core/src/adapters/shared/hmr-manager.dispatch.test.ts
@@ -117,7 +117,7 @@ describe.each(runtimes)('handleFileChange dispatch: $name', ({ create }) => {
 		assert.equal(spy.broadcasts[0].path, htmlFile);
 	});
 
-	test('TS file with no registered entrypoints falls back to DefaultHmrStrategy reload', async () => {
+	test('TS file with no registered entrypoints falls through to DefaultHmrStrategy reload', async () => {
 		const rootDir = createTempRoot('ecopages-dispatch-ts-fallback');
 		const srcDir = path.join(rootDir, 'src');
 		fs.mkdirSync(srcDir, { recursive: true });
@@ -130,6 +130,7 @@ describe.each(runtimes)('handleFileChange dispatch: $name', ({ create }) => {
 
 		assert.equal(spy.broadcasts.length, 1);
 		assert.equal(spy.broadcasts[0].type, 'reload');
+		assert.equal(spy.broadcasts[0].path, tsFile);
 	});
 
 	test('broadcast:false suppresses events even when the strategy returns a broadcast action', async () => {

--- a/packages/integrations/ecopages-jsx/package.json
+++ b/packages/integrations/ecopages-jsx/package.json
@@ -48,7 +48,7 @@
 	},
 	"peerDependencies": {
 		"@ecopages/core": "workspace:*",
-		"@ecopages/jsx": "0.3.0-alpha.25",
-		"@ecopages/radiant": "0.3.0-alpha.25"
+		"@ecopages/jsx": "0.3.0-beta.0",
+		"@ecopages/radiant": "0.3.0-beta.0"
 	}
 }

--- a/packages/integrations/ecopages-jsx/src/ecopages-jsx-hmr-ownership.ts
+++ b/packages/integrations/ecopages-jsx/src/ecopages-jsx-hmr-ownership.ts
@@ -1,0 +1,110 @@
+/**
+ * Tracks the source files that participate in the active SSR render tree.
+ *
+ * @remarks
+ * The JSX integration renderer calls {@link updateEjsxHmrOwnership} after each
+ * page, component, or view render so the HMR strategy can answer
+ * "does this changed file affect SSR HTML?" without re-walking the tree on
+ * every watcher event.
+ *
+ * The state is module-scoped because the HMR strategy and renderer live in
+ * different call sites (server strategy vs SSR renderer) and share no other
+ * lifecycle anchor. A fresh state is installed only when the source-file set
+ * changes, so the renderer's per-render hook stays O(1) in the steady state.
+ */
+
+import path from 'node:path';
+import { rapidhash } from '@ecopages/core/hash';
+import type { EcoComponent, EcoComponentConfig } from '@ecopages/core';
+
+export type EjsxHmrOwnershipState = {
+	fileOwners: ReadonlySet<string>;
+	hash: string;
+};
+
+const EMPTY_STATE: EjsxHmrOwnershipState = {
+	fileOwners: new Set<string>(),
+	hash: '',
+};
+
+let currentState: EjsxHmrOwnershipState = EMPTY_STATE;
+
+/**
+ * Returns the most recently recorded active render tree.
+ */
+export function getEjsxHmrOwnership(): EjsxHmrOwnershipState {
+	return currentState;
+}
+
+/**
+ * Updates the active render tree from one or more root components.
+ *
+ * @remarks
+ * Walks each root's `config.__eco.file`, `config.dependencies.components[*].config`,
+ * and `config.layouts[*].config` recursively, collecting every file path. The
+ * state is replaced only when the resulting file set has a different hash, so
+ * the renderer's per-render hook is free in the steady state.
+ */
+export function updateEjsxHmrOwnership(components: ReadonlyArray<EcoComponent | undefined>): void {
+	const files = collectFileOwners(components);
+	const hash = hashFileSet(files);
+
+	if (hash === currentState.hash) {
+		return;
+	}
+
+	currentState = {
+		fileOwners: files,
+		hash,
+	};
+}
+
+/**
+ * Resets the state to empty. Used by tests and by HMR manager teardown.
+ */
+export function resetEjsxHmrOwnership(): void {
+	currentState = EMPTY_STATE;
+}
+
+function collectFileOwners(components: ReadonlyArray<EcoComponent | undefined>): Set<string> {
+	const files = new Set<string>();
+	const visited = new Set<string>();
+
+	const visit = (config: EcoComponentConfig | undefined) => {
+		const file = config?.__eco?.file;
+		if (!file) {
+			return;
+		}
+
+		const resolved = path.resolve(file);
+		if (visited.has(resolved)) {
+			return;
+		}
+		visited.add(resolved);
+		files.add(resolved);
+
+		for (const dependency of config?.dependencies?.components ?? []) {
+			visit(dependency?.config);
+		}
+
+		for (const layout of config?.layouts ?? []) {
+			visit(layout?.config);
+		}
+	};
+
+	for (const component of components) {
+		visit(component?.config);
+	}
+
+	return files;
+}
+
+function hashFileSet(files: ReadonlySet<string>): string {
+	if (files.size === 0) {
+		return '';
+	}
+
+	const sorted = Array.from(files).sort();
+	const joined = sorted.join('\n');
+	return rapidhash(joined).toString(36);
+}

--- a/packages/integrations/ecopages-jsx/src/ecopages-jsx-hmr-strategy.test.ts
+++ b/packages/integrations/ecopages-jsx/src/ecopages-jsx-hmr-strategy.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { HmrStrategyType } from '@ecopages/core/hmr/hmr-strategy';
+import { EcopagesJsxHmrStrategy } from './ecopages-jsx-hmr-strategy.ts';
+import { getEjsxHmrOwnership, resetEjsxHmrOwnership, updateEjsxHmrOwnership } from './ecopages-jsx-hmr-ownership.ts';
+import type { EcoComponent, EcoComponentConfig } from '@ecopages/core';
+
+const SRC_DIR = '/test/project/src';
+const PAGES_DIR = '/test/project/src/pages';
+const LAYOUTS_DIR = '/test/project/src/layouts';
+const INCLUDES_DIR = '/test/project/src/includes';
+const COMPONENTS_DIR = '/test/project/src/components';
+const TEMPLATE_EXTENSIONS = ['.tsx', '.mdx'];
+
+function makeConfig(file: string, extras: Partial<EcoComponentConfig> = {}): EcoComponentConfig {
+	return {
+		__eco: {
+			id: `id-${file}`,
+			file,
+			integration: 'ecopages-jsx',
+		},
+		...extras,
+	};
+}
+
+function makeContext(
+	overrides: Partial<{
+		watchedFiles: Map<string, string>;
+		srcDir: string;
+		pagesDir: string;
+		layoutsDir: string;
+		includesDir: string;
+		templateExtensions: string[];
+	}> = {},
+) {
+	const defaults = {
+		watchedFiles: new Map<string, string>(),
+		srcDir: SRC_DIR,
+		pagesDir: PAGES_DIR,
+		layoutsDir: LAYOUTS_DIR,
+		includesDir: INCLUDES_DIR,
+		templateExtensions: TEMPLATE_EXTENSIONS,
+	};
+	const merged = { ...defaults, ...overrides };
+	return {
+		getWatchedFiles: () => merged.watchedFiles,
+		getSrcDir: () => merged.srcDir,
+		getPagesDir: () => merged.pagesDir,
+		getLayoutsDir: () => merged.layoutsDir,
+		getIncludesDir: () => merged.includesDir,
+		getTemplateExtensions: () => merged.templateExtensions,
+	};
+}
+
+function makeComponent(file: string, config: Partial<EcoComponentConfig> = {}): EcoComponent {
+	const fn = (() => undefined) as unknown as EcoComponent;
+	(fn as { config?: EcoComponentConfig }).config = makeConfig(file, config);
+	return fn;
+}
+
+describe('EcopagesJsxHmrStrategy', () => {
+	beforeEach(() => {
+		resetEjsxHmrOwnership();
+	});
+
+	it('has INTEGRATION priority', () => {
+		const strategy = new EcopagesJsxHmrStrategy(makeContext());
+		expect(strategy.priority).toBe(HmrStrategyType.INTEGRATION);
+		expect(strategy.type).toBe(HmrStrategyType.INTEGRATION);
+	});
+
+	describe('matches()', () => {
+		it('matches page files with a JSX template extension', () => {
+			const strategy = new EcopagesJsxHmrStrategy(makeContext());
+			expect(strategy.matches(`${PAGES_DIR}/index.tsx`)).toBe(true);
+			expect(strategy.matches(`${PAGES_DIR}/docs/[...slug]/index.tsx`)).toBe(true);
+			expect(strategy.matches(`${PAGES_DIR}/about.mdx`)).toBe(true);
+		});
+
+		it('matches layout files with a JSX template extension', () => {
+			const strategy = new EcopagesJsxHmrStrategy(makeContext());
+			expect(strategy.matches(`${LAYOUTS_DIR}/base-layout.tsx`)).toBe(true);
+		});
+
+		it('does not match page or layout files with non-JSX extensions', () => {
+			const strategy = new EcopagesJsxHmrStrategy(makeContext());
+			expect(strategy.matches(`${PAGES_DIR}/notes.md`)).toBe(false);
+		});
+
+		it('does not match include template files', () => {
+			const strategy = new EcopagesJsxHmrStrategy(makeContext());
+			expect(strategy.matches(`${INCLUDES_DIR}/head.tsx`)).toBe(false);
+		});
+
+		it('does not match files outside srcDir', () => {
+			const strategy = new EcopagesJsxHmrStrategy(makeContext());
+			expect(strategy.matches('/other/path/file.tsx')).toBe(false);
+		});
+
+		it('does not match files outside pages/layouts when not in the active render tree', () => {
+			const strategy = new EcopagesJsxHmrStrategy(makeContext());
+			expect(strategy.matches(`${COMPONENTS_DIR}/orphan.tsx`)).toBe(false);
+		});
+
+		it('does not match files registered as watched HMR entrypoints', () => {
+			const scriptPath = `${COMPONENTS_DIR}/copy-for-llm/copy-for-llm.script.tsx`;
+			const strategy = new EcopagesJsxHmrStrategy(
+				makeContext({ watchedFiles: new Map([[scriptPath, '/assets/_hmr/script.js']]) }),
+			);
+			expect(strategy.matches(scriptPath)).toBe(false);
+		});
+
+		it('matches files that appear in the active render tree', () => {
+			const componentFile = `${COMPONENTS_DIR}/copy-for-llm/index.tsx`;
+			const component = makeComponent(componentFile);
+			updateEjsxHmrOwnership([component]);
+
+			const strategy = new EcopagesJsxHmrStrategy(makeContext());
+			expect(strategy.matches(componentFile)).toBe(true);
+		});
+
+		it('matches layout files referenced by a page in the active render tree', () => {
+			const layoutFile = `${LAYOUTS_DIR}/base-layout.tsx`;
+			const pageFile = `${PAGES_DIR}/index.tsx`;
+
+			const layoutComponent = makeComponent(layoutFile);
+			const pageComponent = makeComponent(pageFile, {
+				layouts: [layoutComponent],
+			});
+			updateEjsxHmrOwnership([pageComponent]);
+
+			const strategy = new EcopagesJsxHmrStrategy(makeContext());
+			expect(strategy.matches(layoutFile)).toBe(true);
+		});
+
+		it('matches nested dependency components in the active render tree', () => {
+			const nestedFile = `${COMPONENTS_DIR}/breadcrumb/breadcrumb.tsx`;
+			const rootFile = `${COMPONENTS_DIR}/docs-bar/index.tsx`;
+
+			const nestedComponent = makeComponent(nestedFile);
+			const rootComponent = makeComponent(rootFile, {
+				dependencies: { components: [nestedComponent] },
+			});
+			updateEjsxHmrOwnership([rootComponent]);
+
+			const strategy = new EcopagesJsxHmrStrategy(makeContext());
+			expect(strategy.matches(nestedFile)).toBe(true);
+		});
+	});
+
+	describe('process()', () => {
+		it('broadcasts a layout-update event with the changed file path and timestamp', async () => {
+			const strategy = new EcopagesJsxHmrStrategy(makeContext());
+			const filePath = `${PAGES_DIR}/index.tsx`;
+
+			const action = await strategy.process(filePath);
+
+			expect(action.type).toBe('broadcast');
+			expect(action.events).toEqual([
+				{
+					type: 'layout-update',
+					path: filePath,
+					timestamp: expect.any(Number),
+				},
+			]);
+		});
+	});
+});
+
+describe('ecopages-jsx-hmr-ownership', () => {
+	beforeEach(() => {
+		resetEjsxHmrOwnership();
+	});
+
+	it('starts with an empty ownership set', () => {
+		const state = getEjsxHmrOwnership();
+		expect(state.fileOwners.size).toBe(0);
+		expect(state.hash).toBe('');
+	});
+
+	it('records the __eco.file of a single root component', () => {
+		const component = makeComponent(`${COMPONENTS_DIR}/copy-for-llm/index.tsx`);
+		updateEjsxHmrOwnership([component]);
+
+		const state = getEjsxHmrOwnership();
+		expect(state.fileOwners.has(`${COMPONENTS_DIR}/copy-for-llm/index.tsx`)).toBe(true);
+	});
+
+	it('walks nested dependencies.components[*].config.__eco.file', () => {
+		const nested = makeComponent(`${COMPONENTS_DIR}/breadcrumb/breadcrumb.tsx`);
+		const root = makeComponent(`${COMPONENTS_DIR}/docs-bar/index.tsx`, {
+			dependencies: { components: [nested] },
+		});
+		updateEjsxHmrOwnership([root]);
+
+		const state = getEjsxHmrOwnership();
+		expect(state.fileOwners.has(`${COMPONENTS_DIR}/docs-bar/index.tsx`)).toBe(true);
+		expect(state.fileOwners.has(`${COMPONENTS_DIR}/breadcrumb/breadcrumb.tsx`)).toBe(true);
+	});
+
+	it('walks layouts[*].config.__eco.file', () => {
+		const layout = makeComponent(`${LAYOUTS_DIR}/base-layout.tsx`);
+		const page = makeComponent(`${PAGES_DIR}/index.tsx`, {
+			layouts: [layout],
+		});
+		updateEjsxHmrOwnership([page]);
+
+		const state = getEjsxHmrOwnership();
+		expect(state.fileOwners.has(`${LAYOUTS_DIR}/base-layout.tsx`)).toBe(true);
+	});
+
+	it('skips the update when the resulting file set is unchanged', () => {
+		const component = makeComponent(`${COMPONENTS_DIR}/copy-for-llm/index.tsx`);
+		updateEjsxHmrOwnership([component]);
+		const firstHash = getEjsxHmrOwnership().hash;
+		const firstSet = getEjsxHmrOwnership().fileOwners;
+
+		updateEjsxHmrOwnership([component]);
+		const secondHash = getEjsxHmrOwnership().hash;
+		const secondSet = getEjsxHmrOwnership().fileOwners;
+
+		expect(secondHash).toBe(firstHash);
+		expect(secondSet).toBe(firstSet);
+	});
+
+	it('updates the hash when the file set changes', () => {
+		const first = makeComponent(`${COMPONENTS_DIR}/copy-for-llm/index.tsx`);
+		updateEjsxHmrOwnership([first]);
+		const firstHash = getEjsxHmrOwnership().hash;
+
+		const second = makeComponent(`${COMPONENTS_DIR}/docs-bar/index.tsx`);
+		updateEjsxHmrOwnership([first, second]);
+
+		expect(getEjsxHmrOwnership().hash).not.toBe(firstHash);
+		expect(getEjsxHmrOwnership().fileOwners.size).toBe(2);
+	});
+
+	it('protects against cycles in the dependency graph', () => {
+		const fileA = `${COMPONENTS_DIR}/a.tsx`;
+		const fileB = `${COMPONENTS_DIR}/b.tsx`;
+
+		const a = makeComponent(fileA);
+		const b = makeComponent(fileB, {
+			dependencies: { components: [a] },
+		});
+		(a as { config: EcoComponentConfig }).config = {
+			...a.config,
+			dependencies: { components: [b] },
+		};
+
+		updateEjsxHmrOwnership([a]);
+
+		const state = getEjsxHmrOwnership();
+		expect(state.fileOwners.has(fileA)).toBe(true);
+		expect(state.fileOwners.has(fileB)).toBe(true);
+	});
+
+	it('ignores components without __eco metadata', () => {
+		const a = makeComponent(`${COMPONENTS_DIR}/a.tsx`);
+		const b = (() => undefined) as unknown as EcoComponent;
+		(b as { config?: EcoComponentConfig }).config = {
+			dependencies: { components: [a] },
+		};
+
+		updateEjsxHmrOwnership([a, b]);
+
+		const state = getEjsxHmrOwnership();
+		expect(state.fileOwners.has(`${COMPONENTS_DIR}/a.tsx`)).toBe(true);
+	});
+});

--- a/packages/integrations/ecopages-jsx/src/ecopages-jsx-hmr-strategy.ts
+++ b/packages/integrations/ecopages-jsx/src/ecopages-jsx-hmr-strategy.ts
@@ -1,0 +1,103 @@
+/**
+ * HMR strategy for JSX integration-owned SSR source modules.
+ *
+ * @remarks
+ * Edits to files that produce SSR HTML (page sources, layout sources, components
+ * that the active render tree depends on) need a soft page refetch so the
+ * browser picks up the new markup. Plain `update` events re-import modules on
+ * the client but leave the server-rendered DOM stale.
+ *
+ * The strategy matches a file when any of these hold:
+ * - the file lives under `pagesDir` or `layoutsDir` and has a JSX `templatesExt`
+ * - the file appears in the active render tree's component dependency graph
+ *
+ * It defers registered HMR entrypoints to {@link JsHmrStrategy} so script-only
+ * edits keep their existing `update`-then-hot-accept path. It also defers
+ * include templates and explicit server views to {@link ServerRenderedTemplateHmrStrategy}
+ * by returning `false` for those paths.
+ */
+
+import path from 'node:path';
+import { HmrStrategy, HmrStrategyType, type HmrAction } from '@ecopages/core/hmr/hmr-strategy';
+import { getEjsxHmrOwnership } from './ecopages-jsx-hmr-ownership.ts';
+
+export interface EcopagesJsxHmrStrategyContext {
+	getWatchedFiles(): Map<string, string>;
+	getSrcDir(): string;
+	getPagesDir(): string;
+	getLayoutsDir(): string;
+	getIncludesDir(): string;
+	getTemplateExtensions(): ReadonlyArray<string>;
+}
+
+export class EcopagesJsxHmrStrategy extends HmrStrategy {
+	override readonly type = HmrStrategyType.INTEGRATION;
+
+	private readonly context: EcopagesJsxHmrStrategyContext;
+
+	constructor(context: EcopagesJsxHmrStrategyContext) {
+		super();
+		this.context = context;
+	}
+
+	override matches(filePath: string): boolean {
+		if (this.context.getWatchedFiles().has(filePath)) {
+			return false;
+		}
+
+		const resolvedPath = path.resolve(filePath);
+		const srcDir = path.resolve(this.context.getSrcDir());
+
+		if (!resolvedPath.startsWith(`${srcDir}${path.sep}`) && resolvedPath !== srcDir) {
+			return false;
+		}
+
+		const includesDir = path.resolve(this.context.getIncludesDir());
+		if (includesDir && (resolvedPath === includesDir || resolvedPath.startsWith(`${includesDir}${path.sep}`))) {
+			return false;
+		}
+
+		if (this.isPageOrLayoutSource(resolvedPath)) {
+			return this.hasJsxTemplateExtension(resolvedPath);
+		}
+
+		const ownership = getEjsxHmrOwnership();
+		if (ownership.fileOwners.has(resolvedPath)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	override async process(filePath: string): Promise<HmrAction> {
+		return {
+			type: 'broadcast',
+			events: [
+				{
+					type: 'layout-update',
+					path: filePath,
+					timestamp: Date.now(),
+				},
+			],
+		};
+	}
+
+	private isPageOrLayoutSource(resolvedPath: string): boolean {
+		const pagesDir = path.resolve(this.context.getPagesDir());
+		const layoutsDir = path.resolve(this.context.getLayoutsDir());
+
+		if (pagesDir && (resolvedPath === pagesDir || resolvedPath.startsWith(`${pagesDir}${path.sep}`))) {
+			return true;
+		}
+
+		if (layoutsDir && (resolvedPath === layoutsDir || resolvedPath.startsWith(`${layoutsDir}${path.sep}`))) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private hasJsxTemplateExtension(resolvedPath: string): boolean {
+		return this.context.getTemplateExtensions().some((extension) => resolvedPath.endsWith(extension));
+	}
+}

--- a/packages/integrations/ecopages-jsx/src/ecopages-jsx-radiant-ssr-policy.ts
+++ b/packages/integrations/ecopages-jsx/src/ecopages-jsx-radiant-ssr-policy.ts
@@ -1,8 +1,22 @@
 import { createMarkupNodeLike } from '@ecopages/jsx';
 import { createServerHydrationBindingState, withServerHydrationBindingState } from '@ecopages/jsx/server';
 
+type RadiantLightDomShimWindow = {
+	CSS: { escape(value: string): string };
+	CustomEvent: typeof CustomEvent;
+	Document: typeof Document;
+	Element: typeof Element;
+	Event: typeof Event;
+	EventTarget: typeof EventTarget;
+	HTMLScriptElement: typeof HTMLScriptElement;
+	HTMLElement: typeof HTMLElement;
+	Node: typeof Node;
+	document: Document;
+	customElements: CustomElementRegistry;
+};
+
 type RadiantServerRuntimeModules = {
-	installLightDomShim: () => void;
+	installLightDomShim: () => RadiantLightDomShimWindow;
 	resolveRadiantElementRenderBridge: (instance: unknown) =>
 		| {
 				renderHost: () => { nodeType: 1; outerHTML: string };
@@ -25,7 +39,7 @@ export class EcopagesJsxRadiantSsrPolicy {
 	private static runtimeModules: RadiantServerRuntimeModules | undefined;
 	private static runtimeModulesPromise:
 		| Promise<{
-				installLightDomShim: () => void;
+				installLightDomShim: () => RadiantLightDomShimWindow;
 				withServerRadiantElementSsrRuntime: <T>(render: () => T) => T;
 		  }>
 		| undefined;
@@ -93,8 +107,11 @@ export class EcopagesJsxRadiantSsrPolicy {
 				radiantLightDomShimEntry,
 			).href;
 
-			EcopagesJsxRadiantSsrPolicy.runtimeModulesPromise = Promise.all([
-				import(radiantElementSsrRuntimeModuleUrl) as Promise<{
+			EcopagesJsxRadiantSsrPolicy.runtimeModulesPromise = (async () => {
+				const lightDomShimModule = await import(radiantLightDomShimEntry);
+				ensureRadiantLightDomGlobals(lightDomShimModule.installLightDomShim);
+
+				const radiantElementSsrRuntimeModule = (await import(radiantElementSsrRuntimeModuleUrl)) as {
 					resolveRadiantElementRenderBridge: (instance: unknown) =>
 						| {
 								renderHost: () => { nodeType: 1; outerHTML: string };
@@ -102,9 +119,8 @@ export class EcopagesJsxRadiantSsrPolicy {
 						  }
 						| undefined;
 					withServerRadiantElementSsrRuntime: <T>(render: () => T) => T;
-				}>,
-				import(radiantLightDomShimEntry),
-			]).then(([radiantElementSsrRuntimeModule, lightDomShimModule]) => {
+				};
+
 				const modules = {
 					installLightDomShim: lightDomShimModule.installLightDomShim,
 					resolveRadiantElementRenderBridge: radiantElementSsrRuntimeModule.resolveRadiantElementRenderBridge,
@@ -114,10 +130,40 @@ export class EcopagesJsxRadiantSsrPolicy {
 
 				EcopagesJsxRadiantSsrPolicy.runtimeModules = modules;
 				return modules;
-			});
+			})();
 		}
 
-		const lightDomShimModule = await EcopagesJsxRadiantSsrPolicy.runtimeModulesPromise;
-		lightDomShimModule.installLightDomShim();
+		await EcopagesJsxRadiantSsrPolicy.runtimeModulesPromise;
+
+		const lightDomShimModule = EcopagesJsxRadiantSsrPolicy.runtimeModules;
+		if (lightDomShimModule) {
+			ensureRadiantLightDomGlobals(lightDomShimModule.installLightDomShim);
+		}
 	}
+}
+
+function ensureRadiantLightDomGlobals(installLightDomShim: () => RadiantLightDomShimWindow): void {
+	if (typeof globalThis.HTMLElement !== 'undefined') {
+		return;
+	}
+
+	const window = installLightDomShim();
+	if (!window) {
+		return;
+	}
+
+	Object.assign(globalThis, {
+		CSS: window.CSS,
+		CustomEvent: window.CustomEvent,
+		Document: window.Document,
+		Element: window.Element,
+		Event: window.Event,
+		EventTarget: window.EventTarget,
+		HTMLScriptElement: window.HTMLScriptElement,
+		HTMLElement: window.HTMLElement,
+		Node: window.Node,
+		document: window.document,
+		customElements: window.customElements,
+		window,
+	});
 }

--- a/packages/integrations/ecopages-jsx/src/ecopages-jsx-renderer.ts
+++ b/packages/integrations/ecopages-jsx/src/ecopages-jsx-renderer.ts
@@ -27,6 +27,7 @@ import {
 } from './ecopages-jsx-mdx.ts';
 import { EcopagesJsxRenderSession } from './ecopages-jsx-render-session.ts';
 import { EcopagesJsxRadiantSsrPolicy } from './ecopages-jsx-radiant-ssr-policy.ts';
+import { updateEjsxHmrOwnership } from './ecopages-jsx-hmr-ownership.ts';
 import type { EcopagesJsxRendererOptions } from './ecopages-jsx.types.ts';
 
 export type { EcopagesJsxRendererConfig, EcopagesJsxRendererOptions } from './ecopages-jsx.types.ts';
@@ -175,7 +176,7 @@ export class EcopagesJsxRenderer extends IntegrationRenderer<JsxRenderable> {
 		return await this.withPreparedRadiantRuntime(() =>
 			this.renderSession.withActiveScope(async () => {
 				try {
-					return await this.renderPageWithDocumentShell({
+					const result = await this.renderPageWithDocumentShell({
 						page: {
 							component: options.Page,
 							props: {
@@ -196,6 +197,10 @@ export class EcopagesJsxRenderer extends IntegrationRenderer<JsxRenderable> {
 						metadata: options.metadata,
 						pageProps: options.pageProps ?? {},
 					});
+
+					this.recordHmrOwnership([options.Page, options.Layout, options.HtmlTemplate]);
+
+					return result;
 				} catch (error) {
 					throw this.createRenderError('Error rendering page', error);
 				}
@@ -244,6 +249,8 @@ export class EcopagesJsxRenderer extends IntegrationRenderer<JsxRenderable> {
 						...componentAssets,
 					]);
 
+					this.recordHmrOwnership([input.component as EcoComponent]);
+
 					return {
 						html: queuedForeignSubtreeResolution.html,
 						canAttachAttributes: true,
@@ -273,12 +280,16 @@ export class EcopagesJsxRenderer extends IntegrationRenderer<JsxRenderable> {
 					const viewComponent = view as AsyncEcoComponent<Record<string, unknown>>;
 					const layouts = viewComponent.config?.layouts;
 
-					return await this.renderViewWithDocumentShell({
+					const response = await this.renderViewWithDocumentShell({
 						view: viewComponent,
 						props: props as Record<string, unknown>,
 						ctx,
 						layout: layouts?.[layouts.length - 1],
 					});
+
+					this.recordHmrOwnership([view as EcoComponent]);
+
+					return response;
 				} catch (error) {
 					throw this.createRenderError('Error rendering view', error);
 				}
@@ -312,5 +323,14 @@ export class EcopagesJsxRenderer extends IntegrationRenderer<JsxRenderable> {
 		return ({ instance }: { instance?: unknown; tagName: string }) => {
 			return instance ? this.radiantSsrPolicy.renderIntrinsicElementMarkup(instance) : undefined;
 		};
+	}
+
+	/**
+	 * Records the source files that produced the current render so
+	 * {@link EcopagesJsxHmrStrategy} can match later watcher events without
+	 * re-walking the component tree.
+	 */
+	private recordHmrOwnership(components: ReadonlyArray<EcoComponent | undefined>): void {
+		updateEjsxHmrOwnership(components);
 	}
 }

--- a/packages/integrations/ecopages-jsx/src/ecopages-jsx.plugin.ts
+++ b/packages/integrations/ecopages-jsx/src/ecopages-jsx.plugin.ts
@@ -4,8 +4,10 @@ import {
 	type IntegrationPluginConfig,
 } from '@ecopages/core/plugins/integration-plugin';
 import { type AssetDefinition, AssetFactory } from '@ecopages/core/services/asset-processing-service';
+import type { HmrStrategy } from '@ecopages/core/hmr/hmr-strategy';
 import type { JsxRenderable } from '@ecopages/jsx';
 import { ECOPAGES_JSX_PLUGIN_NAME } from './ecopages-jsx.constants.ts';
+import { RADIANT_INSTALL_HYDRATOR_FILEPATH } from './resolve-radiant-install-hydrator.ts';
 import {
 	appendMdxExtensions,
 	createMdxLoaderPlugin,
@@ -14,6 +16,7 @@ import {
 	type ResolvedMdxCompileOptions,
 } from './ecopages-jsx-mdx.ts';
 import { EcopagesJsxRenderer } from './ecopages-jsx-renderer.ts';
+import { EcopagesJsxHmrStrategy } from './ecopages-jsx-hmr-strategy.ts';
 import type { EcopagesJsxPluginOptions } from './ecopages-jsx.types.ts';
 
 export type {
@@ -115,7 +118,7 @@ export class EcopagesJsxPlugin extends IntegrationPlugin<JsxRenderable> {
 		return [
 			AssetFactory.createNodeModuleScript({
 				position: 'head',
-				importPath: '@ecopages/radiant/client/install-hydrator',
+				importPath: RADIANT_INSTALL_HYDRATOR_FILEPATH,
 				bundle: false,
 				attributes: {
 					'data-eco-script-id': RADIANT_HYDRATOR_SCRIPT_ID,
@@ -127,6 +130,33 @@ export class EcopagesJsxPlugin extends IntegrationPlugin<JsxRenderable> {
 	/** Ensures MDX build hooks are ready before Ecopages collects contributions. */
 	override async prepareBuildContributions(): Promise<void> {
 		this.ensureMdxLoaderPlugin();
+	}
+
+	/**
+	 * Returns the JSX-integration HMR strategy.
+	 *
+	 * @remarks
+	 * The strategy handles `layout-update` broadcasts for page sources, layout
+	 * sources, and any component file in the active render tree. It defers
+	 * registered script entrypoints to the generic JS strategy and includes /
+	 * explicit server views to `ServerRenderedTemplateHmrStrategy`.
+	 */
+	override getHmrStrategy(): HmrStrategy | undefined {
+		if (!this.hmrManager || !this.appConfig) {
+			return undefined;
+		}
+
+		const context = this.hmrManager.getDefaultContext();
+		const absolutePaths = this.appConfig.absolutePaths;
+
+		return new EcopagesJsxHmrStrategy({
+			getWatchedFiles: context.getWatchedFiles,
+			getSrcDir: context.getSrcDir,
+			getPagesDir: context.getPagesDir,
+			getLayoutsDir: context.getLayoutsDir,
+			getIncludesDir: () => absolutePaths.includesDir,
+			getTemplateExtensions: () => this.extensions,
+		});
 	}
 
 	/**

--- a/packages/integrations/ecopages-jsx/src/resolve-radiant-install-hydrator.ts
+++ b/packages/integrations/ecopages-jsx/src/resolve-radiant-install-hydrator.ts
@@ -1,0 +1,6 @@
+import { fileURLToPath } from 'node:url';
+
+/** Absolute path to `@ecopages/radiant/client/install-hydrator` from this integration package. */
+export const RADIANT_INSTALL_HYDRATOR_FILEPATH = fileURLToPath(
+	import.meta.resolve('@ecopages/radiant/client/install-hydrator'),
+);

--- a/packages/integrations/ecopages-jsx/src/test/ecopages-jsx.plugin.test.ts
+++ b/packages/integrations/ecopages-jsx/src/test/ecopages-jsx.plugin.test.ts
@@ -7,6 +7,7 @@ import remarkGfm from 'remark-gfm';
 import { VFile, type Compatible as VFileCompatible } from 'vfile';
 import { EcopagesJsxPlugin, ecopagesJsxPlugin } from '../ecopages-jsx.plugin.ts';
 import { resolveMdxCompilerOptions } from '../ecopages-jsx-mdx.ts';
+import { RADIANT_INSTALL_HYDRATOR_FILEPATH } from '../resolve-radiant-install-hydrator.ts';
 
 function getMdxLoaderFilter(plugin: EcoBuildPlugin): RegExp {
 	let capturedFilter: RegExp | undefined;
@@ -67,14 +68,14 @@ test('EcopagesJsxPlugin supports direct construction with MDX public options', (
 test('EcopagesJsxPlugin installs the explicit Radiant hydrator bootstrap when Radiant SSR is enabled', () => {
 	const plugin = new EcopagesJsxPlugin();
 	const dependency = (plugin as any).integrationDependencies.find(
-		(asset: NodeModuleScriptAsset) => asset.importPath === '@ecopages/radiant/client/install-hydrator',
+		(asset: NodeModuleScriptAsset) => asset.importPath === RADIANT_INSTALL_HYDRATOR_FILEPATH,
 	);
 
 	assert.deepEqual(dependency, {
 		kind: 'script',
 		source: 'node-module',
 		position: 'head',
-		importPath: '@ecopages/radiant/client/install-hydrator',
+		importPath: RADIANT_INSTALL_HYDRATOR_FILEPATH,
 		bundle: false,
 		attributes: {
 			'data-eco-script-id': 'ecopages-jsx-radiant-hydrator',
@@ -85,7 +86,7 @@ test('EcopagesJsxPlugin installs the explicit Radiant hydrator bootstrap when Ra
 test('EcopagesJsxPlugin skips the explicit Radiant hydrator bootstrap when Radiant SSR is disabled', () => {
 	const plugin = new EcopagesJsxPlugin({ radiant: false });
 	const dependency = (plugin as any).integrationDependencies.find(
-		(asset: NodeModuleScriptAsset) => asset.importPath === '@ecopages/radiant/client/install-hydrator',
+		(asset: NodeModuleScriptAsset) => asset.importPath === RADIANT_INSTALL_HYDRATOR_FILEPATH,
 	);
 
 	assert.equal(dependency, undefined);


### PR DESCRIPTION
## Summary
- Resolves the Radiant client hydrator from the ecopages-jsx integration package instead of relying on fragile app-relative paths.
- Adds render-tree HMR ownership so docs dev can hot-reload JSX pages without losing Radiant custom-element state.
- Guards light-DOM shim installation when the shim is unavailable (e.g. unit tests with mocked runtime modules).

## Test plan
- [ ] `pnpm --filter @ecopages/ecopages-jsx test`
- [ ] `pnpm --dir apps/docs dev` — verify CodeTabs and other Radiant elements hydrate on first load