### PR TITLE
feat(docs-kit): add defineDocsKit with injectable content modules

### DIFF
--- a/apps/docs/src/lib/docs-kit/chrome-events.ts
+++ b/apps/docs/src/lib/docs-kit/chrome-events.ts
@@ -1,0 +1,5 @@
+/** Window event names used by the docs sidebar burger integration. */
+export const docsKitBurgerEvents = {
+	TOGGLE_MENU: 'toggle-menu',
+	CLOSE_MENU: 'close-menu',
+} as const;

--- a/apps/docs/src/lib/docs-kit/components/docs-bar/docs-bar.css
+++ b/apps/docs/src/lib/docs-kit/components/docs-bar/docs-bar.css
@@ -1,0 +1,7 @@
+.docs-bar {
+	@apply mb-4 flex min-h-8 items-center justify-between gap-4;
+}
+
+.docs-breadcrumb {
+	@apply min-w-0 flex-1;
+}

--- a/apps/docs/src/lib/docs-kit/components/docs-bar/index.tsx
+++ b/apps/docs/src/lib/docs-kit/components/docs-bar/index.tsx
@@ -1,0 +1,27 @@
+import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+import { Breadcrumb, type BreadcrumbItem } from '@/components/breadcrumb/breadcrumb';
+import { CopyForLlm } from '@/components/copy-for-llm';
+
+export type DocsBarProps = {
+	crumbs?: BreadcrumbItem[];
+	llmUrl?: string;
+	label?: string;
+};
+
+export const DocsBar = eco.component<DocsBarProps, JsxRenderable>({
+	dependencies: {
+		components: [Breadcrumb, CopyForLlm],
+		stylesheets: ['./docs-bar.css'],
+	},
+	render: ({ crumbs = [], llmUrl, label }) => {
+		return (
+			<div class="docs-bar">
+				{crumbs.length > 0 ? (
+					<Breadcrumb class="docs-breadcrumb" items={crumbs} ariaLabel="Breadcrumb" />
+				) : null}
+				{llmUrl ? <CopyForLlm llmUrl={llmUrl} label={label} /> : null}
+			</div>
+		);
+	},
+});

--- a/apps/docs/src/lib/docs-kit/config.ts
+++ b/apps/docs/src/lib/docs-kit/config.ts
@@ -1,0 +1,41 @@
+import { join } from 'node:path';
+import type { DocsSiteContent } from '@/lib/docs-kit/content/docs-site-content.types';
+import { clearDocsManifestCache } from './manifest/get-docs-manifest';
+
+export type DocsKitConfig = {
+	rootDir: string;
+	contentRoot: string;
+	content: DocsSiteContent;
+	mdxComponents: Record<string, unknown>;
+	shellLayout: unknown;
+	layoutComponents: unknown[];
+	strictImageImports?: boolean;
+};
+
+let kitConfig: DocsKitConfig | null = null;
+
+/**
+ * Registers docs-kit paths and app-specific dependencies.
+ *
+ * @remarks Call once from `docs-kit.instance.ts` before any docs-kit module runs.
+ */
+export function defineDocsKit(options: Omit<DocsKitConfig, 'contentRoot'> & { contentRoot?: string }): void {
+	kitConfig = {
+		...options,
+		contentRoot: options.contentRoot ?? join(options.rootDir, 'src/content/docs'),
+	};
+	clearDocsManifestCache();
+}
+
+export function getDocsKit(): DocsKitConfig {
+	if (!kitConfig) {
+		throw new Error('Docs kit is not configured. Import docs-kit.instance.ts before using docs-kit.');
+	}
+
+	return kitConfig;
+}
+
+/** Clears registered config (for tests). */
+export function clearDocsKitConfig(): void {
+	kitConfig = null;
+}

--- a/apps/docs/src/lib/docs-kit/content/content-tree.test.ts
+++ b/apps/docs/src/lib/docs-kit/content/content-tree.test.ts
@@ -1,0 +1,37 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+async function collectMdxFiles(dir: string): Promise<string[]> {
+	const entries = await readdir(dir, { withFileTypes: true });
+	const files: string[] = [];
+
+	for (const entry of entries) {
+		const fullPath = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...(await collectMdxFiles(fullPath)));
+		} else if (entry.isFile() && entry.name.endsWith('.mdx')) {
+			files.push(fullPath);
+		}
+	}
+
+	return files;
+}
+
+describe('content tree', () => {
+	test('every content/docs MDX file is ceremony-free', async () => {
+		const contentDir = join(import.meta.dirname, '../../../content/docs');
+		const files = await collectMdxFiles(contentDir);
+
+		expect(files.length).toBeGreaterThanOrEqual(43);
+
+		for (const file of files) {
+			const source = await readFile(file, 'utf8');
+			const preamble = source.split('\n').slice(0, 20).join('\n');
+
+			expect(preamble, `${file} should not retain DocsLayout import`).not.toMatch(/import \{ DocsLayout \}/);
+			expect(preamble, `${file} should not retain page config`).not.toMatch(/export const config\s*=/);
+			expect(preamble, `${file} should not retain getMetadata`).not.toMatch(/export const getMetadata\s*=/);
+		}
+	});
+});

--- a/apps/docs/src/lib/docs-kit/content/docs-site-content.types.ts
+++ b/apps/docs/src/lib/docs-kit/content/docs-site-content.types.ts
@@ -1,0 +1,36 @@
+import type { JsxRenderable } from '@ecopages/jsx';
+import type { DocsMdxComponent } from '@/lib/docs-kit/mdx/docs-mdx.types';
+
+export type DocsContentPageMeta = {
+	slug: string;
+	title: string;
+	description: string;
+	llms?: boolean;
+};
+
+export type DocsContentPage = DocsContentPageMeta & {
+	content: DocsMdxComponent;
+};
+
+export type DocsContentSectionMeta = {
+	id: string;
+	title: string;
+	icon?: JsxRenderable;
+	pages: DocsContentPageMeta[];
+};
+
+export type DocsContentSection = Omit<DocsContentSectionMeta, 'pages'> & {
+	pages: DocsContentPage[];
+};
+
+/** Navigation, metadata, and icons for the docs site (no MDX modules). */
+export type DocsSiteContentMeta = {
+	rootDir: string;
+	sections: DocsContentSectionMeta[];
+};
+
+/** Navigation, metadata, icons, and MDX modules for the docs site. */
+export type DocsSiteContent = {
+	rootDir: string;
+	sections: DocsContentSection[];
+};

--- a/apps/docs/src/lib/docs-kit/content/get-docs-content.test.ts
+++ b/apps/docs/src/lib/docs-kit/content/get-docs-content.test.ts
@@ -1,0 +1,32 @@
+import { expect, test, vi } from 'vitest';
+
+vi.mock('@/lib/docs-kit/config', () => ({
+	getDocsKit: () => ({
+		content: {
+			sections: [
+				{
+					id: 'getting-started',
+					title: 'Getting Started',
+					pages: [
+						{
+							slug: 'introduction',
+							title: 'Introduction',
+							description: 'Intro.',
+							content: () => 'content',
+						},
+					],
+				},
+			],
+		},
+	}),
+}));
+
+import { getDocsContent } from './get-docs-content';
+
+test('getDocsContent resolves imported MDX modules from site content', () => {
+	expect(getDocsContent('getting-started', 'introduction')()).toBe('content');
+});
+
+test('getDocsContent rejects unknown pages', () => {
+	expect(() => getDocsContent('missing', 'page')).toThrow(/Unknown docs page/);
+});

--- a/apps/docs/src/lib/docs-kit/content/get-docs-content.ts
+++ b/apps/docs/src/lib/docs-kit/content/get-docs-content.ts
@@ -1,0 +1,7 @@
+import { resolveDocsNavPage } from './resolve-docs-nav-page';
+import type { DocsMdxComponent } from '@/lib/docs-kit/mdx/docs-mdx.types';
+
+/** Resolves a section/slug pair to its imported MDX content module. */
+export function getDocsContent(section: string, slug: string): DocsMdxComponent {
+	return resolveDocsNavPage(section, slug).content;
+}

--- a/apps/docs/src/lib/docs-kit/content/resolve-docs-nav-page.ts
+++ b/apps/docs/src/lib/docs-kit/content/resolve-docs-nav-page.ts
@@ -1,0 +1,18 @@
+import type { DocsContentPage } from '@/lib/docs-kit/content/docs-site-content.types';
+import { getDocsKit } from '@/lib/docs-kit/config';
+
+export type ResolvedDocsNavPage = DocsContentPage & {
+	section: string;
+};
+
+/** Resolves configured content metadata for a section/slug pair. */
+export function resolveDocsNavPage(section: string, slug: string): ResolvedDocsNavPage {
+	const sectionEntry = getDocsKit().content.sections.find((entry) => entry.id === section);
+	const page = sectionEntry?.pages.find((entry) => entry.slug === slug);
+
+	if (!page) {
+		throw new Error(`Unknown docs page: ${section}/${slug}`);
+	}
+
+	return { section, ...page };
+}

--- a/apps/docs/src/lib/docs-kit/content/resolve-docs-page.ts
+++ b/apps/docs/src/lib/docs-kit/content/resolve-docs-page.ts
@@ -1,0 +1,25 @@
+import type { DocsMdxComponent } from '@/lib/docs-kit/mdx/docs-mdx.types';
+import { resolveDocsNavPage } from './resolve-docs-nav-page';
+
+export type ResolvedDocsPage = {
+	section: string;
+	slug: string;
+	title: string;
+	description: string;
+	llms?: boolean;
+	content: DocsMdxComponent;
+};
+
+/** Resolves content-tree metadata and the imported MDX module for a page. */
+export function resolveDocsPage(section: string, slug: string): ResolvedDocsPage {
+	const page = resolveDocsNavPage(section, slug);
+
+	return {
+		section,
+		slug,
+		title: page.title,
+		description: page.description,
+		llms: page.llms,
+		content: page.content,
+	};
+}

--- a/apps/docs/src/lib/docs-kit/layout/docs-layout/components/docs-pagination/docs-pagination.script.tsx
+++ b/apps/docs/src/lib/docs-kit/layout/docs-layout/components/docs-pagination/docs-pagination.script.tsx
@@ -1,0 +1,99 @@
+import { RadiantElement } from '@ecopages/radiant/core/radiant-element';
+import { customElement } from '@ecopages/radiant/decorators/custom-element';
+import { onEvent } from '@ecopages/radiant/decorators/on-event';
+import { state } from '@ecopages/radiant/decorators/state';
+import type { JsxCustomElementAttributes } from '@ecopages/jsx';
+
+type PaginationLink = {
+	href: string;
+	title: string;
+};
+
+type ManifestData = {
+	pages: Array<{
+		href: string;
+		title: string;
+	}>;
+};
+
+function readManifestPages(): ManifestData['pages'] {
+	const node = document.getElementById('docs-manifest-data');
+	if (!node?.textContent) {
+		return [];
+	}
+
+	try {
+		const parsed = JSON.parse(node.textContent) as ManifestData;
+		return parsed.pages ?? [];
+	} catch {
+		return [];
+	}
+}
+
+@customElement('radiant-docs-pagination')
+export class RadiantDocsPagination extends RadiantElement {
+	@state prevLink: PaginationLink | null = null;
+	@state nextLink: PaginationLink | null = null;
+
+	override connectedCallback(): void {
+		super.connectedCallback();
+		this.renderPagination();
+	}
+
+	@onEvent({ document: true, type: 'eco:page-load' })
+	onPageLoad(): void {
+		this.renderPagination();
+	}
+
+	@onEvent({ document: true, type: 'eco:after-swap' })
+	onAfterSwap(): void {
+		this.renderPagination();
+	}
+
+	renderPagination(): void {
+		const pages = readManifestPages();
+		const currentPath = window.location.pathname;
+		const currentIndex = pages.findIndex((page) => page.href === currentPath);
+		if (currentIndex === -1) {
+			this.prevLink = null;
+			this.nextLink = null;
+			return;
+		}
+
+		const prevPage = currentIndex > 0 ? pages[currentIndex - 1] : null;
+		const nextPage = currentIndex < pages.length - 1 ? pages[currentIndex + 1] : null;
+		this.prevLink = prevPage ? { href: prevPage.href, title: prevPage.title } : null;
+		this.nextLink = nextPage ? { href: nextPage.href, title: nextPage.title } : null;
+	}
+
+	override render() {
+		if (!this.prevLink && !this.nextLink) {
+			return null;
+		}
+
+		return (
+			<>
+				{this.prevLink ? (
+					<a href={this.prevLink.href} class="group prev">
+						<span class="pagination-label">Previous</span>
+						<span class="pagination-title">{this.prevLink.title}</span>
+					</a>
+				) : (
+					<div></div>
+				)}
+				{this.nextLink ? (
+					<a href={this.nextLink.href} class="group next">
+						<span class="pagination-label">Next</span>
+						<span class="pagination-title">{this.nextLink.title}</span>
+					</a>
+				) : null}
+			</>
+		);
+	}
+}
+
+declare module '@ecopages/jsx' {
+	interface JsxCustomIntrinsicElements {
+		'radiant-docs-pagination': JsxCustomElementAttributes<RadiantDocsPagination>;
+	}
+}

--- a/apps/docs/src/lib/docs-kit/layout/docs-layout/components/docs-pagination/docs-pagination.test.browser.ts
+++ b/apps/docs/src/lib/docs-kit/layout/docs-layout/components/docs-pagination/docs-pagination.test.browser.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
+import { RadiantDocsPagination } from './docs-pagination.script';
+
+function resetDom(): void {
+	document.body.innerHTML = '';
+	window.history.replaceState({}, '', '/');
+}
+
+function createManifestData(paths: string[]): void {
+	const script = document.createElement('script');
+	script.id = 'docs-manifest-data';
+	script.type = 'application/json';
+	script.textContent = JSON.stringify({
+		pages: paths.map((href) => ({
+			href,
+			title: href.split('/').filter(Boolean).join(' ') || 'home',
+		})),
+	});
+	document.body.appendChild(script);
+}
+
+describe('RadiantDocsPagination', () => {
+	beforeEach(() => {
+		resetDom();
+	});
+
+	afterEach(() => {
+		resetDom();
+		vi.restoreAllMocks();
+	});
+
+	it('renders previous and next links around the active docs page', async () => {
+		createManifestData(['/docs/start', '/docs/current', '/docs/next']);
+		window.history.replaceState({}, '', '/docs/current');
+
+		const pagination = document.createElement('radiant-docs-pagination') as RadiantDocsPagination;
+		document.body.appendChild(pagination);
+
+		await vi.waitFor(() => {
+			expect(pagination.querySelector('a.prev')?.getAttribute('href')).toBe('/docs/start');
+			expect(pagination.querySelector('a.next')?.getAttribute('href')).toBe('/docs/next');
+		});
+		expect(pagination.textContent).toContain('Previous');
+		expect(pagination.textContent).toContain('Next');
+	});
+
+	it('recomputes pagination links after an after-swap update', async () => {
+		createManifestData(['/docs/start', '/docs/current', '/docs/next']);
+		window.history.replaceState({}, '', '/docs/start');
+
+		const pagination = document.createElement('radiant-docs-pagination') as RadiantDocsPagination;
+		document.body.appendChild(pagination);
+
+		await vi.waitFor(() => {
+			expect(pagination.querySelector('a.prev')).toBeNull();
+			expect(pagination.querySelector('a.next')?.getAttribute('href')).toBe('/docs/current');
+		});
+
+		window.history.replaceState({}, '', '/docs/current');
+		document.dispatchEvent(new CustomEvent('eco:after-swap'));
+
+		await vi.waitFor(() => {
+			expect(pagination.querySelector('a.prev')?.getAttribute('href')).toBe('/docs/start');
+			expect(pagination.querySelector('a.next')?.getAttribute('href')).toBe('/docs/next');
+		});
+	});
+});

--- a/apps/docs/src/lib/docs-kit/layout/docs-layout/components/docs-pagination/index.tsx
+++ b/apps/docs/src/lib/docs-kit/layout/docs-layout/components/docs-pagination/index.tsx
@@ -1,0 +1,12 @@
+import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+import './docs-pagination.script';
+
+export const DocsPagination = eco.component<Record<string, never>, JsxRenderable>({
+	dependencies: {
+		scripts: ['./docs-pagination.script.tsx'],
+	},
+	render: () => {
+		return <radiant-docs-pagination class="docs-layout__pagination" />;
+	},
+});

--- a/apps/docs/src/lib/docs-kit/layout/docs-layout/components/navigation/index.tsx
+++ b/apps/docs/src/lib/docs-kit/layout/docs-layout/components/navigation/index.tsx
@@ -1,0 +1,55 @@
+import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+import '@/docs-kit.instance';
+import { getDocsKit } from '@/lib/docs-kit/config';
+import './navigation.script';
+
+const DocsNavigation = () => {
+	const { content } = getDocsKit();
+
+	return (
+		<nav aria-label="Main Navigation">
+			<ul class="docs-layout__nav-list">
+				{content.sections.map((group, index) => (
+					<li>
+						{index > 0 ? <div class="docs-layout__nav-separator" role="presentation" /> : null}
+						<div class="docs-layout__nav-group">
+							<span class="docs-layout__nav-group-icon">{group.icon ?? null}</span>
+							<span safe>{group.title}</span>
+						</div>
+						<ul class="docs-layout__nav-group-list">
+							{group.pages.map((page) => {
+								const href = `${content.rootDir}/${group.id}/${page.slug}`;
+
+								return (
+									<li>
+										<a href={href} data-nav-link data-testid={`docs-nav-link:${href}`} safe>
+											{page.title}
+										</a>
+									</li>
+								);
+							})}
+						</ul>
+					</li>
+				))}
+			</ul>
+		</nav>
+	);
+};
+
+export const DocsSidebar = eco.component<Record<string, never>, JsxRenderable>({
+	dependencies: {
+		scripts: ['./navigation.script.ts'],
+	},
+	render: () => {
+		return (
+			<radiant-navigation
+				class="docs-layout__aside hidden md:block"
+				data-eco-persist="docs-sidebar"
+				data-testid="docs-sidebar"
+			>
+				<DocsNavigation />
+			</radiant-navigation>
+		);
+	},
+});

--- a/apps/docs/src/lib/docs-kit/layout/docs-layout/components/navigation/navigation.script.ts
+++ b/apps/docs/src/lib/docs-kit/layout/docs-layout/components/navigation/navigation.script.ts
@@ -1,0 +1,61 @@
+import { RadiantElement } from '@ecopages/radiant/core/radiant-element';
+import { customElement } from '@ecopages/radiant/decorators/custom-element';
+import { onEvent } from '@ecopages/radiant/decorators/on-event';
+import type { JsxCustomElementAttributes } from '@ecopages/jsx';
+import { docsKitBurgerEvents } from '../../../../chrome-events';
+
+@customElement('radiant-navigation')
+export class RadiantNavigation extends RadiantElement {
+	override connectedCallback(): void {
+		super.connectedCallback();
+		this.highlightActiveLink({ scrollToActiveLink: true });
+	}
+
+	@onEvent({ document: true, type: 'eco:page-load' })
+	onPageLoad(): void {
+		this.highlightActiveLink();
+	}
+
+	@onEvent({ document: true, type: 'eco:after-swap' })
+	onAfterSwap(): void {
+		this.highlightActiveLink();
+	}
+
+	@onEvent({ window: true, type: 'popstate' })
+	onPopState(): void {
+		this.highlightActiveLink();
+	}
+
+	highlightActiveLink(options?: { scrollToActiveLink?: boolean }): void {
+		const links = this.querySelectorAll<HTMLAnchorElement>('[data-nav-link]');
+		const currentPath = window.location.pathname;
+		const shouldScroll = options?.scrollToActiveLink ?? false;
+
+		links.forEach((link) => {
+			if (link.pathname === currentPath) {
+				link.classList.add('active');
+				if (shouldScroll) {
+					link.scrollIntoView({ block: 'nearest' });
+				}
+			} else {
+				link.classList.remove('active');
+			}
+		});
+	}
+
+	@onEvent({ window: true, type: docsKitBurgerEvents.TOGGLE_MENU })
+	toggleNavigation(): void {
+		this.classList.toggle('hidden');
+	}
+
+	@onEvent({ window: true, type: docsKitBurgerEvents.CLOSE_MENU })
+	closeNavigation(): void {
+		this.classList.add('hidden');
+	}
+}
+
+declare module '@ecopages/jsx' {
+	interface JsxCustomIntrinsicElements {
+		'radiant-navigation': JsxCustomElementAttributes<RadiantNavigation>;
+	}
+}

--- a/apps/docs/src/lib/docs-kit/layout/docs-layout/components/navigation/navigation.test.browser.ts
+++ b/apps/docs/src/lib/docs-kit/layout/docs-layout/components/navigation/navigation.test.browser.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { docsKitBurgerEvents } from '../../../../chrome-events';
+import { RadiantNavigation } from './navigation.script';
+
+function resetDom(): void {
+	document.body.innerHTML = '';
+	window.history.replaceState({}, '', '/');
+}
+
+function createNavigation(paths: string[]): RadiantNavigation {
+	const navigation = document.createElement('radiant-navigation') as RadiantNavigation;
+	navigation.className = 'hidden';
+
+	for (const path of paths) {
+		const link = document.createElement('a');
+		link.setAttribute('data-nav-link', '');
+		link.href = path;
+		link.textContent = path;
+		navigation.appendChild(link);
+	}
+
+	document.body.appendChild(navigation);
+	return navigation;
+}
+
+function createNavigationElement(paths: string[]): RadiantNavigation {
+	const navigation = document.createElement('radiant-navigation') as RadiantNavigation;
+	navigation.className = 'hidden';
+
+	for (const path of paths) {
+		const link = document.createElement('a');
+		link.setAttribute('data-nav-link', '');
+		link.href = path;
+		link.textContent = path;
+		navigation.appendChild(link);
+	}
+
+	return navigation;
+}
+
+describe('RadiantNavigation', () => {
+	beforeEach(() => {
+		resetDom();
+	});
+
+	afterEach(() => {
+		resetDom();
+		vi.restoreAllMocks();
+	});
+
+	it('marks the active link and scrolls it into view on first connect', async () => {
+		window.history.replaceState({}, '', '/docs/current');
+		const navigation = createNavigationElement(['/docs/start', '/docs/current', '/docs/next']);
+		const currentLink = navigation.querySelectorAll<HTMLAnchorElement>('[data-nav-link]')[1];
+		const scrollIntoViewSpy = vi.fn();
+		Object.defineProperty(currentLink, 'scrollIntoView', {
+			configurable: true,
+			value: scrollIntoViewSpy,
+		});
+		document.body.appendChild(navigation);
+
+		await vi.waitFor(() => {
+			expect(currentLink?.classList.contains('active')).toBe(true);
+		});
+		expect(navigation.querySelector('[href="/docs/start"]')?.classList.contains('active')).toBe(false);
+		expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: 'nearest' });
+	});
+
+	it('updates the active link after navigation and responds to burger events', async () => {
+		window.history.replaceState({}, '', '/docs/start');
+		const navigation = createNavigation(['/docs/start', '/docs/current', '/docs/next']);
+
+		await vi.waitFor(() => {
+			expect(navigation.querySelector('[href="/docs/start"]')?.classList.contains('active')).toBe(true);
+		});
+
+		window.history.replaceState({}, '', '/docs/current');
+		document.dispatchEvent(new CustomEvent('eco:after-swap'));
+
+		await vi.waitFor(() => {
+			expect(navigation.querySelector('[href="/docs/current"]')?.classList.contains('active')).toBe(true);
+		});
+		expect(navigation.querySelector('[href="/docs/start"]')?.classList.contains('active')).toBe(false);
+
+		window.dispatchEvent(new CustomEvent(docsKitBurgerEvents.TOGGLE_MENU));
+		expect(navigation.classList.contains('hidden')).toBe(false);
+
+		window.dispatchEvent(new CustomEvent(docsKitBurgerEvents.CLOSE_MENU));
+		expect(navigation.classList.contains('hidden')).toBe(true);
+	});
+
+	it('updates the active link after browser history navigation', async () => {
+		window.history.replaceState({}, '', '/docs/start');
+		const navigation = createNavigation(['/docs/start', '/docs/current', '/docs/next']);
+
+		await vi.waitFor(() => {
+			expect(navigation.querySelector('[href="/docs/start"]')?.classList.contains('active')).toBe(true);
+		});
+
+		window.history.replaceState({}, '', '/docs/current');
+		window.dispatchEvent(new PopStateEvent('popstate'));
+
+		await vi.waitFor(() => {
+			expect(navigation.querySelector('[href="/docs/current"]')?.classList.contains('active')).toBe(true);
+		});
+		expect(navigation.querySelector('[href="/docs/start"]')?.classList.contains('active')).toBe(false);
+	});
+});

--- a/apps/docs/src/lib/docs-kit/layout/docs-layout/components/toc/index.tsx
+++ b/apps/docs/src/lib/docs-kit/layout/docs-layout/components/toc/index.tsx
@@ -1,0 +1,12 @@
+import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+import './toc.script';
+
+export const DocsToc = eco.component<Record<string, never>, JsxRenderable>({
+	dependencies: {
+		scripts: ['./toc.script.tsx'],
+	},
+	render: () => {
+		return <radiant-toc class="docs-layout__toc" />;
+	},
+});

--- a/apps/docs/src/lib/docs-kit/layout/docs-layout/components/toc/toc.script.tsx
+++ b/apps/docs/src/lib/docs-kit/layout/docs-layout/components/toc/toc.script.tsx
@@ -1,0 +1,260 @@
+import { RadiantElement } from '@ecopages/radiant/core/radiant-element';
+import { customElement } from '@ecopages/radiant/decorators/custom-element';
+import { onEvent } from '@ecopages/radiant/decorators/on-event';
+import { state } from '@ecopages/radiant/decorators/state';
+import type { JsxCustomElementAttributes } from '@ecopages/jsx';
+
+type TocItem = {
+	id: string;
+	label: string;
+	depth: 2 | 3;
+};
+
+@customElement('radiant-toc')
+export class RadiantToc extends RadiantElement {
+	@state tocItems: TocItem[] = [];
+	@state activeHeadingId = '';
+
+	private cleanupScrollTracking: (() => void) | null = null;
+	private pendingScrollTargetId: string | null = null;
+	private readonly scrollOffset = 120;
+	private readonly scrollOffsetTolerance = 4;
+	private headings: HTMLElement[] = [];
+
+	override connectedCallback(): void {
+		super.connectedCallback();
+		this.renderToc();
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+		this.cleanupScrollTracking?.();
+		this.cleanupScrollTracking = null;
+	}
+
+	@onEvent({ document: true, type: 'eco:page-load' })
+	onPageLoad(): void {
+		this.renderToc();
+	}
+
+	@onEvent({ document: true, type: 'eco:after-swap' })
+	onAfterSwap(): void {
+		this.renderToc();
+	}
+
+	renderToc(): void {
+		const content = document.querySelector('.docs-layout__content');
+		if (!content) {
+			this.tocItems = [];
+			this.activeHeadingId = '';
+			return;
+		}
+
+		const headings = Array.from(content.querySelectorAll<HTMLElement>('h2, h3'));
+		if (headings.length === 0) {
+			this.cleanupScrollTracking?.();
+			this.cleanupScrollTracking = null;
+			this.headings = [];
+			this.pendingScrollTargetId = null;
+			this.tocItems = [];
+			this.activeHeadingId = '';
+			return;
+		}
+
+		const usedHeadingIds = new Set<string>();
+		this.headings = headings;
+		this.tocItems = headings.map((heading) => {
+			const id = this.getUniqueHeadingId(heading, usedHeadingIds);
+			heading.id = id;
+			return {
+				id,
+				label: (heading.textContent || '').trim(),
+				depth: heading.tagName.toLowerCase() === 'h3' ? 3 : 2,
+			};
+		});
+		this.setupObserver(headings);
+	}
+
+	private getUniqueHeadingId(heading: HTMLElement, usedHeadingIds: Set<string>): string {
+		const requestedId = heading.id.trim();
+		const baseId = requestedId || this.slugifyHeadingLabel(heading.textContent || 'section');
+		let candidateId = baseId || 'section';
+		let suffix = 2;
+
+		while (usedHeadingIds.has(candidateId)) {
+			candidateId = `${baseId || 'section'}-${String(suffix)}`;
+			suffix += 1;
+		}
+
+		usedHeadingIds.add(candidateId);
+		return candidateId;
+	}
+
+	private slugifyHeadingLabel(value: string): string {
+		return (
+			value
+				.trim()
+				.toLowerCase()
+				.replace(/\s+/g, '-')
+				.replace(/[^\w-]/g, '')
+				.replace(/-+/g, '-')
+				.replace(/^-|-$/g, '') || 'section'
+		);
+	}
+
+	private scrollToHeading(id: string, heading: HTMLElement): void {
+		const behavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
+
+		window.history.replaceState(
+			window.history.state,
+			'',
+			`${window.location.pathname}${window.location.search}#${id}`,
+		);
+		heading.scrollIntoView({ behavior, block: 'start' });
+	}
+
+	private hasPendingScrollReachedTarget(heading: HTMLElement): boolean {
+		const headingTop = heading.getBoundingClientRect().top;
+		return (
+			headingTop <= this.scrollOffset + this.scrollOffsetTolerance && headingTop >= -this.scrollOffsetTolerance
+		);
+	}
+
+	private findHeadingById(id: string): HTMLElement | null {
+		return this.headings.find((heading) => heading.id === id) ?? null;
+	}
+
+	private setActiveHeading(id: string): void {
+		if (this.activeHeadingId === id) {
+			return;
+		}
+
+		this.activeHeadingId = id;
+	}
+
+	private readonly handleTocClick = (
+		event: PointerEvent & { readonly currentTarget: HTMLAnchorElement },
+		id: string,
+	) => {
+		if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
+			return;
+		}
+
+		const heading = this.findHeadingById(id);
+		if (!heading) {
+			return;
+		}
+
+		event.preventDefault();
+		this.pendingScrollTargetId = id;
+		this.setActiveHeading(id);
+		this.scrollToHeading(id, heading);
+	};
+
+	private readonly getTocClickHandler = (id: string) => {
+		return {
+			handleEvent: (event: PointerEvent & { readonly currentTarget: HTMLAnchorElement }) => {
+				this.handleTocClick(event, id);
+			},
+		};
+	};
+
+	setupObserver(headings: HTMLElement[]): void {
+		this.cleanupScrollTracking?.();
+		this.cleanupScrollTracking = null;
+		let rafPending = false;
+
+		const updateActive = () => {
+			if (headings.length === 0) return;
+
+			const isAtBottom = window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 10;
+
+			if (this.pendingScrollTargetId) {
+				const pendingHeading = this.findHeadingById(this.pendingScrollTargetId);
+				if (!pendingHeading) {
+					this.pendingScrollTargetId = null;
+				} else if (!this.hasPendingScrollReachedTarget(pendingHeading)) {
+					this.setActiveHeading(this.pendingScrollTargetId);
+					return;
+				} else {
+					this.pendingScrollTargetId = null;
+				}
+			}
+
+			if (isAtBottom) {
+				const lastId = headings[headings.length - 1]?.id;
+				if (lastId) {
+					this.setActiveHeading(lastId);
+				}
+				return;
+			}
+
+			let activeId: string | null = null;
+			for (const heading of headings) {
+				if (heading.getBoundingClientRect().top <= this.scrollOffset + this.scrollOffsetTolerance) {
+					activeId = heading.id;
+				} else {
+					break;
+				}
+			}
+
+			if (activeId) {
+				this.setActiveHeading(activeId);
+			}
+		};
+
+		const onScroll = () => {
+			if (rafPending) return;
+			rafPending = true;
+			requestAnimationFrame(() => {
+				updateActive();
+				rafPending = false;
+			});
+		};
+
+		window.addEventListener('scroll', onScroll, { passive: true });
+		this.cleanupScrollTracking = () => {
+			window.removeEventListener('scroll', onScroll);
+		};
+		updateActive();
+	}
+
+	override render() {
+		if (this.tocItems.length === 0) {
+			return null;
+		}
+
+		return (
+			<>
+				<h3>On this page</h3>
+				<ul>
+					{this.tocItems.map((item) => {
+						const isActive = item.id === this.activeHeadingId;
+						const className = [item.depth === 3 ? 'toc-depth-3' : '', isActive ? 'toc-active' : '']
+							.filter(Boolean)
+							.join(' ');
+						return (
+							<li key={item.id}>
+								<a
+									href={`#${item.id}`}
+									data-toc-link={item.id}
+									class={className || undefined}
+									aria-current={isActive ? 'location' : undefined}
+									on:click={this.getTocClickHandler(item.id)}
+								>
+									{item.label}
+								</a>
+							</li>
+						);
+					})}
+				</ul>
+			</>
+		);
+	}
+}
+
+declare module '@ecopages/jsx' {
+	interface JsxCustomIntrinsicElements {
+		'radiant-toc': JsxCustomElementAttributes<RadiantToc>;
+	}
+}

--- a/apps/docs/src/lib/docs-kit/layout/docs-layout/components/toc/toc.test.browser.ts
+++ b/apps/docs/src/lib/docs-kit/layout/docs-layout/components/toc/toc.test.browser.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { RadiantToc } from './toc.script';
+
+type RectInit = Pick<DOMRect, 'top' | 'bottom' | 'left' | 'right' | 'width' | 'height' | 'x' | 'y'>;
+
+function resetDom(): void {
+	document.body.innerHTML = '';
+	window.history.replaceState({}, '', '/docs/page');
+}
+
+function createRect(overrides: Partial<RectInit>): DOMRect {
+	const rect = {
+		top: 0,
+		bottom: 0,
+		left: 0,
+		right: 0,
+		width: 0,
+		height: 0,
+		x: 0,
+		y: 0,
+		...overrides,
+	};
+	return {
+		...rect,
+		toJSON: () => rect,
+	} as DOMRect;
+}
+
+function setHeadingTop(element: HTMLElement, top: number): void {
+	Object.defineProperty(element, 'getBoundingClientRect', {
+		configurable: true,
+		value: () => createRect({ top, bottom: top + 40, height: 40 }),
+	});
+}
+
+function createDocsContent(): { content: HTMLElement; headings: HTMLElement[] } {
+	const content = document.createElement('main');
+	content.className = 'docs-layout__content';
+	content.innerHTML = `
+		<h2>Introduction</h2>
+		<h3>When to Use</h3>
+		<h3>When to Use</h3>
+		<h2>Installation</h2>
+	`;
+	document.body.appendChild(content);
+	return {
+		content,
+		headings: Array.from(content.querySelectorAll<HTMLElement>('h2, h3')),
+	};
+}
+
+describe('RadiantToc', () => {
+	beforeEach(() => {
+		resetDom();
+		Object.defineProperty(window, 'matchMedia', {
+			configurable: true,
+			value: vi.fn().mockReturnValue({ matches: false, addEventListener() {}, removeEventListener() {} }),
+		});
+		Object.defineProperty(window, 'scrollY', { configurable: true, value: 0, writable: true });
+		Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800, writable: true });
+		Object.defineProperty(document.documentElement, 'scrollHeight', {
+			configurable: true,
+			value: 2400,
+			writable: true,
+		});
+	});
+
+	afterEach(() => {
+		resetDom();
+		vi.restoreAllMocks();
+	});
+
+	it('renders unique anchor targets for repeated headings', async () => {
+		const { headings } = createDocsContent();
+		setHeadingTop(headings[0], 80);
+		setHeadingTop(headings[1], 160);
+		setHeadingTop(headings[2], 240);
+		setHeadingTop(headings[3], 320);
+
+		const toc = document.createElement('radiant-toc') as RadiantToc;
+		document.body.appendChild(toc);
+
+		await vi.waitFor(() => {
+			const links = Array.from(toc.querySelectorAll<HTMLAnchorElement>('a[data-toc-link]'));
+			expect(links.map((link) => link.getAttribute('data-toc-link'))).toEqual([
+				'introduction',
+				'when-to-use',
+				'when-to-use-2',
+				'installation',
+			]);
+		});
+		expect(headings[1]?.id).toBe('when-to-use');
+		expect(headings[2]?.id).toBe('when-to-use-2');
+		expect(toc.querySelector('a[data-toc-link="when-to-use-2"]')?.classList.contains('toc-depth-3')).toBe(true);
+	});
+
+	it('keeps the clicked heading active until the pending scroll target is reached', async () => {
+		const user = userEvent.setup();
+		const { headings } = createDocsContent();
+		setHeadingTop(headings[0], 80);
+		setHeadingTop(headings[1], 160);
+		setHeadingTop(headings[2], 240);
+		setHeadingTop(headings[3], 360);
+		const scrollIntoViewSpy = vi.fn();
+		Object.defineProperty(headings[3], 'scrollIntoView', {
+			configurable: true,
+			value: scrollIntoViewSpy,
+		});
+
+		const toc = document.createElement('radiant-toc') as RadiantToc;
+		document.body.appendChild(toc);
+
+		await vi.waitFor(() => {
+			expect(toc.querySelector('a.toc-active')?.getAttribute('data-toc-link')).toBe('introduction');
+		});
+
+		const installationLink = toc.querySelector<HTMLAnchorElement>('a[data-toc-link="installation"]');
+		expect(installationLink).not.toBeNull();
+
+		await user.click(installationLink!);
+		window.dispatchEvent(new Event('scroll'));
+
+		await vi.waitFor(() => {
+			expect(toc.querySelector('a.toc-active')?.getAttribute('data-toc-link')).toBe('installation');
+		});
+		expect(toc.querySelector('a[data-toc-link="installation"]')?.getAttribute('aria-current')).toBe('location');
+		expect(window.location.hash).toBe('#installation');
+		expect(scrollIntoViewSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+	});
+
+	it('keeps the clicked heading active when the page starts at the bottom', async () => {
+		const user = userEvent.setup();
+		const { headings } = createDocsContent();
+		setHeadingTop(headings[0], -720);
+		setHeadingTop(headings[1], -640);
+		setHeadingTop(headings[2], -560);
+		setHeadingTop(headings[3], -480);
+		Object.defineProperty(window, 'scrollY', { configurable: true, value: 1600, writable: true });
+		const scrollIntoViewSpy = vi.fn();
+		Object.defineProperty(headings[3], 'scrollIntoView', {
+			configurable: true,
+			value: scrollIntoViewSpy,
+		});
+
+		const toc = document.createElement('radiant-toc') as RadiantToc;
+		document.body.appendChild(toc);
+
+		await vi.waitFor(() => {
+			expect(toc.querySelector('a.toc-active')?.getAttribute('data-toc-link')).toBe('installation');
+		});
+
+		const introductionLink = toc.querySelector<HTMLAnchorElement>('a[data-toc-link="introduction"]');
+		expect(introductionLink).not.toBeNull();
+
+		await user.click(introductionLink!);
+		window.dispatchEvent(new Event('scroll'));
+
+		await vi.waitFor(() => {
+			expect(toc.querySelector('a.toc-active')?.getAttribute('data-toc-link')).toBe('introduction');
+		});
+		expect(window.location.hash).toBe('#introduction');
+		expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+	});
+});

--- a/apps/docs/src/lib/docs-kit/layout/docs-layout/docs-layout.css
+++ b/apps/docs/src/lib/docs-kit/layout/docs-layout/docs-layout.css
@@ -1,0 +1,107 @@
+.docs-layout {
+	@apply md:grid md:grid-cols-[250px_1fr] xl:grid-cols-[250px_minmax(0,1fr)_250px] xl:max-w-7xl xl:mx-auto min-h-screen relative;
+
+	.docs-layout__aside {
+		@apply fixed inset-0 z-40 md:z-0 md:relative md:block;
+		@apply h-svh md:h-[calc(100svh_-_4rem)] md:sticky md:top-16 overflow-y-auto;
+		@apply bg-background/90 md:bg-transparent backdrop-blur-md md:backdrop-blur-none border-r border-border/60;
+
+		nav {
+			@apply p-6 pt-20 md:p-8;
+		}
+
+		ul {
+			@apply list-none p-0 m-0;
+		}
+
+		.docs-layout__nav-group {
+			@apply flex items-center mb-1.5 mt-8 first:mt-0 font-mono gap-1.5;
+			@apply text-sm font-semibold uppercase tracking-widest text-on-background/50;
+
+			&-icon {
+				@apply text-on-background/40 w-3 h-3 flex items-center justify-center;
+			}
+		}
+
+		.docs-layout__nav-separator {
+			@apply h-px bg-border/40 my-4 mx-2;
+		}
+
+		.docs-layout__nav-group-list {
+			@apply space-y-px mb-6 border-l border-border/30 ml-1.5 pl-3;
+
+			li a {
+				@apply flex items-center px-2 py-1.5 rounded-sm text-sm transition-colors duration-200 font-sans relative;
+				@apply text-on-background/70 hover:text-on-background hover:bg-background-accent/80;
+				@apply no-underline font-normal;
+
+				&.active {
+					@apply text-primary font-medium bg-transparent;
+				}
+
+				&.active::before {
+					content: '';
+					@apply absolute -left-[13px] top-1/2 -translate-y-1/2 w-0.5 h-3 bg-primary rounded-r-sm;
+				}
+			}
+		}
+	}
+
+	.docs-layout__content {
+		@apply px-6 py-4 md:px-8 md:py-8 max-w-[800px] xl:max-w-none mx-auto w-full min-w-0 relative;
+	}
+
+	.docs-layout__toc {
+		@apply hidden xl:block sticky top-16 h-[calc(100svh_-_4rem)] overflow-y-auto px-6 py-8 border-l border-border/60;
+
+		h3 {
+			@apply text-sm font-semibold uppercase tracking-widest text-on-background/50 mb-3 font-mono m-0;
+		}
+
+		ul {
+			@apply list-none p-0 m-0 space-y-2 border-l border-border/30 ml-1 pl-3;
+		}
+
+		li a {
+			@apply block text-sm text-on-background/80 hover:text-on-background transition-colors duration-200 no-underline font-sans relative;
+
+			&.toc-active {
+				@apply text-primary;
+				/* text-shadow fakes bold weight without changing glyph metrics — no reflow, no line-wrap */
+				text-shadow: 0 0 0.5px currentColor;
+			}
+			&.toc-active::before {
+				content: '';
+				@apply absolute -left-[13px] top-1/2 -translate-y-1/2 w-0.5 h-3 bg-primary rounded-r-sm transition-all duration-300;
+			}
+		}
+
+		.toc-depth-3 {
+			@apply ml-3 text-sm;
+		}
+	}
+
+	.docs-layout__pagination {
+		@apply mt-16 pt-8 border-t border-border/40 flex flex-col sm:flex-row gap-4 justify-between;
+
+		a {
+			@apply flex-1 flex flex-col gap-1 p-4 rounded-lg border border-border/40 bg-background-accent/10 hover:bg-background-accent/40 hover:border-border/80 transition-all duration-200 no-underline;
+
+			.pagination-label {
+				@apply text-xs font-mono uppercase tracking-widest text-on-background/50 group-hover:text-on-background/70 transition-colors;
+			}
+
+			.pagination-title {
+				@apply text-sm font-medium text-on-background;
+			}
+
+			&.prev {
+				@apply items-start text-left;
+			}
+
+			&.next {
+				@apply items-end text-right;
+			}
+		}
+	}
+}

--- a/apps/docs/src/lib/docs-kit/layout/docs-layout/docs-layout.tsx
+++ b/apps/docs/src/lib/docs-kit/layout/docs-layout/docs-layout.tsx
@@ -1,0 +1,58 @@
+import type { LayoutProps } from '@ecopages/core';
+import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+import '@/docs-kit.instance';
+import { DocsBar } from '@/lib/docs-kit/components/docs-bar';
+import { getDocsKit } from '@/lib/docs-kit/config';
+import { getDocsLlmUrl } from '@/lib/docs-kit/llm/docs-llm-url';
+import { projectDocsManifest } from '@/lib/docs-kit/manifest/project-docs-manifest';
+import { resolveDocsBreadcrumb } from '@/lib/docs-kit/navigation/resolve-docs-breadcrumb';
+import { serializeDocsManifestData } from '@/lib/docs-kit/manifest/serialize-docs-manifest';
+import { DocsPagination } from './components/docs-pagination';
+import { DocsSidebar } from './components/navigation';
+import { DocsToc } from './components/toc';
+
+type DocsLayoutPageProps = {
+	section?: string;
+	slug?: string;
+};
+
+type DocsLayoutRenderProps = LayoutProps<JsxRenderable> & DocsLayoutPageProps;
+
+type ShellLayoutProps = {
+	class?: string;
+	showBurger?: boolean;
+	children?: JsxRenderable;
+};
+
+const { content, layoutComponents, shellLayout } = getDocsKit();
+const manifestData = serializeDocsManifestData(projectDocsManifest(content));
+const ShellLayout = shellLayout as (props: ShellLayoutProps) => JsxRenderable;
+
+export const DocsLayout = eco.layout<JsxRenderable>({
+	dependencies: {
+		stylesheets: ['./docs-layout.css'],
+		components: layoutComponents,
+	},
+	render: ({ children, section, slug }: DocsLayoutRenderProps) => {
+		const llmUrl = section && slug ? getDocsLlmUrl(section, slug) : undefined;
+		const crumbs = section && slug ? resolveDocsBreadcrumb(content, section, slug) : [];
+
+		return (
+			<ShellLayout class="docs-layout" showBurger={true}>
+				<script type="application/json" id="docs-manifest-data" safe>
+					{manifestData}
+				</script>
+				<DocsSidebar />
+				<div class="docs-layout__content">
+					<DocsBar crumbs={crumbs} llmUrl={llmUrl} />
+					<div class="prose">{children}</div>
+					<DocsPagination />
+				</div>
+				<DocsToc />
+			</ShellLayout>
+		);
+	},
+});
+
+export default DocsLayout;

--- a/apps/docs/src/lib/docs-kit/layout/docs-layout/index.ts
+++ b/apps/docs/src/lib/docs-kit/layout/docs-layout/index.ts
@@ -1,0 +1,1 @@
+export * from './docs-layout';

--- a/apps/docs/src/lib/docs-kit/layout/index.ts
+++ b/apps/docs/src/lib/docs-kit/layout/index.ts
@@ -1,0 +1,1 @@
+export { DocsLayout as default, DocsLayout } from './docs-layout/docs-layout';

--- a/apps/docs/src/lib/docs-kit/llm/docs-llm-url.test.ts
+++ b/apps/docs/src/lib/docs-kit/llm/docs-llm-url.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest';
+import { getDocsLlmUrlFromPathname } from '@/lib/docs-kit/llm/docs-llm-url';
+
+test('getDocsLlmUrlFromPathname maps docs paths to markdown URLs', () => {
+	expect(getDocsLlmUrlFromPathname('/docs/getting-started/introduction')).toBe(
+		'/docs-llm/getting-started/introduction.md',
+	);
+	expect(getDocsLlmUrlFromPathname('/docs/getting-started/introduction/')).toBe(
+		'/docs-llm/getting-started/introduction.md',
+	);
+});
+
+test('getDocsLlmUrlFromPathname returns null for non-docs paths', () => {
+	expect(getDocsLlmUrlFromPathname('/')).toBeNull();
+	expect(getDocsLlmUrlFromPathname('/docs/getting-started')).toBeNull();
+});

--- a/apps/docs/src/lib/docs-kit/llm/docs-llm-url.ts
+++ b/apps/docs/src/lib/docs-kit/llm/docs-llm-url.ts
@@ -1,0 +1,23 @@
+/**
+ * Maps a docs page pathname to the static markdown URL under `/docs-llm/*`.
+ */
+export function getDocsLlmUrlFromPathname(pathname: string): string | null {
+	const segments = pathname.replace(/\/$/, '').split('/').filter(Boolean);
+
+	if (segments[0] !== 'docs' || segments.length < 3) {
+		return null;
+	}
+
+	const section = segments[1];
+	const slug = segments[2];
+
+	if (!section || !slug) {
+		return null;
+	}
+
+	return getDocsLlmUrl(section, slug);
+}
+
+export function getDocsLlmUrl(section: string, slug: string): string {
+	return `/docs-llm/${section}/${slug}.md`;
+}

--- a/apps/docs/src/lib/docs-kit/manifest/build-docs-manifest.test.ts
+++ b/apps/docs/src/lib/docs-kit/manifest/build-docs-manifest.test.ts
@@ -1,0 +1,167 @@
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, expect, test } from 'vitest';
+import type { DocsSiteContent } from '../content/docs-site-content.types';
+import { defineDocsKit, clearDocsKitConfig } from '../config';
+import { buildDocsManifest } from './build-docs-manifest';
+import { clearDocsManifestCache } from './get-docs-manifest';
+
+const appRoot = path.resolve(import.meta.dirname, '../../../..');
+
+const testContent = {
+	rootDir: '/docs',
+	sections: [
+		{
+			id: 'getting-started',
+			title: 'Getting Started',
+			pages: [
+				{
+					slug: 'introduction',
+					title: 'Introduction',
+					description: 'Test description',
+					content: () => null,
+				},
+				{
+					slug: 'installation',
+					title: 'Installation',
+					description: 'Install Ecopages.',
+					content: () => null,
+				},
+			],
+		},
+		{
+			id: 'core',
+			title: 'Core Concepts',
+			pages: [
+				{
+					slug: 'concepts',
+					title: 'Concepts',
+					description: 'Core concepts.',
+					content: () => null,
+				},
+			],
+		},
+		{
+			id: 'llms-fixture',
+			title: 'LLM Fixture',
+			pages: [
+				{
+					slug: 'excluded',
+					title: 'Excluded',
+					description: 'Excluded from LLM exports.',
+					llms: false,
+					content: () => null,
+				},
+			],
+		},
+	],
+} satisfies DocsSiteContent;
+
+let contentRoot = join(appRoot, 'src/content/docs');
+
+beforeAll(async () => {
+	contentRoot = await mkdtemp(join(tmpdir(), 'docs-manifest-content-'));
+	const gettingStartedDir = join(contentRoot, 'getting-started');
+	const coreDir = join(contentRoot, 'core');
+	const llmsFixtureDir = join(contentRoot, 'llms-fixture');
+	await mkdir(gettingStartedDir, { recursive: true });
+	await mkdir(coreDir, { recursive: true });
+	await mkdir(llmsFixtureDir, { recursive: true });
+	await writeFile(join(gettingStartedDir, 'introduction.mdx'), '# Introduction', 'utf8');
+	await writeFile(join(gettingStartedDir, 'installation.mdx'), '# Installation', 'utf8');
+	await writeFile(join(coreDir, 'concepts.mdx'), '# Concepts', 'utf8');
+	await writeFile(join(llmsFixtureDir, 'excluded.mdx'), '# Excluded', 'utf8');
+
+	defineDocsKit({
+		rootDir: appRoot,
+		contentRoot,
+		content: testContent,
+		mdxComponents: {},
+		shellLayout: () => null,
+		layoutComponents: [],
+	});
+});
+
+afterAll(async () => {
+	clearDocsKitConfig();
+	clearDocsManifestCache();
+	await rm(contentRoot, { recursive: true, force: true });
+});
+
+test('buildDocsManifest preserves semantic section and page order', async () => {
+	const manifest = await buildDocsManifest(testContent);
+
+	expect(manifest.sections[0]?.id).toBe('getting-started');
+	expect(manifest.sections[0]?.pages[0]?.slug).toBe('introduction');
+	expect(manifest.sections[1]?.pages[0]?.slug).toBe('concepts');
+});
+
+test('buildDocsManifest carries description from content tree', async () => {
+	clearDocsManifestCache();
+	const manifest = await buildDocsManifest(testContent);
+	const introduction = manifest.sections[0]?.pages.find((page) => page.slug === 'introduction');
+
+	expect(introduction?.description).toBe('Test description');
+});
+
+test('buildDocsManifest throws when a content entry has no MDX file', async () => {
+	await expect(
+		buildDocsManifest({
+			rootDir: '/docs',
+			sections: [
+				{
+					id: 'missing',
+					title: 'Missing',
+					pages: [
+						{
+							slug: 'page',
+							title: 'Missing Page',
+							description: 'Missing page.',
+							content: () => null,
+						},
+					],
+				},
+			],
+		}),
+	).rejects.toThrow(/Docs content entry has no MDX file/);
+});
+
+test('buildDocsManifest throws when a content file is missing from site content', async () => {
+	const orphanRoot = await mkdtemp(join(tmpdir(), 'docs-content-orphan-'));
+	await mkdir(join(orphanRoot, 'getting-started'), { recursive: true });
+	await writeFile(join(orphanRoot, 'getting-started/orphan.mdx'), '# Orphan', 'utf8');
+
+	defineDocsKit({
+		rootDir: appRoot,
+		contentRoot: orphanRoot,
+		content: { rootDir: '/docs', sections: [] },
+		mdxComponents: {},
+		shellLayout: () => null,
+		layoutComponents: [],
+	});
+	clearDocsManifestCache();
+
+	await expect(buildDocsManifest()).rejects.toThrow(/Content files are not listed in docs site content/);
+
+	defineDocsKit({
+		rootDir: appRoot,
+		contentRoot,
+		content: testContent,
+		mdxComponents: {},
+		shellLayout: () => null,
+		layoutComponents: [],
+	});
+	clearDocsManifestCache();
+});
+
+test('buildDocsManifest carries llms:false from content tree', async () => {
+	clearDocsManifestCache();
+	const manifest = await buildDocsManifest(testContent);
+	const excluded = manifest.sections
+		.find((section) => section.id === 'llms-fixture')
+		?.pages.find((page) => page.slug === 'excluded');
+
+	expect(excluded?.llms).toBe(false);
+});

--- a/apps/docs/src/lib/docs-kit/manifest/build-docs-manifest.ts
+++ b/apps/docs/src/lib/docs-kit/manifest/build-docs-manifest.ts
@@ -1,0 +1,81 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { getDocsKit } from '@/lib/docs-kit/config';
+import type { DocsSiteContent } from '@/lib/docs-kit/content/docs-site-content.types';
+import type { DocsManifest, DocsManifestPage } from '@/lib/docs-kit/manifest/docs-manifest';
+import { contentPageKey, discoverContentFiles } from '@/lib/docs-kit/manifest/discover-content-files';
+import { projectDocsManifest } from '@/lib/docs-kit/manifest/project-docs-manifest';
+
+function resolveContentPath(contentRoot: string, section: string, slug: string): string {
+	return join(contentRoot, section, `${slug}.mdx`);
+}
+
+function collectConfiguredPageKeys(content: DocsSiteContent): Set<string> {
+	return new Set(
+		content.sections.flatMap((section) => section.pages.map((page) => contentPageKey(section.id, page.slug))),
+	);
+}
+
+async function assertNoOrphanContentFiles(contentRoot: string, content: DocsSiteContent): Promise<void> {
+	const discovered = await discoverContentFiles(contentRoot);
+	const configuredKeys = collectConfiguredPageKeys(content);
+	const orphans = discovered.filter((page) => !configuredKeys.has(contentPageKey(page.section, page.slug)));
+
+	if (orphans.length > 0) {
+		const listed = orphans.map((page) => contentPageKey(page.section, page.slug)).join(', ');
+		throw new Error(`Content files are not listed in docs site content: ${listed}`);
+	}
+}
+
+/**
+ * Builds the validated docs manifest from the site content tree.
+ */
+export async function buildDocsManifest(contentOverride?: DocsSiteContent): Promise<DocsManifest> {
+	const kit = getDocsKit();
+	const content = contentOverride ?? kit.content;
+	const contentRoot = kit.contentRoot;
+	const projected = projectDocsManifest(content);
+	const sections = [];
+
+	if (!contentOverride) {
+		await assertNoOrphanContentFiles(contentRoot, content);
+	}
+
+	for (const section of projected.sections) {
+		const pages: DocsManifestPage[] = [];
+
+		for (const page of section.pages) {
+			const contentPath = resolveContentPath(contentRoot, page.section, page.slug);
+
+			try {
+				await readFile(contentPath, 'utf8');
+			} catch {
+				throw new Error(`Docs content entry has no MDX file: ${contentPath}`);
+			}
+
+			pages.push({
+				section: page.section,
+				slug: page.slug,
+				title: page.title,
+				description: page.description,
+				llms: page.llms,
+			});
+		}
+
+		sections.push({
+			id: section.id,
+			title: section.title,
+			pages,
+		});
+	}
+
+	return {
+		rootDir: projected.rootDir,
+		sections,
+	};
+}
+
+export function getContentFilePath(section: string, slug: string): string {
+	const { contentRoot } = getDocsKit();
+	return resolveContentPath(contentRoot, section, slug);
+}

--- a/apps/docs/src/lib/docs-kit/manifest/discover-content-files.ts
+++ b/apps/docs/src/lib/docs-kit/manifest/discover-content-files.ts
@@ -1,0 +1,47 @@
+import { access, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export type DiscoveredContentPage = {
+	section: string;
+	slug: string;
+};
+
+/**
+ * Walks `contentRoot` and returns every `section/slug` pair for `.mdx` files.
+ */
+export async function discoverContentFiles(contentRoot: string): Promise<DiscoveredContentPage[]> {
+	try {
+		await access(contentRoot);
+	} catch {
+		throw new Error(`Docs content directory does not exist: ${contentRoot}`);
+	}
+
+	const sections = await readdir(contentRoot, { withFileTypes: true });
+	const pages: DiscoveredContentPage[] = [];
+
+	for (const sectionEntry of sections) {
+		if (!sectionEntry.isDirectory()) {
+			continue;
+		}
+
+		const sectionDir = join(contentRoot, sectionEntry.name);
+		const files = await readdir(sectionDir, { withFileTypes: true });
+
+		for (const fileEntry of files) {
+			if (!fileEntry.isFile() || !fileEntry.name.endsWith('.mdx')) {
+				continue;
+			}
+
+			pages.push({
+				section: sectionEntry.name,
+				slug: fileEntry.name.replace(/\.mdx$/, ''),
+			});
+		}
+	}
+
+	return pages;
+}
+
+export function contentPageKey(section: string, slug: string): string {
+	return `${section}/${slug}`;
+}

--- a/apps/docs/src/lib/docs-kit/manifest/docs-manifest.ts
+++ b/apps/docs/src/lib/docs-kit/manifest/docs-manifest.ts
@@ -1,0 +1,18 @@
+export type DocsManifestPage = {
+	section: string;
+	slug: string;
+	title: string;
+	description?: string;
+	llms?: boolean;
+};
+
+export type DocsManifestSection = {
+	id: string;
+	title: string;
+	pages: DocsManifestPage[];
+};
+
+export type DocsManifest = {
+	rootDir: string;
+	sections: DocsManifestSection[];
+};

--- a/apps/docs/src/lib/docs-kit/manifest/get-docs-manifest.ts
+++ b/apps/docs/src/lib/docs-kit/manifest/get-docs-manifest.ts
@@ -1,0 +1,34 @@
+import type { DocsManifest } from './docs-manifest';
+import type { DocsSiteContent } from '@/lib/docs-kit/content/docs-site-content.types';
+import { buildDocsManifest } from './build-docs-manifest';
+
+let cachedManifest: DocsManifest | null = null;
+let manifestPromise: Promise<DocsManifest> | null = null;
+
+/** Clears the cached manifest (for tests and config resets). */
+export function clearDocsManifestCache(): void {
+	cachedManifest = null;
+	manifestPromise = null;
+}
+
+/**
+ * Returns the validated docs manifest, building and caching it on first access.
+ */
+export async function getDocsManifest(nav?: DocsSiteContent): Promise<DocsManifest> {
+	if (nav) {
+		return buildDocsManifest(nav);
+	}
+
+	if (cachedManifest) {
+		return cachedManifest;
+	}
+
+	if (!manifestPromise) {
+		manifestPromise = buildDocsManifest().then((manifest) => {
+			cachedManifest = manifest;
+			return manifest;
+		});
+	}
+
+	return manifestPromise;
+}

--- a/apps/docs/src/lib/docs-kit/manifest/project-docs-manifest.ts
+++ b/apps/docs/src/lib/docs-kit/manifest/project-docs-manifest.ts
@@ -1,0 +1,20 @@
+import type { DocsSiteContent } from '@/lib/docs-kit/content/docs-site-content.types';
+import type { DocsManifest } from '@/lib/docs-kit/manifest/docs-manifest';
+
+/** Projects configured content metadata into the runtime manifest shape. */
+export function projectDocsManifest(content: DocsSiteContent): DocsManifest {
+	return {
+		rootDir: content.rootDir,
+		sections: content.sections.map((section) => ({
+			id: section.id,
+			title: section.title,
+			pages: section.pages.map((page) => ({
+				section: section.id,
+				slug: page.slug,
+				title: page.title,
+				description: page.description,
+				llms: page.llms,
+			})),
+		})),
+	};
+}

--- a/apps/docs/src/lib/docs-kit/manifest/serialize-docs-manifest.ts
+++ b/apps/docs/src/lib/docs-kit/manifest/serialize-docs-manifest.ts
@@ -1,0 +1,36 @@
+import type { DocsManifest } from '@/lib/docs-kit/manifest/docs-manifest';
+
+export type DocsManifestNavPage = {
+	href: string;
+	title: string;
+	section: string;
+	slug: string;
+};
+
+export function flattenManifestPages(manifest: DocsManifest): DocsManifestNavPage[] {
+	return manifest.sections.flatMap((section) =>
+		section.pages.map((page) => ({
+			href: `${manifest.rootDir}/${page.section}/${page.slug}`,
+			title: page.title,
+			section: page.section,
+			slug: page.slug,
+		})),
+	);
+}
+
+export function serializeDocsManifestData(manifest: DocsManifest): string {
+	return JSON.stringify({
+		rootDir: manifest.rootDir,
+		sections: manifest.sections.map((section) => ({
+			id: section.id,
+			title: section.title,
+			pages: section.pages.map((page) => ({
+				href: `${manifest.rootDir}/${page.section}/${page.slug}`,
+				title: page.title,
+				section: page.section,
+				slug: page.slug,
+			})),
+		})),
+		pages: flattenManifestPages(manifest),
+	});
+}

--- a/apps/docs/src/lib/docs-kit/mdx/docs-mdx-components.ts
+++ b/apps/docs/src/lib/docs-kit/mdx/docs-mdx-components.ts
@@ -1,0 +1,11 @@
+import { EcoImage } from '@ecopages/image-processor/component/html';
+import type { MDXComponents } from 'mdx/types.js';
+import { getDocsKit } from '@/lib/docs-kit/config';
+
+/** MDX components injected when rendering imported docs content modules. */
+export function getDocsMdxComponents(): MDXComponents {
+	return {
+		...getDocsKit().mdxComponents,
+		EcoImage,
+	};
+}

--- a/apps/docs/src/lib/docs-kit/mdx/docs-mdx.types.ts
+++ b/apps/docs/src/lib/docs-kit/mdx/docs-mdx.types.ts
@@ -1,0 +1,4 @@
+import type { EcoComponent } from '@ecopages/core';
+
+/** Imported MDX default export from the ecopages-jsx loader. */
+export type DocsMdxComponent = EcoComponent<Record<string, unknown>>;

--- a/apps/docs/src/lib/docs-kit/mdx/mdx-plugin-options.ts
+++ b/apps/docs/src/lib/docs-kit/mdx/mdx-plugin-options.ts
@@ -1,0 +1,27 @@
+import type { Pluggable } from 'unified';
+import remarkGfm from 'remark-gfm';
+import rehypePrettyCode from 'rehype-pretty-code';
+import { rehypeSimpleTableWrapper } from '@/lib/plugins/rehype-simple-table-wrapper';
+import { remarkEscapeInlineCodeHtml } from '@/lib/plugins/remark-escape-inline-code-html';
+
+const rehypePlugins = [
+	[
+		rehypePrettyCode,
+		{
+			theme: {
+				light: 'light-plus',
+				dark: 'dark-plus',
+			},
+		},
+	],
+	rehypeSimpleTableWrapper,
+] satisfies Pluggable[];
+
+/** MDX plugin options wired into `ecopagesJsxPlugin({ mdx: getDocsMdxPluginOptions() })`. */
+export function getDocsMdxPluginOptions() {
+	return {
+		enabled: true as const,
+		remarkPlugins: [remarkGfm, remarkEscapeInlineCodeHtml],
+		rehypePlugins,
+	};
+}

--- a/apps/docs/src/lib/docs-kit/navigation/resolve-docs-breadcrumb.test.ts
+++ b/apps/docs/src/lib/docs-kit/navigation/resolve-docs-breadcrumb.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'vitest';
+import { resolveDocsBreadcrumb } from './resolve-docs-breadcrumb';
+
+const sampleNav = {
+	rootDir: '/docs',
+	sections: [
+		{
+			id: 'getting-started',
+			title: 'Getting Started',
+			pages: [{ slug: 'introduction', title: 'Introduction', description: 'Intro.', content: () => null }],
+		},
+		{
+			id: 'core',
+			title: 'Core Concepts',
+			pages: [{ slug: 'hmr', title: 'HMR', description: 'Hot module replacement.', content: () => null }],
+		},
+	],
+};
+
+test('resolveDocsBreadcrumb returns docs, section, and page labels', () => {
+	const crumbs = resolveDocsBreadcrumb(sampleNav, 'core', 'hmr');
+
+	expect(crumbs).toEqual([
+		{ label: 'Docs', href: '/docs/getting-started/introduction' },
+		{ label: 'Core Concepts', href: '/docs/core/hmr' },
+		{ label: 'HMR' },
+	]);
+});
+
+test('resolveDocsBreadcrumb returns empty for unknown pages', () => {
+	expect(resolveDocsBreadcrumb(sampleNav, 'missing', 'page')).toEqual([]);
+});

--- a/apps/docs/src/lib/docs-kit/navigation/resolve-docs-breadcrumb.ts
+++ b/apps/docs/src/lib/docs-kit/navigation/resolve-docs-breadcrumb.ts
@@ -1,0 +1,27 @@
+import type { BreadcrumbItem } from '../../../components/breadcrumb/breadcrumb';
+import type { DocsSiteContent } from '../content/docs-site-content.types';
+
+/** Builds docs breadcrumb items from site content and the current page. */
+export function resolveDocsBreadcrumb(content: DocsSiteContent, section: string, slug: string): BreadcrumbItem[] {
+	const contentSection = content.sections.find((entry) => entry.id === section);
+	const page = contentSection?.pages.find((entry) => entry.slug === slug);
+
+	if (!contentSection || !page) {
+		return [];
+	}
+
+	const firstSection = content.sections[0];
+	const firstPage = firstSection?.pages[0];
+	const docsIndexHref =
+		firstSection && firstPage ? `${content.rootDir}/${firstSection.id}/${firstPage.slug}` : content.rootDir;
+	const firstSectionPage = contentSection.pages[0];
+
+	return [
+		{ label: 'Docs', href: docsIndexHref },
+		{
+			label: contentSection.title,
+			href: firstSectionPage ? `${content.rootDir}/${section}/${firstSectionPage.slug}` : undefined,
+		},
+		{ label: page.title },
+	];
+}

--- a/apps/docs/src/lib/docs-kit/navigation/resolve-from-catch-all.test.ts
+++ b/apps/docs/src/lib/docs-kit/navigation/resolve-from-catch-all.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest';
+import { resolveFromCatchAll } from './resolve-from-catch-all';
+
+test('resolveFromCatchAll maps string[] slug to section and page slug', () => {
+	expect(resolveFromCatchAll(['getting-started', 'introduction'])).toEqual({
+		section: 'getting-started',
+		slug: 'introduction',
+	});
+});
+
+test('resolveFromCatchAll accepts joined slug strings', () => {
+	expect(resolveFromCatchAll('getting-started/introduction')).toEqual({
+		section: 'getting-started',
+		slug: 'introduction',
+	});
+});
+
+test('resolveFromCatchAll rejects missing segments', () => {
+	expect(() => resolveFromCatchAll(['introduction'])).toThrow(/Invalid docs slug/);
+});

--- a/apps/docs/src/lib/docs-kit/navigation/resolve-from-catch-all.ts
+++ b/apps/docs/src/lib/docs-kit/navigation/resolve-from-catch-all.ts
@@ -1,0 +1,24 @@
+import type { PageParams } from '@ecopages/core';
+
+export type ResolvedDocsSlug = {
+	section: string;
+	slug: string;
+};
+
+type CatchAllSlugParam = PageParams[string];
+
+/**
+ * Maps catch-all `slug` param segments to a docs section and page slug.
+ */
+export function resolveFromCatchAll(slug: CatchAllSlugParam): ResolvedDocsSlug {
+	const segments = Array.isArray(slug) ? slug : slug ? slug.split('/') : [];
+
+	if (segments.length < 2) {
+		throw new Error(`Invalid docs slug: expected /docs/<section>/<page>, got ${segments.join('/')}`);
+	}
+
+	return {
+		section: segments[0]!,
+		slug: segments[1]!,
+	};
+}

--- a/examples/docs-starter/.env.example
+++ b/examples/docs-starter/.env.example
@@ -1,0 +1,1 @@
+ECOPAGES_BASE_URL=http://localhost:3000

--- a/examples/docs-starter/.gitignore
+++ b/examples/docs-starter/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.eco
+.env

--- a/examples/docs-starter/README.md
+++ b/examples/docs-starter/README.md
@@ -1,0 +1,39 @@
+# Docs starter
+
+Minimal Ecopages docs site using a content tree, manifest-driven navigation, and a catch-all docs route.
+
+## Structure
+
+- `src/content/docs/**` — body-only MDX content
+- `src/docs-kit/**` — compile helpers, manifest, layout, and docs chrome (mirrors `apps/docs/src/lib/docs-kit` patterns)
+- `src/docs-kit.instance.ts` — app-specific wiring via `defineDocsKit()`
+- `src/pages/docs/[...slug]/index.tsx` — single catch-all route for all docs pages
+
+## Configuration
+
+- Edit `src/docs-kit/manifest/docs-manifest.config.ts` to add, remove, or reorder pages.
+- Every `.mdx` file under `src/content/docs` must appear in the manifest; orphan files fail `buildDocsManifest()`.
+- Inject shell layout and MDX components in `src/docs-kit.instance.ts`.
+
+## Docs bar
+
+The docs layout composes kit-local components:
+
+- `Breadcrumb` — receives `items` via props (resolved server-side from the manifest)
+- `CopyForLlm` — SSR markup with a Radiant script for clipboard behavior only (no client render override)
+
+Markup lives in `eco.component` render functions so layout HMR updates text and structure immediately.
+
+## Commands
+
+```bash
+pnpm install
+pnpm dev
+pnpm build
+```
+
+Open `/docs/getting-started/introduction` after starting the dev server.
+
+## Full docs app
+
+See `apps/docs` for the complete docs kit: sidebar icons, table of contents, pagination, and static LLM exports under `src/public/docs-llm/`.

--- a/examples/docs-starter/app.ts
+++ b/examples/docs-starter/app.ts
@@ -1,0 +1,6 @@
+import { createApp } from '@ecopages/core/create-app';
+import appConfig from './eco.config';
+
+const app = await createApp({ appConfig });
+
+await app.start();

--- a/examples/docs-starter/eco.config.ts
+++ b/examples/docs-starter/eco.config.ts
@@ -1,0 +1,29 @@
+import path from 'node:path';
+import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
+import { postcssProcessorPlugin } from '@ecopages/postcss-processor';
+import { tailwindV4Preset } from '@ecopages/postcss-processor/presets/tailwind-v4';
+import { getDocsMdxPluginOptions } from './src/docs-kit/mdx/mdx-plugin-options';
+
+const appRoot = path.resolve(import.meta.dirname);
+
+const config = await new ConfigBuilder()
+	.setRootDir(appRoot)
+	.setBaseUrl(process.env.ECOPAGES_BASE_URL ?? 'http://localhost:3000')
+	.setIntegrations([
+		ecopagesJsxPlugin({
+			extensions: ['.tsx'],
+			mdx: getDocsMdxPluginOptions(),
+		}),
+	])
+	.setAdditionalWatchPaths(['src/content', 'src/docs-kit'])
+	.setProcessors([
+		postcssProcessorPlugin(
+			tailwindV4Preset({
+				referencePath: path.resolve(appRoot, 'src/styles/tailwind.css'),
+			}),
+		),
+	])
+	.build();
+
+export default config;

--- a/examples/docs-starter/modules.d.ts
+++ b/examples/docs-starter/modules.d.ts
@@ -1,0 +1,1 @@
+import '@ecopages/jsx/jsx-runtime';

--- a/examples/docs-starter/package.json
+++ b/examples/docs-starter/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@ecopages/docs-starter",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"start": "pnpm run build && ecopages start",
+		"dev": "ecopages dev",
+		"build": "ecopages build",
+		"preview": "ecopages preview"
+	},
+	"devDependencies": {
+		"@ecopages/core": "0.2.0-alpha.2",
+		"@ecopages/ecopages-jsx": "0.2.0-alpha.2",
+		"@ecopages/jsx": "0.3.0-beta.0",
+		"@ecopages/mdx": "0.2.0-alpha.2",
+		"@ecopages/postcss-processor": "0.2.0-alpha.2",
+		"@ecopages/radiant": "0.3.0-beta.0",
+		"@mdx-js/mdx": "^3.1.1",
+		"@tailwindcss/postcss": "^4.0.0",
+		"ecopages": "0.2.0-alpha.2",
+		"remark-gfm": "^4.0.1",
+		"tailwindcss": "^4.0.0",
+		"vfile": "^6.0.3"
+	}
+}

--- a/examples/docs-starter/src/content/docs/content.ts
+++ b/examples/docs-starter/src/content/docs/content.ts
@@ -1,0 +1,29 @@
+import type { DocsSiteContent } from '@/docs-kit/content/docs-site-content.types';
+
+import GettingStartedIntroduction from './getting-started/introduction.mdx';
+import GettingStartedNextSteps from './getting-started/next-steps.mdx';
+
+/** Docs navigation, metadata, and MDX modules — single source of truth. */
+export const docsSiteContent = {
+	rootDir: '/docs',
+	sections: [
+		{
+			id: 'getting-started',
+			title: 'Getting Started',
+			pages: [
+				{
+					slug: 'introduction',
+					title: 'Introduction',
+					description: 'Welcome to the docs starter — a minimal Ecopages docs site template.',
+					content: GettingStartedIntroduction,
+				},
+				{
+					slug: 'next-steps',
+					title: 'Next steps',
+					description: 'Extend the starter with more sections, pages, and MDX content.',
+					content: GettingStartedNextSteps,
+				},
+			],
+		},
+	],
+} satisfies DocsSiteContent;

--- a/examples/docs-starter/src/content/docs/getting-started/introduction.mdx
+++ b/examples/docs-starter/src/content/docs/getting-started/introduction.mdx
@@ -1,0 +1,8 @@
+# Introduction
+
+Welcome to the docs starter. Content files live under `src/content/docs` and are rendered through one catch-all route.
+
+## Add a page
+
+1. Add MDX under `src/content/docs/<section>/<slug>.mdx`.
+2. Register the page in `src/content/docs/content.ts`.

--- a/examples/docs-starter/src/content/docs/getting-started/next-steps.mdx
+++ b/examples/docs-starter/src/content/docs/getting-started/next-steps.mdx
@@ -1,0 +1,5 @@
+# Next steps
+
+- Copy this example into your own app.
+- Extend `src/content/docs/content.ts` with more sections.
+- Add shared JSX in `docs-kit.instance.ts` and pass it through `getDocsMdxComponents()`.

--- a/examples/docs-starter/src/docs-kit.instance.ts
+++ b/examples/docs-starter/src/docs-kit.instance.ts
@@ -1,0 +1,20 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { docsSiteContent } from '@/content/docs/content';
+import { DocsBar } from '@/docs-kit/components/docs-bar';
+import { defineDocsKit } from '@/docs-kit/config';
+import { BaseLayout } from '@/layouts/base-layout';
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const appRoot = moduleDir.includes(`${path.sep}.eco${path.sep}`)
+	? path.resolve(moduleDir, '../..')
+	: path.resolve(moduleDir, '..');
+
+defineDocsKit({
+	rootDir: appRoot,
+	content: docsSiteContent,
+	mdxComponents: {},
+	shellLayout: BaseLayout,
+	layoutComponents: [BaseLayout, DocsBar],
+	strictImageImports: false,
+});

--- a/examples/docs-starter/src/docs-kit/components/docs-bar/docs-bar.css
+++ b/examples/docs-starter/src/docs-kit/components/docs-bar/docs-bar.css
@@ -1,0 +1,7 @@
+.docs-bar {
+	@apply mb-4 flex min-h-8 items-center justify-between gap-4;
+}
+
+.docs-breadcrumb {
+	@apply min-w-0 flex-1;
+}

--- a/examples/docs-starter/src/docs-kit/components/docs-bar/index.tsx
+++ b/examples/docs-starter/src/docs-kit/components/docs-bar/index.tsx
@@ -1,0 +1,27 @@
+import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+import { Breadcrumb, type BreadcrumbItem } from '../breadcrumb/breadcrumb';
+import { CopyForLlm } from '../copy-for-llm';
+
+export type DocsBarProps = {
+	crumbs?: BreadcrumbItem[];
+	llmUrl?: string;
+	label?: string;
+};
+
+export const DocsBar = eco.component<DocsBarProps, JsxRenderable>({
+	dependencies: {
+		components: [Breadcrumb, CopyForLlm],
+		stylesheets: ['./docs-bar.css'],
+	},
+	render: ({ crumbs = [], llmUrl, label }) => {
+		return (
+			<div class="docs-bar">
+				{crumbs.length > 0 ? (
+					<Breadcrumb class="docs-breadcrumb" items={crumbs} ariaLabel="Breadcrumb" />
+				) : null}
+				{llmUrl ? <CopyForLlm llmUrl={llmUrl} label={label} /> : null}
+			</div>
+		);
+	},
+});

--- a/examples/docs-starter/src/docs-kit/config.ts
+++ b/examples/docs-starter/src/docs-kit/config.ts
@@ -1,0 +1,35 @@
+import { join } from 'node:path';
+import type { DocsSiteContent } from '@/docs-kit/content/docs-site-content.types';
+import { clearDocsManifestCache } from './manifest/get-docs-manifest';
+
+export type DocsKitConfig = {
+	rootDir: string;
+	contentRoot: string;
+	content: DocsSiteContent;
+	mdxComponents: Record<string, unknown>;
+	shellLayout: unknown;
+	layoutComponents: unknown[];
+	strictImageImports?: boolean;
+};
+
+let kitConfig: DocsKitConfig | null = null;
+
+export function defineDocsKit(options: Omit<DocsKitConfig, 'contentRoot'> & { contentRoot?: string }): void {
+	kitConfig = {
+		...options,
+		contentRoot: options.contentRoot ?? join(options.rootDir, 'src/content/docs'),
+	};
+	clearDocsManifestCache();
+}
+
+export function getDocsKit(): DocsKitConfig {
+	if (!kitConfig) {
+		throw new Error('Docs kit is not configured. Import docs-kit.instance.ts before using docs-kit.');
+	}
+
+	return kitConfig;
+}
+
+export function clearDocsKitConfig(): void {
+	kitConfig = null;
+}

--- a/examples/docs-starter/src/docs-kit/content/docs-site-content.types.ts
+++ b/examples/docs-starter/src/docs-kit/content/docs-site-content.types.ts
@@ -1,0 +1,22 @@
+import type { JsxRenderable } from '@ecopages/jsx';
+import type { DocsMdxComponent } from '@/docs-kit/mdx/docs-mdx.types';
+
+export type DocsContentPage = {
+	slug: string;
+	title: string;
+	description: string;
+	llms?: boolean;
+	content: DocsMdxComponent;
+};
+
+export type DocsContentSection = {
+	id: string;
+	title: string;
+	icon?: JsxRenderable;
+	pages: DocsContentPage[];
+};
+
+export type DocsSiteContent = {
+	rootDir: string;
+	sections: DocsContentSection[];
+};

--- a/examples/docs-starter/src/docs-kit/content/get-docs-content.ts
+++ b/examples/docs-starter/src/docs-kit/content/get-docs-content.ts
@@ -1,0 +1,6 @@
+import { resolveDocsNavPage } from './resolve-docs-nav-page';
+import type { DocsMdxComponent } from '@/docs-kit/mdx/docs-mdx.types';
+
+export function getDocsContent(section: string, slug: string): DocsMdxComponent {
+	return resolveDocsNavPage(section, slug).content;
+}

--- a/examples/docs-starter/src/docs-kit/content/resolve-docs-nav-page.ts
+++ b/examples/docs-starter/src/docs-kit/content/resolve-docs-nav-page.ts
@@ -1,0 +1,17 @@
+import type { DocsContentPage } from '@/docs-kit/content/docs-site-content.types';
+import { getDocsKit } from '@/docs-kit/config';
+
+export type ResolvedDocsNavPage = DocsContentPage & {
+	section: string;
+};
+
+export function resolveDocsNavPage(section: string, slug: string): ResolvedDocsNavPage {
+	const sectionEntry = getDocsKit().content.sections.find((entry) => entry.id === section);
+	const page = sectionEntry?.pages.find((entry) => entry.slug === slug);
+
+	if (!page) {
+		throw new Error(`Unknown docs page: ${section}/${slug}`);
+	}
+
+	return { section, ...page };
+}

--- a/examples/docs-starter/src/docs-kit/content/resolve-docs-page.ts
+++ b/examples/docs-starter/src/docs-kit/content/resolve-docs-page.ts
@@ -1,0 +1,24 @@
+import type { DocsMdxComponent } from '@/docs-kit/mdx/docs-mdx.types';
+import { resolveDocsNavPage } from './resolve-docs-nav-page';
+
+export type ResolvedDocsPage = {
+	section: string;
+	slug: string;
+	title: string;
+	description: string;
+	llms?: boolean;
+	content: DocsMdxComponent;
+};
+
+export function resolveDocsPage(section: string, slug: string): ResolvedDocsPage {
+	const page = resolveDocsNavPage(section, slug);
+
+	return {
+		section,
+		slug,
+		title: page.title,
+		description: page.description,
+		llms: page.llms,
+		content: page.content,
+	};
+}

--- a/examples/docs-starter/src/docs-kit/layout/docs-layout.css
+++ b/examples/docs-starter/src/docs-kit/layout/docs-layout.css
@@ -1,0 +1,16 @@
+.docs-layout {
+	display: grid;
+	grid-template-columns: 240px minmax(0, 1fr);
+	gap: 2rem;
+	padding: 2rem;
+}
+
+.docs-layout__aside ul {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.docs-layout__aside a {
+	text-decoration: none;
+}

--- a/examples/docs-starter/src/docs-kit/layout/docs-layout.tsx
+++ b/examples/docs-starter/src/docs-kit/layout/docs-layout.tsx
@@ -1,0 +1,67 @@
+import { eco } from '@ecopages/core';
+import type { LayoutProps } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+import '@/docs-kit.instance';
+import { DocsBar } from '@/docs-kit/components/docs-bar';
+import { getDocsKit } from '@/docs-kit/config';
+import { getDocsLlmUrl } from '@/docs-kit/llm/docs-llm-url';
+import { resolveDocsBreadcrumb } from '@/docs-kit/navigation/resolve-docs-breadcrumb';
+
+type DocsLayoutPageProps = {
+	section?: string;
+	slug?: string;
+};
+
+type DocsLayoutRenderProps = LayoutProps<JsxRenderable> & DocsLayoutPageProps;
+
+type ShellLayoutProps = {
+	class?: string;
+	children?: JsxRenderable;
+};
+
+const { content, layoutComponents, shellLayout } = getDocsKit();
+const ShellLayout = shellLayout as (props: ShellLayoutProps) => JsxRenderable;
+
+export const DocsLayout = eco.layout<JsxRenderable>({
+	dependencies: {
+		stylesheets: ['./docs-layout.css'],
+		components: layoutComponents,
+	},
+	render: ({ children, section, slug }: DocsLayoutRenderProps) => {
+		const llmUrl = section && slug ? getDocsLlmUrl(section, slug) : undefined;
+		const crumbs = section && slug ? resolveDocsBreadcrumb(content, section, slug) : [];
+
+		return (
+			<ShellLayout class="docs-layout">
+				<aside class="docs-layout__aside">
+					<nav aria-label="Docs">
+						<ul>
+							{content.sections.map((contentSection) => (
+								<li>
+									<p>{contentSection.title}</p>
+									<ul>
+										{contentSection.pages.map((page) => {
+											const href = `${content.rootDir}/${contentSection.id}/${page.slug}`;
+
+											return (
+												<li>
+													<a href={href}>{page.title}</a>
+												</li>
+											);
+										})}
+									</ul>
+								</li>
+							))}
+						</ul>
+					</nav>
+				</aside>
+				<div class="docs-layout__content">
+					<DocsBar crumbs={crumbs} llmUrl={llmUrl} />
+					<div class="prose">{children}</div>
+				</div>
+			</ShellLayout>
+		);
+	},
+});
+
+export default DocsLayout;

--- a/examples/docs-starter/src/docs-kit/layout/index.ts
+++ b/examples/docs-starter/src/docs-kit/layout/index.ts
@@ -1,0 +1,1 @@
+export { DocsLayout as default, DocsLayout } from './docs-layout';

--- a/examples/docs-starter/src/docs-kit/llm/docs-llm-url.ts
+++ b/examples/docs-starter/src/docs-kit/llm/docs-llm-url.ts
@@ -1,0 +1,23 @@
+/**
+ * Maps a docs page pathname to the static markdown URL under `/docs-llm/*`.
+ */
+export function getDocsLlmUrlFromPathname(pathname: string): string | null {
+	const segments = pathname.replace(/\/$/, '').split('/').filter(Boolean);
+
+	if (segments[0] !== 'docs' || segments.length < 3) {
+		return null;
+	}
+
+	const section = segments[1];
+	const slug = segments[2];
+
+	if (!section || !slug) {
+		return null;
+	}
+
+	return getDocsLlmUrl(section, slug);
+}
+
+export function getDocsLlmUrl(section: string, slug: string): string {
+	return `/docs-llm/${section}/${slug}.md`;
+}

--- a/examples/docs-starter/src/docs-kit/manifest/build-docs-manifest.ts
+++ b/examples/docs-starter/src/docs-kit/manifest/build-docs-manifest.ts
@@ -1,0 +1,79 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { getDocsKit } from '@/docs-kit/config';
+import type { DocsSiteContent } from '@/docs-kit/content/docs-site-content.types';
+import type { DocsManifest, DocsManifestPage } from '@/docs-kit/manifest/docs-manifest';
+import { contentPageKey, discoverContentFiles } from '@/docs-kit/manifest/discover-content-files';
+import { projectDocsManifest } from '@/docs-kit/manifest/project-docs-manifest';
+
+function resolveContentPath(contentRoot: string, section: string, slug: string): string {
+	return join(contentRoot, section, `${slug}.mdx`);
+}
+
+function collectConfiguredPageKeys(content: DocsSiteContent): Set<string> {
+	return new Set(
+		content.sections.flatMap((section) => section.pages.map((page) => contentPageKey(section.id, page.slug))),
+	);
+}
+
+async function assertNoOrphanContentFiles(contentRoot: string, content: DocsSiteContent): Promise<void> {
+	const discovered = await discoverContentFiles(contentRoot);
+	const configuredKeys = collectConfiguredPageKeys(content);
+	const orphans = discovered.filter((page) => !configuredKeys.has(contentPageKey(page.section, page.slug)));
+
+	if (orphans.length > 0) {
+		const listed = orphans.map((page) => contentPageKey(page.section, page.slug)).join(', ');
+		throw new Error(`Content files are not listed in docs site content: ${listed}`);
+	}
+}
+
+/** Builds the validated docs manifest from the site content tree. */
+export async function buildDocsManifest(contentOverride?: DocsSiteContent): Promise<DocsManifest> {
+	const kit = getDocsKit();
+	const content = contentOverride ?? kit.content;
+	const contentRoot = kit.contentRoot;
+	const projected = projectDocsManifest(content);
+	const sections = [];
+
+	if (!contentOverride) {
+		await assertNoOrphanContentFiles(contentRoot, content);
+	}
+
+	for (const section of projected.sections) {
+		const pages: DocsManifestPage[] = [];
+
+		for (const page of section.pages) {
+			const contentPath = resolveContentPath(contentRoot, page.section, page.slug);
+
+			try {
+				await readFile(contentPath, 'utf8');
+			} catch {
+				throw new Error(`Docs content entry has no MDX file: ${contentPath}`);
+			}
+
+			pages.push({
+				section: page.section,
+				slug: page.slug,
+				title: page.title,
+				description: page.description,
+				llms: page.llms,
+			});
+		}
+
+		sections.push({
+			id: section.id,
+			title: section.title,
+			pages,
+		});
+	}
+
+	return {
+		rootDir: projected.rootDir,
+		sections,
+	};
+}
+
+export function getContentFilePath(section: string, slug: string): string {
+	const { contentRoot } = getDocsKit();
+	return resolveContentPath(contentRoot, section, slug);
+}

--- a/examples/docs-starter/src/docs-kit/manifest/discover-content-files.ts
+++ b/examples/docs-starter/src/docs-kit/manifest/discover-content-files.ts
@@ -1,0 +1,41 @@
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export type DiscoveredContentPage = {
+	section: string;
+	slug: string;
+};
+
+/**
+ * Walks `contentRoot` and returns every `section/slug` pair for `.mdx` files.
+ */
+export async function discoverContentFiles(contentRoot: string): Promise<DiscoveredContentPage[]> {
+	const sections = await readdir(contentRoot, { withFileTypes: true });
+	const pages: DiscoveredContentPage[] = [];
+
+	for (const sectionEntry of sections) {
+		if (!sectionEntry.isDirectory()) {
+			continue;
+		}
+
+		const sectionDir = join(contentRoot, sectionEntry.name);
+		const files = await readdir(sectionDir, { withFileTypes: true });
+
+		for (const fileEntry of files) {
+			if (!fileEntry.isFile() || !fileEntry.name.endsWith('.mdx')) {
+				continue;
+			}
+
+			pages.push({
+				section: sectionEntry.name,
+				slug: fileEntry.name.replace(/\.mdx$/, ''),
+			});
+		}
+	}
+
+	return pages;
+}
+
+export function contentPageKey(section: string, slug: string): string {
+	return `${section}/${slug}`;
+}

--- a/examples/docs-starter/src/docs-kit/manifest/docs-manifest.ts
+++ b/examples/docs-starter/src/docs-kit/manifest/docs-manifest.ts
@@ -1,0 +1,18 @@
+export type DocsManifestPage = {
+	section: string;
+	slug: string;
+	title: string;
+	description?: string;
+	llms?: boolean;
+};
+
+export type DocsManifestSection = {
+	id: string;
+	title: string;
+	pages: DocsManifestPage[];
+};
+
+export type DocsManifest = {
+	rootDir: string;
+	sections: DocsManifestSection[];
+};

--- a/examples/docs-starter/src/docs-kit/manifest/get-docs-manifest.ts
+++ b/examples/docs-starter/src/docs-kit/manifest/get-docs-manifest.ts
@@ -1,0 +1,30 @@
+import type { DocsManifest } from './docs-manifest';
+import type { DocsSiteContent } from '@/docs-kit/content/docs-site-content.types';
+import { buildDocsManifest } from './build-docs-manifest';
+
+let cachedManifest: DocsManifest | null = null;
+let manifestPromise: Promise<DocsManifest> | null = null;
+
+export function clearDocsManifestCache(): void {
+	cachedManifest = null;
+	manifestPromise = null;
+}
+
+export async function getDocsManifest(nav?: DocsSiteContent): Promise<DocsManifest> {
+	if (nav) {
+		return buildDocsManifest(nav);
+	}
+
+	if (cachedManifest) {
+		return cachedManifest;
+	}
+
+	if (!manifestPromise) {
+		manifestPromise = buildDocsManifest().then((manifest) => {
+			cachedManifest = manifest;
+			return manifest;
+		});
+	}
+
+	return manifestPromise;
+}

--- a/examples/docs-starter/src/docs-kit/manifest/project-docs-manifest.ts
+++ b/examples/docs-starter/src/docs-kit/manifest/project-docs-manifest.ts
@@ -1,0 +1,19 @@
+import type { DocsSiteContent } from '@/docs-kit/content/docs-site-content.types';
+import type { DocsManifest } from '@/docs-kit/manifest/docs-manifest';
+
+export function projectDocsManifest(content: DocsSiteContent): DocsManifest {
+	return {
+		rootDir: content.rootDir,
+		sections: content.sections.map((section) => ({
+			id: section.id,
+			title: section.title,
+			pages: section.pages.map((page) => ({
+				section: section.id,
+				slug: page.slug,
+				title: page.title,
+				description: page.description,
+				llms: page.llms,
+			})),
+		})),
+	};
+}

--- a/examples/docs-starter/src/docs-kit/mdx/docs-mdx-components.ts
+++ b/examples/docs-starter/src/docs-kit/mdx/docs-mdx-components.ts
@@ -1,0 +1,9 @@
+import type { MDXComponents } from 'mdx/types.js';
+import { getDocsKit } from '@/docs-kit/config';
+
+/** MDX components injected when rendering imported docs content modules. */
+export function getDocsMdxComponents(): MDXComponents {
+	return {
+		...getDocsKit().mdxComponents,
+	};
+}

--- a/examples/docs-starter/src/docs-kit/mdx/docs-mdx.types.ts
+++ b/examples/docs-starter/src/docs-kit/mdx/docs-mdx.types.ts
@@ -1,0 +1,3 @@
+import type { EcoComponent } from '@ecopages/core';
+
+export type DocsMdxComponent = EcoComponent<Record<string, unknown>>;

--- a/examples/docs-starter/src/docs-kit/mdx/mdx-plugin-options.ts
+++ b/examples/docs-starter/src/docs-kit/mdx/mdx-plugin-options.ts
@@ -1,0 +1,9 @@
+import remarkGfm from 'remark-gfm';
+
+/** MDX plugin options wired into `ecopagesJsxPlugin({ mdx: getDocsMdxPluginOptions() })`. */
+export function getDocsMdxPluginOptions() {
+	return {
+		enabled: true as const,
+		remarkPlugins: [remarkGfm],
+	};
+}

--- a/examples/docs-starter/src/docs-kit/navigation/resolve-docs-breadcrumb.ts
+++ b/examples/docs-starter/src/docs-kit/navigation/resolve-docs-breadcrumb.ts
@@ -1,0 +1,26 @@
+import type { BreadcrumbItem } from '../components/breadcrumb/breadcrumb';
+import type { DocsSiteContent } from '../content/docs-site-content.types';
+
+export function resolveDocsBreadcrumb(content: DocsSiteContent, section: string, slug: string): BreadcrumbItem[] {
+	const contentSection = content.sections.find((entry) => entry.id === section);
+	const page = contentSection?.pages.find((entry) => entry.slug === slug);
+
+	if (!contentSection || !page) {
+		return [];
+	}
+
+	const firstSection = content.sections[0];
+	const firstPage = firstSection?.pages[0];
+	const docsIndexHref =
+		firstSection && firstPage ? `${content.rootDir}/${firstSection.id}/${firstPage.slug}` : content.rootDir;
+	const firstSectionPage = contentSection.pages[0];
+
+	return [
+		{ label: 'Docs', href: docsIndexHref },
+		{
+			label: contentSection.title,
+			href: firstSectionPage ? `${content.rootDir}/${section}/${firstSectionPage.slug}` : undefined,
+		},
+		{ label: page.title },
+	];
+}

--- a/examples/docs-starter/src/docs-kit/navigation/resolve-from-catch-all.ts
+++ b/examples/docs-starter/src/docs-kit/navigation/resolve-from-catch-all.ts
@@ -1,0 +1,22 @@
+import type { PageParams } from '@ecopages/core';
+
+export type ResolvedDocsSlug = {
+	section: string;
+	slug: string;
+};
+
+type CatchAllSlugParam = PageParams[string];
+
+/** Maps catch-all `slug` param segments to a docs section and page slug. */
+export function resolveFromCatchAll(slug: CatchAllSlugParam): ResolvedDocsSlug {
+	const segments = Array.isArray(slug) ? slug : slug ? slug.split('/') : [];
+
+	if (segments.length < 2) {
+		throw new Error(`Invalid docs slug: expected /docs/<section>/<page>, got ${segments.join('/')}`);
+	}
+
+	return {
+		section: segments[0]!,
+		slug: segments[1]!,
+	};
+}

--- a/examples/docs-starter/src/layouts/base-layout/base-layout.css
+++ b/examples/docs-starter/src/layouts/base-layout/base-layout.css
@@ -1,0 +1,9 @@
+.site-header {
+	padding: 1rem 2rem;
+	border-bottom: 1px solid #e5e7eb;
+}
+
+.site-header a {
+	font-weight: 600;
+	text-decoration: none;
+}

--- a/examples/docs-starter/src/layouts/base-layout/base-layout.tsx
+++ b/examples/docs-starter/src/layouts/base-layout/base-layout.tsx
@@ -1,0 +1,25 @@
+import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+
+export type BaseLayoutProps = {
+	children: JsxRenderable;
+	class?: string;
+};
+
+export const BaseLayout = eco.component<BaseLayoutProps>({
+	dependencies: {
+		stylesheets: ['../../styles/tailwind.css', './base-layout.css'],
+	},
+	render: ({ children, class: className }) => {
+		return (
+			<body>
+				<header class="site-header">
+					<a href="/">Docs starter</a>
+				</header>
+				<main class={className}>{children}</main>
+			</body>
+		);
+	},
+});
+
+export default BaseLayout;

--- a/examples/docs-starter/src/layouts/base-layout/index.ts
+++ b/examples/docs-starter/src/layouts/base-layout/index.ts
@@ -1,0 +1,1 @@
+export { BaseLayout as default, BaseLayout } from './base-layout.tsx';

--- a/examples/docs-starter/src/pages/docs/[...slug]/index.tsx
+++ b/examples/docs-starter/src/pages/docs/[...slug]/index.tsx
@@ -1,0 +1,60 @@
+import { eco } from '@ecopages/core';
+import type { GetMetadata, GetStaticProps } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+import '@/docs-kit.instance';
+import { getDocsContent } from '@/docs-kit/content/get-docs-content';
+import { resolveDocsPage } from '@/docs-kit/content/resolve-docs-page';
+import { getDocsMdxComponents } from '@/docs-kit/mdx/docs-mdx-components';
+import { DocsLayout } from '@/docs-kit/layout';
+import { getDocsManifest } from '@/docs-kit/manifest/get-docs-manifest';
+import { resolveFromCatchAll } from '@/docs-kit/navigation/resolve-from-catch-all';
+
+type DocsCatchAllProps = {
+	section: string;
+	slug: string;
+	title: string;
+	description?: string;
+};
+
+export const getMetadata: GetMetadata<DocsCatchAllProps> = ({ props: { title, description } }) => ({
+	title: `Docs | ${title}`,
+	description: description ?? '',
+});
+
+const staticProps: GetStaticProps<DocsCatchAllProps> = async ({ pathname }) => {
+	const resolved = resolveFromCatchAll(pathname.params.slug);
+	const page = resolveDocsPage(resolved.section, resolved.slug);
+
+	return {
+		props: {
+			section: page.section,
+			slug: page.slug,
+			title: page.title,
+			description: page.description,
+		},
+	};
+};
+
+export default eco.page<DocsCatchAllProps, JsxRenderable>({
+	layout: DocsLayout,
+	staticPaths: async () => {
+		const manifest = await getDocsManifest();
+
+		return {
+			paths: manifest.sections.flatMap((section) =>
+				section.pages.map((page) => ({
+					params: {
+						slug: [page.section, page.slug],
+					},
+				})),
+			),
+		};
+	},
+	staticProps,
+	metadata: getMetadata,
+	render: async ({ section, slug }) => {
+		const Content = getDocsContent(section, slug);
+
+		return await Content({ components: getDocsMdxComponents() });
+	},
+});

--- a/examples/docs-starter/src/pages/index.tsx
+++ b/examples/docs-starter/src/pages/index.tsx
@@ -1,0 +1,16 @@
+import { eco } from '@ecopages/core';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page({
+	layout: BaseLayout,
+	render: () => {
+		return (
+			<div class="prose">
+				<h1>Docs starter</h1>
+				<p>
+					<a href="/docs/getting-started/introduction">Open the docs</a>
+				</p>
+			</div>
+		);
+	},
+});

--- a/examples/docs-starter/src/styles/tailwind.css
+++ b/examples/docs-starter/src/styles/tailwind.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/examples/docs-starter/tsconfig.json
+++ b/examples/docs-starter/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"jsx": "react-jsx",
+		"jsxImportSource": "@ecopages/jsx",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"noImplicitOverride": true,
+		"paths": {
+			"@/*": ["./src/*"]
+		},
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"target": "ES2021",
+		"useDefineForClassFields": true,
+		"verbatimModuleSyntax": true
+	},
+	"include": ["modules.d.ts", "src"]
+}


### PR DESCRIPTION
## Summary
- Introduces `defineDocsKit()` with injectable content, manifest, navigation, and MDX component config.
- Removes the runtime MDX compile layer and the `@ecopages/mdx` compile runtime in favor of explicit content module wiring.
- Aligns `examples/docs-starter` with the shared kit pattern (content modules, manifest, layout, navigation).

## Test plan
- [ ] `pnpm --filter docs-starter build`
- [ ] `pnpm --dir apps/docs test` (kit unit tests under `src/lib/docs-kit`)