### PR TITLE
examples(docs-starter): add LLM doc exports

### DIFF
--- a/examples/docs-starter/.gitignore
+++ b/examples/docs-starter/.gitignore
@@ -2,3 +2,7 @@ node_modules
 dist
 .eco
 .env
+
+# generated before dev/build
+src/public/llms.txt
+src/public/docs-llm

--- a/examples/docs-starter/README.md
+++ b/examples/docs-starter/README.md
@@ -11,7 +11,7 @@ Minimal Ecopages docs site using a content tree, manifest-driven navigation, and
 
 ## Configuration
 
-- Edit `src/docs-kit/manifest/docs-manifest.config.ts` to add, remove, or reorder pages.
+- Edit `src/content/docs/content.meta.ts` to add, remove, or reorder pages (and wire MDX modules in `content.ts`).
 - Every `.mdx` file under `src/content/docs` must appear in the manifest; orphan files fail `buildDocsManifest()`.
 - Inject shell layout and MDX components in `src/docs-kit.instance.ts`.
 
@@ -24,16 +24,23 @@ The docs layout composes kit-local components:
 
 Markup lives in `eco.component` render functions so layout HMR updates text and structure immediately.
 
+## LLM exports
+
+`scripts/generate-llm-docs.ts` writes `src/public/llms.txt` and `src/public/docs-llm/**/*.md` from the manifest before `dev` and `build`. Pages can opt out with `llms: false` in `content.meta.ts`.
+
+For the full Ecopages agent skill pack, see [ecopages.app/skill.txt](https://ecopages.app/skill.txt).
+
 ## Commands
 
 ```bash
 pnpm install
 pnpm dev
 pnpm build
+pnpm run generate:llms
 ```
 
 Open `/docs/getting-started/introduction` after starting the dev server.
 
 ## Full docs app
 
-See `apps/docs` for the complete docs kit: sidebar icons, table of contents, pagination, and static LLM exports under `src/public/docs-llm/`.
+See `apps/docs` for the complete docs kit: sidebar icons, table of contents, pagination, and the progressive agent skill pack under `src/public/skill/`.

--- a/examples/docs-starter/README.md
+++ b/examples/docs-starter/README.md
@@ -11,7 +11,7 @@ Minimal Ecopages docs site using a content tree, manifest-driven navigation, and
 
 ## Configuration
 
-- Edit `src/content/docs/content.meta.ts` to add, remove, or reorder pages (and wire MDX modules in `content.ts`).
+- Edit `src/content/docs/content.meta.ts` to add, remove, or reorder pages (and register MDX modules in `content.ts`).
 - Every `.mdx` file under `src/content/docs` must appear in the manifest; orphan files fail `buildDocsManifest()`.
 - Inject shell layout and MDX components in `src/docs-kit.instance.ts`.
 
@@ -28,8 +28,6 @@ Markup lives in `eco.component` render functions so layout HMR updates text and 
 
 `scripts/generate-llm-docs.ts` writes `src/public/llms.txt` and `src/public/docs-llm/**/*.md` from the manifest before `dev` and `build`. Pages can opt out with `llms: false` in `content.meta.ts`.
 
-For the full Ecopages agent skill pack, see [ecopages.app/skill.txt](https://ecopages.app/skill.txt).
-
 ## Commands
 
 ```bash
@@ -43,4 +41,4 @@ Open `/docs/getting-started/introduction` after starting the dev server.
 
 ## Full docs app
 
-See `apps/docs` for the complete docs kit: sidebar icons, table of contents, pagination, and the progressive agent skill pack under `src/public/skill/`.
+See `apps/docs` for the complete docs kit: sidebar icons, table of contents, and pagination.

--- a/examples/docs-starter/package.json
+++ b/examples/docs-starter/package.json
@@ -4,8 +4,9 @@
 	"type": "module",
 	"scripts": {
 		"start": "pnpm run build && ecopages start",
-		"dev": "ecopages dev",
-		"build": "ecopages build",
+		"generate:llms": "tsx scripts/generate-llm-docs.ts",
+		"dev": "pnpm run generate:llms && ecopages dev",
+		"build": "pnpm run generate:llms && ecopages build",
 		"preview": "ecopages preview"
 	},
 	"devDependencies": {
@@ -20,6 +21,7 @@
 		"ecopages": "0.2.0-alpha.2",
 		"remark-gfm": "^4.0.1",
 		"tailwindcss": "^4.0.0",
+		"tsx": "^4.22.3",
 		"vfile": "^6.0.3"
 	}
 }

--- a/examples/docs-starter/scripts/generate-llm-docs.ts
+++ b/examples/docs-starter/scripts/generate-llm-docs.ts
@@ -2,28 +2,11 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { defineDocsKit } from '../src/docs-kit/config';
-import type { DocsSiteContent, DocsSiteContentMeta } from '../src/docs-kit/content/docs-site-content.types';
-import type { DocsMdxComponent } from '../src/docs-kit/mdx/docs-mdx.types';
 import { getContentFilePath } from '../src/docs-kit/manifest/build-docs-manifest';
 import { getDocsManifest } from '../src/docs-kit/manifest/get-docs-manifest';
 
 const appRoot = join(import.meta.dirname, '..');
 const publicRoot = join(appRoot, 'src/public');
-
-function withStubContent(meta: DocsSiteContentMeta): DocsSiteContent {
-	const stub: DocsMdxComponent = () => null;
-
-	return {
-		rootDir: meta.rootDir,
-		sections: meta.sections.map((section) => ({
-			...section,
-			pages: section.pages.map((page) => ({
-				...page,
-				content: stub,
-			})),
-		})),
-	};
-}
 
 async function ensureDir(path: string): Promise<void> {
 	await mkdir(path, { recursive: true });
@@ -33,7 +16,6 @@ async function ensureDir(path: string): Promise<void> {
  * Writes raw MDX bodies and `llms.txt` into the public directory for static serving.
  *
  * @remarks
- * Agent-facing contract:
  * - `llms.txt` is a `.txt` discovery index only.
  * - Linked page bodies live under `docs-llm/<section>/<slug>.md`.
  */
@@ -49,7 +31,6 @@ export async function generateLlmDocs(outputRoot = publicRoot): Promise<void> {
 		'',
 		'- This `llms.txt` file is an index only.',
 		'- Follow links to `/docs-llm/<section>/<slug>.md` for full page exports.',
-		'- For Ecopages build guidance, see https://ecopages.app/skill.txt.',
 		'',
 	];
 
@@ -82,10 +63,11 @@ const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process
 
 if (isDirectRun) {
 	const { docsSiteContentMeta } = await import('../src/content/docs/content.meta.ts');
+	const { stubDocsSiteContent } = await import('../src/content/docs/attach-docs-content-modules.ts');
 
 	defineDocsKit({
 		rootDir: appRoot,
-		content: withStubContent(docsSiteContentMeta),
+		content: stubDocsSiteContent(docsSiteContentMeta),
 		mdxComponents: {},
 		shellLayout: () => null,
 		layoutComponents: [],

--- a/examples/docs-starter/scripts/generate-llm-docs.ts
+++ b/examples/docs-starter/scripts/generate-llm-docs.ts
@@ -1,0 +1,95 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { defineDocsKit } from '../src/docs-kit/config';
+import type { DocsSiteContent, DocsSiteContentMeta } from '../src/docs-kit/content/docs-site-content.types';
+import type { DocsMdxComponent } from '../src/docs-kit/mdx/docs-mdx.types';
+import { getContentFilePath } from '../src/docs-kit/manifest/build-docs-manifest';
+import { getDocsManifest } from '../src/docs-kit/manifest/get-docs-manifest';
+
+const appRoot = join(import.meta.dirname, '..');
+const publicRoot = join(appRoot, 'src/public');
+
+function withStubContent(meta: DocsSiteContentMeta): DocsSiteContent {
+	const stub: DocsMdxComponent = () => null;
+
+	return {
+		rootDir: meta.rootDir,
+		sections: meta.sections.map((section) => ({
+			...section,
+			pages: section.pages.map((page) => ({
+				...page,
+				content: stub,
+			})),
+		})),
+	};
+}
+
+async function ensureDir(path: string): Promise<void> {
+	await mkdir(path, { recursive: true });
+}
+
+/**
+ * Writes raw MDX bodies and `llms.txt` into the public directory for static serving.
+ *
+ * @remarks
+ * Agent-facing contract:
+ * - `llms.txt` is a `.txt` discovery index only.
+ * - Linked page bodies live under `docs-llm/<section>/<slug>.md`.
+ */
+export async function generateLlmDocs(outputRoot = publicRoot): Promise<void> {
+	const manifest = await getDocsManifest();
+	const llmRoot = join(outputRoot, 'docs-llm');
+	const baseUrl = process.env.ECOPAGES_BASE_URL ?? 'http://localhost:3000';
+	const lines: string[] = [
+		'# Docs Starter',
+		'> Minimal Ecopages docs site template.',
+		'',
+		'## How to use this file',
+		'',
+		'- This `llms.txt` file is an index only.',
+		'- Follow links to `/docs-llm/<section>/<slug>.md` for full page exports.',
+		'- For Ecopages build guidance, see https://ecopages.app/skill.txt.',
+		'',
+	];
+
+	for (const section of manifest.sections) {
+		lines.push(`## ${section.title}`);
+
+		for (const page of section.pages) {
+			if (page.llms === false) {
+				continue;
+			}
+
+			const sourcePath = getContentFilePath(page.section, page.slug);
+			const body = await readFile(sourcePath, 'utf8');
+			const outputPath = join(llmRoot, page.section, `${page.slug}.md`);
+			await ensureDir(dirname(outputPath));
+			await writeFile(outputPath, body, 'utf8');
+
+			const url = `${baseUrl}/docs-llm/${page.section}/${page.slug}.md`;
+			lines.push(`- [${page.title}](${url})`);
+		}
+
+		lines.push('');
+	}
+
+	await ensureDir(outputRoot);
+	await writeFile(join(outputRoot, 'llms.txt'), lines.join('\n'), 'utf8');
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+	const { docsSiteContentMeta } = await import('../src/content/docs/content.meta.ts');
+
+	defineDocsKit({
+		rootDir: appRoot,
+		content: withStubContent(docsSiteContentMeta),
+		mdxComponents: {},
+		shellLayout: () => null,
+		layoutComponents: [],
+	});
+	await generateLlmDocs();
+	console.log(`[llms] Generated ${join(publicRoot, 'llms.txt')} and ${join(publicRoot, 'docs-llm')}/`);
+}

--- a/examples/docs-starter/src/content/docs/attach-docs-content-modules.ts
+++ b/examples/docs-starter/src/content/docs/attach-docs-content-modules.ts
@@ -1,0 +1,37 @@
+import type { DocsSiteContent, DocsSiteContentMeta } from '@/docs-kit/content/docs-site-content.types';
+import type { DocsMdxComponent } from '@/docs-kit/mdx/docs-mdx.types';
+
+/** Joins site metadata with imported MDX modules for each configured page. */
+export function attachDocsContentModules(
+	meta: DocsSiteContentMeta,
+	modules: Record<string, DocsMdxComponent>,
+): DocsSiteContent {
+	return {
+		rootDir: meta.rootDir,
+		sections: meta.sections.map((section) => ({
+			...section,
+			pages: section.pages.map((page) => {
+				const key = `${section.id}/${page.slug}`;
+				const content = modules[key];
+
+				if (!content) {
+					throw new Error(`Missing MDX module for docs page: ${key}`);
+				}
+
+				return { ...page, content };
+			}),
+		})),
+	};
+}
+
+/** Builds site content with stub modules for Node CLI scripts that must not import MDX. */
+export function stubDocsSiteContent(meta: DocsSiteContentMeta): DocsSiteContent {
+	const stub: DocsMdxComponent = () => null;
+
+	return attachDocsContentModules(
+		meta,
+		Object.fromEntries(
+			meta.sections.flatMap((section) => section.pages.map((page) => [`${section.id}/${page.slug}`, stub])),
+		),
+	);
+}

--- a/examples/docs-starter/src/content/docs/content.meta.ts
+++ b/examples/docs-starter/src/content/docs/content.meta.ts
@@ -1,0 +1,24 @@
+import type { DocsSiteContentMeta } from '@/docs-kit/content/docs-site-content.types';
+
+/** Docs navigation and page metadata — safe to import from Node CLI scripts. */
+export const docsSiteContentMeta = {
+	rootDir: '/docs',
+	sections: [
+		{
+			id: 'getting-started',
+			title: 'Getting Started',
+			pages: [
+				{
+					slug: 'introduction',
+					title: 'Introduction',
+					description: 'Welcome to the docs starter — a minimal Ecopages docs site template.',
+				},
+				{
+					slug: 'next-steps',
+					title: 'Next steps',
+					description: 'Extend the starter with more sections, pages, and MDX content.',
+				},
+			],
+		},
+	],
+} satisfies DocsSiteContentMeta;

--- a/examples/docs-starter/src/content/docs/content.ts
+++ b/examples/docs-starter/src/content/docs/content.ts
@@ -1,25 +1,12 @@
 import type { DocsSiteContent } from '@/docs-kit/content/docs-site-content.types';
-import type { DocsMdxComponent } from '@/docs-kit/mdx/docs-mdx.types';
 
+import { attachDocsContentModules } from './attach-docs-content-modules';
+import { docsSiteContentMeta } from './content.meta';
 import GettingStartedIntroduction from './getting-started/introduction.mdx';
 import GettingStartedNextSteps from './getting-started/next-steps.mdx';
-import { docsSiteContentMeta } from './content.meta';
-
-const stub: DocsMdxComponent = () => null;
-
-const contentByKey = new Map<string, DocsMdxComponent>([
-	['getting-started/introduction', GettingStartedIntroduction],
-	['getting-started/next-steps', GettingStartedNextSteps],
-]);
 
 /** Docs navigation, metadata, and MDX modules — single source of truth. */
-export const docsSiteContent = {
-	rootDir: docsSiteContentMeta.rootDir,
-	sections: docsSiteContentMeta.sections.map((section) => ({
-		...section,
-		pages: section.pages.map((page) => ({
-			...page,
-			content: contentByKey.get(`${section.id}/${page.slug}`) ?? stub,
-		})),
-	})),
-} satisfies DocsSiteContent;
+export const docsSiteContent = attachDocsContentModules(docsSiteContentMeta, {
+	'getting-started/introduction': GettingStartedIntroduction,
+	'getting-started/next-steps': GettingStartedNextSteps,
+}) satisfies DocsSiteContent;

--- a/examples/docs-starter/src/content/docs/content.ts
+++ b/examples/docs-starter/src/content/docs/content.ts
@@ -1,29 +1,25 @@
 import type { DocsSiteContent } from '@/docs-kit/content/docs-site-content.types';
+import type { DocsMdxComponent } from '@/docs-kit/mdx/docs-mdx.types';
 
 import GettingStartedIntroduction from './getting-started/introduction.mdx';
 import GettingStartedNextSteps from './getting-started/next-steps.mdx';
+import { docsSiteContentMeta } from './content.meta';
+
+const stub: DocsMdxComponent = () => null;
+
+const contentByKey = new Map<string, DocsMdxComponent>([
+	['getting-started/introduction', GettingStartedIntroduction],
+	['getting-started/next-steps', GettingStartedNextSteps],
+]);
 
 /** Docs navigation, metadata, and MDX modules — single source of truth. */
 export const docsSiteContent = {
-	rootDir: '/docs',
-	sections: [
-		{
-			id: 'getting-started',
-			title: 'Getting Started',
-			pages: [
-				{
-					slug: 'introduction',
-					title: 'Introduction',
-					description: 'Welcome to the docs starter — a minimal Ecopages docs site template.',
-					content: GettingStartedIntroduction,
-				},
-				{
-					slug: 'next-steps',
-					title: 'Next steps',
-					description: 'Extend the starter with more sections, pages, and MDX content.',
-					content: GettingStartedNextSteps,
-				},
-			],
-		},
-	],
+	rootDir: docsSiteContentMeta.rootDir,
+	sections: docsSiteContentMeta.sections.map((section) => ({
+		...section,
+		pages: section.pages.map((page) => ({
+			...page,
+			content: contentByKey.get(`${section.id}/${page.slug}`) ?? stub,
+		})),
+	})),
 } satisfies DocsSiteContent;

--- a/examples/docs-starter/src/content/docs/getting-started/introduction.mdx
+++ b/examples/docs-starter/src/content/docs/getting-started/introduction.mdx
@@ -2,7 +2,9 @@
 
 Welcome to the docs starter. Content files live under `src/content/docs` and are rendered through one catch-all route.
 
+Agent-readable exports: [`llms.txt`](/llms.txt) indexes every page; bodies are at `/docs-llm/<section>/<slug>.md`. Both are generated before `dev` and `build`.
+
 ## Add a page
 
 1. Add MDX under `src/content/docs/<section>/<slug>.mdx`.
-2. Register the page in `src/content/docs/content.ts`.
+2. Register the page in `src/content/docs/content.meta.ts` and wire the module in `content.ts`.

--- a/examples/docs-starter/src/content/docs/getting-started/introduction.mdx
+++ b/examples/docs-starter/src/content/docs/getting-started/introduction.mdx
@@ -2,9 +2,9 @@
 
 Welcome to the docs starter. Content files live under `src/content/docs` and are rendered through one catch-all route.
 
-Agent-readable exports: [`llms.txt`](/llms.txt) indexes every page; bodies are at `/docs-llm/<section>/<slug>.md`. Both are generated before `dev` and `build`.
+LLM exports: [`llms.txt`](/llms.txt) lists every page; full bodies live at `/docs-llm/<section>/<slug>.md`. Both are generated before `dev` and `build`.
 
 ## Add a page
 
 1. Add MDX under `src/content/docs/<section>/<slug>.mdx`.
-2. Register the page in `src/content/docs/content.meta.ts` and wire the module in `content.ts`.
+2. Register the page in `src/content/docs/content.meta.ts` and add its MDX module to `content.ts`.

--- a/examples/docs-starter/src/docs-kit/content/docs-site-content.types.ts
+++ b/examples/docs-starter/src/docs-kit/content/docs-site-content.types.ts
@@ -1,18 +1,30 @@
 import type { JsxRenderable } from '@ecopages/jsx';
 import type { DocsMdxComponent } from '@/docs-kit/mdx/docs-mdx.types';
 
-export type DocsContentPage = {
+export type DocsContentPageMeta = {
 	slug: string;
 	title: string;
 	description: string;
 	llms?: boolean;
-	content: DocsMdxComponent;
 };
 
-export type DocsContentSection = {
+export type DocsContentSectionMeta = {
 	id: string;
 	title: string;
 	icon?: JsxRenderable;
+	pages: DocsContentPageMeta[];
+};
+
+export type DocsSiteContentMeta = {
+	rootDir: string;
+	sections: DocsContentSectionMeta[];
+};
+
+export type DocsContentPage = DocsContentPageMeta & {
+	content: DocsMdxComponent;
+};
+
+export type DocsContentSection = Omit<DocsContentSectionMeta, 'pages'> & {
 	pages: DocsContentPage[];
 };
 


### PR DESCRIPTION
## Summary

- Add `scripts/generate-llm-docs.ts` to emit `llms.txt` and `docs-llm/**/*.md` before `dev` and `build`
- Introduce `content.meta.ts` so CLI scripts can read the manifest without importing MDX modules
- Document agent exports in the starter README and introduction page

## Test plan

- [x] `pnpm run generate:llms` in `examples/docs-starter`
- [x] Pre-commit hooks passed
- [x] `pnpm dev` in `examples/docs-starter` and verify `/llms.txt` and `/docs-llm/getting-started/introduction.md` are served