### PR TITLE
refactor(nav): canonical link policy in core [PR-01]

### DIFF
--- a/packages/browser-router/src/client/eco-router.ts
+++ b/packages/browser-router/src/client/eco-router.ts
@@ -7,9 +7,11 @@ import type { EcoRouterOptions, EcoNavigationEvent, EcoBeforeSwapEvent, EcoAfter
 import { getEcoNavigationRuntime } from '@ecopages/core/router/navigation-coordinator';
 import {
 	getAnchorFromNavigationEvent,
+	isStaticAssetHref,
 	recoverPendingNavigationHref,
 	type EcoPendingNavigationIntent,
 } from '@ecopages/core/router/link-intent';
+import { assertHtmlPageResponse, getNavigableHrefFromClick } from '@ecopages/core/router/link-navigation-policy';
 import { DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC, DEFAULT_OPTIONS } from './types.ts';
 import { syncDocumentElementAttributes } from './document-element-sync.ts';
 import { DomSwapper, ScrollManager, ViewTransitionManager, PrefetchManager } from './services/index.ts';
@@ -61,33 +63,9 @@ export class EcoRouter {
 	}
 
 	private canInterceptLink(event: MouseEvent | PointerEvent, link: HTMLAnchorElement): string | null {
-		if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return null;
-		if (event.button !== 0) return null;
-
-		const target = link.getAttribute('target');
-		if (target && target !== '_self') return null;
-
-		if (link.hasAttribute(this.options.reloadAttribute)) return null;
-		if (link.hasAttribute('download')) return null;
-
-		const href = link.getAttribute('href');
-		if (!href) return null;
-
-		if (href.startsWith('#')) return null;
-		if (href.startsWith('javascript:')) return null;
-
-		const url = new URL(href, window.location.origin);
-		if (!this.isSameOrigin(url)) return null;
-
-		/**
-		 * Skip same-page anchor navigation — let the browser handle it natively.
-		 * This covers full-path hash links like "/docs/page#section" when already on that page.
-		 */
-		if (url.hash && url.pathname === window.location.pathname && url.search === window.location.search) {
-			return null;
-		}
-
-		return href;
+		return getNavigableHrefFromClick(event, link, {
+			reloadAttribute: this.options.reloadAttribute,
+		});
 	}
 
 	private getRecoveredPointerHref(): string | null {
@@ -373,6 +351,11 @@ export class EcoRouter {
 			return;
 		}
 
+		if (isStaticAssetHref(href)) {
+			window.location.assign(url.href);
+			return;
+		}
+
 		await this.performNavigation(url, options.replace ? 'replace' : 'forward');
 	}
 
@@ -599,6 +582,7 @@ export class EcoRouter {
 			throw new Error(`Failed to fetch page: ${response.status}`);
 		}
 
+		await assertHtmlPageResponse(response);
 		return response.text();
 	}
 }

--- a/packages/browser-router/src/client/services/prefetch-manager.ts
+++ b/packages/browser-router/src/client/services/prefetch-manager.ts
@@ -4,6 +4,8 @@
  * @module prefetch-manager
  */
 
+import { assertHtmlPageResponse, shouldPrefetchLink } from '@ecopages/core/router/link-navigation-policy';
+
 export type PrefetchStrategy = 'viewport' | 'hover' | 'intent';
 
 export interface PrefetchOptions {
@@ -99,6 +101,7 @@ export class PrefetchManager {
 
 			if (!response.ok) return;
 
+			await assertHtmlPageResponse(response);
 			const html = await response.text();
 
 			this.htmlCache.set(url.href, html);
@@ -275,11 +278,9 @@ export class PrefetchManager {
 		const link = target.closest(this.options.linkSelector) as HTMLAnchorElement | null;
 
 		if (!link) return null;
-		if (link.hasAttribute(this.options.noPrefetchAttribute)) return null;
-		if (link.hasAttribute('download')) return null;
-
-		const href = link.getAttribute('href');
-		if (!href || href.startsWith('#') || href.startsWith('javascript:')) return null;
+		if (!shouldPrefetchLink(link, { noPrefetchAttribute: this.options.noPrefetchAttribute })) {
+			return null;
+		}
 
 		return link;
 	}

--- a/packages/browser-router/test/eco-router.test.browser.ts
+++ b/packages/browser-router/test/eco-router.test.browser.ts
@@ -41,10 +41,14 @@ function resetBrowserRuntimeState(): void {
 }
 
 function mockFetch(htmlContent: string) {
-	return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-		ok: true,
-		text: async () => htmlContent,
-	} as Response);
+	return vi.spyOn(globalThis, 'fetch').mockResolvedValue(htmlFetchResponse(htmlContent));
+}
+
+function htmlFetchResponse(body: string): Response {
+	return new Response(body, {
+		status: 200,
+		headers: { 'Content-Type': 'text/html; charset=utf-8' },
+	});
 }
 
 function createLink(attributes: Record<string, string>): HTMLAnchorElement {
@@ -176,10 +180,12 @@ describe('EcoRouter', () => {
 			router = createRouter();
 			const fullMockHtml =
 				'<html><head><title>New Title</title></head><body><div id="content">New Content</div></body></html>';
-			fetchSpy?.mockResolvedValueOnce({
-				ok: true,
-				text: async () => fullMockHtml,
-			} as Response);
+			fetchSpy?.mockResolvedValueOnce(
+				new Response(fullMockHtml, {
+					status: 200,
+					headers: { 'Content-Type': 'text/html; charset=utf-8' },
+				}),
+			);
 
 			await router.navigate('/full-update');
 
@@ -194,10 +200,12 @@ describe('EcoRouter', () => {
 			});
 			const fullMockHtml =
 				'<html lang="fr" data-theme="light"><head><title>New Title</title></head><body><div id="content">New Content</div></body></html>';
-			fetchSpy?.mockResolvedValueOnce({
-				ok: true,
-				text: async () => fullMockHtml,
-			} as Response);
+			fetchSpy?.mockResolvedValueOnce(
+				new Response(fullMockHtml, {
+					status: 200,
+					headers: { 'Content-Type': 'text/html; charset=utf-8' },
+				}),
+			);
 
 			await router.navigate('/custom-html-sync');
 
@@ -269,19 +277,19 @@ describe('EcoRouter', () => {
 							abortSignal?.addEventListener('abort', handleAbort, { once: true });
 							firstFetch.promise.then(() => {
 								abortSignal?.removeEventListener('abort', handleAbort);
-								resolve({
-									ok: true,
-									text: async () =>
+								resolve(
+									htmlFetchResponse(
 										'<html><head></head><body><div id="content">First Content</div></body></html>',
-								} as Response);
+									),
+								);
 							});
 						}),
 				);
-				fetchSpy?.mockResolvedValueOnce({
-					ok: true,
-					text: async () =>
+				fetchSpy?.mockResolvedValueOnce(
+					htmlFetchResponse(
 						'<html><head></head><body><div id="content">Recovered Content</div></body></html>',
-				} as Response);
+					),
+				);
 
 				const firstLink = createLink({ href: '/first-route', id: 'first-link' });
 				const hoveredLink = createLink({ href: '/hover-recovered-route', id: 'hovered-link' });
@@ -465,6 +473,19 @@ describe('EcoRouter', () => {
 				link.addEventListener('click', (e) => e.preventDefault());
 
 				simulateClick(link);
+
+				expect(pushStateSpy).not.toHaveBeenCalled();
+			});
+
+			it('should NOT intercept links to static asset files', () => {
+				router = createRouter();
+				const pushStateSpy = vi.spyOn(window.history, 'pushState');
+
+				for (const href of ['/skill.txt', '/skill/reference/full-stack.md', '/llms.txt']) {
+					const link = createLink({ href, id: `static-${href}` });
+					link.addEventListener('click', (e) => e.preventDefault());
+					simulateClick(link);
+				}
 
 				expect(pushStateSpy).not.toHaveBeenCalled();
 			});
@@ -670,10 +691,7 @@ describe('EcoRouter', () => {
 				'<body><main>React Route</main></body>',
 				'</html>',
 			].join('');
-			fetchSpy?.mockResolvedValueOnce({
-				ok: true,
-				text: async () => reactHtml,
-			} as Response);
+			fetchSpy?.mockResolvedValueOnce(htmlFetchResponse(reactHtml));
 
 			const reloadSpy = vi.spyOn(
 				router as EcoRouter & { reloadDocument: (url: URL) => void },
@@ -875,10 +893,7 @@ describe('EcoRouter', () => {
 			const fetchCalled = new Promise((resolve) => {
 				fetchSpy?.mockImplementationOnce(async () => {
 					resolve(true);
-					return {
-						ok: true,
-						text: async () => '<html><body>Popstate Content</body></html>',
-					} as Response;
+					return htmlFetchResponse('<html><body>Popstate Content</body></html>');
 				});
 			});
 
@@ -919,10 +934,7 @@ describe('EcoRouter', () => {
 					});
 				}
 
-				return Promise.resolve({
-					ok: true,
-					text: async () => '<html><body>Second</body></html>',
-				} as Response);
+				return Promise.resolve(htmlFetchResponse('<html><body>Second</body></html>'));
 			});
 
 			void router.navigate('/first-page');
@@ -946,10 +958,7 @@ describe('EcoRouter', () => {
 					abortSignal = init?.signal ?? undefined;
 					return new Promise(() => {});
 				}
-				return Promise.resolve({
-					ok: true,
-					text: async () => '<html><body>Second</body></html>',
-				} as Response);
+				return Promise.resolve(htmlFetchResponse('<html><body>Second</body></html>'));
 			});
 
 			router.navigate('/first-page');
@@ -970,16 +979,14 @@ describe('EcoRouter', () => {
 
 			fetchSpy?.mockImplementation((url: string | URL | Request) => {
 				if (url.toString().includes('/slow-page')) {
-					return Promise.resolve({
-						ok: true,
-						text: async () => '<html><body><div id="content">Slow Content</div></body></html>',
-					} as Response);
+					return Promise.resolve(
+						htmlFetchResponse('<html><body><div id="content">Slow Content</div></body></html>'),
+					);
 				}
 
-				return Promise.resolve({
-					ok: true,
-					text: async () => '<html><body><div id="content">Fast Content</div></body></html>',
-				} as Response);
+				return Promise.resolve(
+					htmlFetchResponse('<html><body><div id="content">Fast Content</div></body></html>'),
+				);
 			});
 
 			const routerWithInternals = router as unknown as {
@@ -1022,18 +1029,16 @@ describe('EcoRouter', () => {
 							},
 						);
 						slowPage.promise.then(() => {
-							resolve({
-								ok: true,
-								text: async () => '<html><body><div id="content">Slow Content</div></body></html>',
-							} as Response);
+							resolve(
+								htmlFetchResponse('<html><body><div id="content">Slow Content</div></body></html>'),
+							);
 						});
 					});
 				}
 
-				return Promise.resolve({
-					ok: true,
-					text: async () => '<html><body><div id="content">Fast Content</div></body></html>',
-				} as Response);
+				return Promise.resolve(
+					htmlFetchResponse('<html><body><div id="content">Fast Content</div></body></html>'),
+				);
 			});
 
 			const slowNavigation = router.navigate('/slow-page');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -89,6 +89,10 @@
 			"types": "./src/router/client/link-intent.ts",
 			"default": "./src/router/client/link-intent.ts"
 		},
+		"./router/link-navigation-policy": {
+			"types": "./src/router/client/link-navigation-policy.ts",
+			"default": "./src/router/client/link-navigation-policy.ts"
+		},
 		"./eco": {
 			"browser": "./src/eco/eco.browser.ts",
 			"types": "./src/eco/eco.ts",

--- a/packages/core/src/router/client/link-intent.d.ts
+++ b/packages/core/src/router/client/link-intent.d.ts
@@ -1,53 +1,6 @@
 /**
  * Shared client-side navigation intent helpers.
- *
- * Browser runtimes use the same low-level mechanics to:
- * - locate the anchor associated with a click, pointer, or hover event,
- * - persist the last valid pointer or hover target while a navigation is in flight,
- * - recover the final intended href when the DOM changes before the click lands.
- *
- * Keeping those mechanics here lets browser-router and react-router share one
- * implementation while preserving their router-specific interception rules.
- *
  * @module
  */
-/**
- * Timestamped navigation intent captured from pointer or hover activity.
- */
-export type EcoPendingNavigationIntent = {
-	href: string;
-	timestamp: number;
-};
-/**
- * Finds the nearest matching anchor within an event's composed path.
- *
- * This works across Shadow DOM boundaries, which is required for delegated
- * navigation handling when links are rendered inside custom elements.
- *
- * @param event - Pointer or mouse event being inspected.
- * @param linkSelector - Selector that identifies navigable anchors.
- * @returns The matched anchor element, or `null` when no matching anchor exists.
- */
-export declare function getAnchorFromNavigationEvent(
-	event: MouseEvent | PointerEvent,
-	linkSelector: string,
-): HTMLAnchorElement | null;
-/**
- * Resolves a previously captured intent while a navigation is still in flight.
- *
- * Pending intents expire quickly because they are only meant to bridge the gap
- * between pointer or hover capture and the later click event when the DOM or
- * active runtime changes during a rapid navigation sequence.
- *
- * @param intent - Previously captured pointer or hover intent.
- * @param hasInFlightNavigation - Whether a router navigation is still active.
- * @param now - Current monotonic timestamp, usually from `performance.now()`.
- * @param maxAgeMs - Maximum allowed age for the recovered intent.
- * @returns The intended href when still valid, otherwise `null`.
- */
-export declare function recoverPendingNavigationHref(
-	intent: EcoPendingNavigationIntent | null,
-	hasInFlightNavigation: boolean,
-	now: number,
-	maxAgeMs?: number,
-): string | null;
+export type { EcoPendingNavigationIntent } from './link-intent.ts';
+export { getAnchorFromNavigationEvent, isStaticAssetHref, recoverPendingNavigationHref } from './link-intent.ts';

--- a/packages/core/src/router/client/link-intent.test.browser.ts
+++ b/packages/core/src/router/client/link-intent.test.browser.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getAnchorFromNavigationEvent, recoverPendingNavigationHref } from './link-intent.ts';
+import { getAnchorFromNavigationEvent, isStaticAssetHref, recoverPendingNavigationHref } from './link-intent.ts';
 
 describe('getAnchorFromNavigationEvent', () => {
 	it('returns the anchor when the event target is a text node inside it', () => {
@@ -35,6 +35,19 @@ describe('getAnchorFromNavigationEvent', () => {
 		});
 
 		expect(getAnchorFromNavigationEvent(event, 'a[data-eco-link]')).toBe(anchor);
+	});
+});
+
+describe('isStaticAssetHref', () => {
+	it('returns true for known static asset paths', () => {
+		expect(isStaticAssetHref('/skill.txt')).toBe(true);
+		expect(isStaticAssetHref('/skill/reference/full-stack.md')).toBe(true);
+		expect(isStaticAssetHref('/assets/logo.png')).toBe(true);
+	});
+
+	it('returns false for application routes', () => {
+		expect(isStaticAssetHref('/docs/getting-started/introduction')).toBe(false);
+		expect(isStaticAssetHref('/')).toBe(false);
 	});
 });
 

--- a/packages/core/src/router/client/link-intent.ts
+++ b/packages/core/src/router/client/link-intent.ts
@@ -1,3 +1,5 @@
+import { hasKnownStaticExtension } from '../../utils/static-file-extensions.ts';
+
 /**
  * Shared client-side navigation intent helpers.
  *
@@ -62,17 +64,23 @@ export function getAnchorFromNavigationEvent(
 }
 
 /**
+ * Returns whether an href targets a static asset that should use a full document load.
+ */
+export function isStaticAssetHref(href: string): boolean {
+	try {
+		const url = new URL(href, 'http://localhost');
+		return hasKnownStaticExtension(url.pathname);
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Resolves a previously captured intent while a navigation is still in flight.
  *
- * Pending intents expire quickly because they are only meant to bridge the gap
- * between pointer or hover capture and the later click event when the DOM or
- * active runtime changes during a rapid navigation sequence.
- *
- * @param intent - Previously captured pointer or hover intent.
- * @param hasInFlightNavigation - Whether a router navigation is still active.
- * @param now - Current monotonic timestamp, usually from `performance.now()`.
- * @param maxAgeMs - Maximum allowed age for the recovered intent.
- * @returns The intended href when still valid, otherwise `null`.
+ * @remarks
+ * Pending intents expire quickly because they bridge pointer or hover capture
+ * and the later click when the DOM changes during a rapid navigation sequence.
  */
 export function recoverPendingNavigationHref(
 	intent: EcoPendingNavigationIntent | null,

--- a/packages/core/src/router/client/link-navigation-policy.d.ts
+++ b/packages/core/src/router/client/link-navigation-policy.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Canonical link navigation policy for Ecopages client routers.
+ * @module
+ */
+export type { LinkNavigationDecision, LinkNavigationPolicyOptions } from './link-navigation-policy.ts';
+export {
+	assertHtmlPageResponse,
+	getLinkNavigationDecision,
+	getNavigableHrefFromClick,
+	isHtmlPageResponse,
+	isSamePageHashNavigationHref,
+	shouldPrefetchLink,
+} from './link-navigation-policy.ts';

--- a/packages/core/src/router/client/link-navigation-policy.test.browser.ts
+++ b/packages/core/src/router/client/link-navigation-policy.test.browser.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+	assertHtmlPageResponse,
+	getLinkNavigationDecision,
+	getNavigableHrefFromClick,
+	isHtmlPageResponse,
+	isSamePageHashNavigationHref,
+	shouldPrefetchLink,
+} from './link-navigation-policy.ts';
+
+function createLink(href: string, attributes: Record<string, string> = {}): HTMLAnchorElement {
+	const link = document.createElement('a');
+	link.href = href;
+	for (const [key, value] of Object.entries(attributes)) {
+		link.setAttribute(key, value);
+	}
+	document.body.append(link);
+	return link;
+}
+
+function createMouseEvent(button = 0, modifiers: Partial<MouseEventInit> = {}): MouseEvent {
+	return new MouseEvent('click', { bubbles: true, cancelable: true, button, ...modifiers });
+}
+
+const policy = { reloadAttribute: 'data-eco-reload', noPrefetchAttribute: 'data-eco-no-prefetch' };
+
+describe('isSamePageHashNavigationHref', () => {
+	it('returns true for same pathname with a new hash', () => {
+		history.replaceState({}, '', '/docs/page');
+		expect(isSamePageHashNavigationHref('/docs/page#section')).toBe(true);
+	});
+});
+
+describe('getLinkNavigationDecision', () => {
+	it('allows same-origin page links', () => {
+		const link = createLink('/page');
+		const decision = getLinkNavigationDecision(createMouseEvent(), link, policy);
+		expect(decision).toEqual({ shouldIntercept: true, href: '/page' });
+	});
+
+	it('rejects static asset links', () => {
+		const link = createLink('/skill.txt');
+		expect(getLinkNavigationDecision(createMouseEvent(), link, policy)).toEqual({
+			shouldIntercept: false,
+			reason: 'static-asset',
+		});
+	});
+
+	it('rejects explicit reload links', () => {
+		const link = createLink('/logout', { 'data-eco-reload': '' });
+		expect(getLinkNavigationDecision(createMouseEvent(), link, policy)).toEqual({
+			shouldIntercept: false,
+			reason: 'explicit-reload',
+		});
+	});
+});
+
+describe('getNavigableHrefFromClick', () => {
+	it('returns href when navigation should be intercepted', () => {
+		const link = createLink('/page');
+		expect(getNavigableHrefFromClick(createMouseEvent(), link, policy)).toBe('/page');
+	});
+
+	it('returns null for static assets', () => {
+		const link = createLink('/llms.txt');
+		expect(getNavigableHrefFromClick(createMouseEvent(), link, policy)).toBeNull();
+	});
+});
+
+describe('shouldPrefetchLink', () => {
+	it('prefetches internal page links', () => {
+		history.replaceState({}, '', '/');
+		const link = createLink('/docs/intro');
+		expect(shouldPrefetchLink(link, policy)).toBe(true);
+	});
+
+	it('skips static assets and opt-outs', () => {
+		history.replaceState({}, '', '/');
+		expect(shouldPrefetchLink(createLink('/skill.txt'), policy)).toBe(false);
+		expect(shouldPrefetchLink(createLink('/page', { 'data-eco-no-prefetch': '' }), policy)).toBe(false);
+	});
+});
+
+describe('isHtmlPageResponse', () => {
+	it('accepts html content types', () => {
+		expect(isHtmlPageResponse(new Response('', { headers: { 'Content-Type': 'text/html; charset=utf-8' } }))).toBe(
+			true,
+		);
+	});
+
+	it('rejects plain text responses', () => {
+		expect(isHtmlPageResponse(new Response('', { headers: { 'Content-Type': 'text/plain' } }))).toBe(false);
+	});
+});
+
+describe('assertHtmlPageResponse', () => {
+	it('throws for non-html responses', async () => {
+		await expect(
+			assertHtmlPageResponse(new Response('text', { headers: { 'Content-Type': 'text/plain' } })),
+		).rejects.toThrow(/Expected HTML page response/);
+	});
+
+	it('accepts document-shaped bodies when the runtime defaults to text/plain', async () => {
+		await expect(
+			assertHtmlPageResponse(new Response('<html><body></body></html>', { status: 200 })),
+		).resolves.toBeUndefined();
+	});
+});

--- a/packages/core/src/router/client/link-navigation-policy.ts
+++ b/packages/core/src/router/client/link-navigation-policy.ts
@@ -1,0 +1,179 @@
+import { isStaticAssetHref } from './link-intent.ts';
+
+/**
+ * Options shared by link interception and prefetch eligibility checks.
+ */
+export type LinkNavigationPolicyOptions = {
+	/** Attribute that forces a full document reload instead of SPA navigation. */
+	reloadAttribute?: string;
+	/** Attribute that opts a link out of prefetch. */
+	noPrefetchAttribute?: string;
+};
+
+export type LinkNavigationDecision =
+	| { shouldIntercept: true; href: string }
+	| {
+			shouldIntercept: false;
+			reason:
+				| 'modified-click'
+				| 'non-left-click'
+				| 'external-target'
+				| 'explicit-reload'
+				| 'download'
+				| 'no-prefetch'
+				| 'invalid-href'
+				| 'cross-origin'
+				| 'static-asset'
+				| 'same-page-hash';
+	  };
+
+/**
+ * Returns whether an href only adds a hash fragment on the current page.
+ */
+export function isSamePageHashNavigationHref(href: string): boolean {
+	if (!href) {
+		return false;
+	}
+
+	const currentUrl = new URL(window.location.href);
+	const targetUrl = new URL(href, currentUrl);
+
+	return (
+		targetUrl.origin === currentUrl.origin &&
+		targetUrl.hash.length > 0 &&
+		targetUrl.pathname === currentUrl.pathname &&
+		targetUrl.search === currentUrl.search
+	);
+}
+
+/**
+ * Decides whether a pointer or click on an anchor should be handled as SPA navigation.
+ */
+export function getLinkNavigationDecision(
+	event: MouseEvent | PointerEvent,
+	link: HTMLAnchorElement,
+	options: LinkNavigationPolicyOptions,
+): LinkNavigationDecision {
+	if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+		return { shouldIntercept: false, reason: 'modified-click' };
+	}
+	if (event.button !== 0) {
+		return { shouldIntercept: false, reason: 'non-left-click' };
+	}
+
+	const target = link.getAttribute('target');
+	if (target && target !== '_self') {
+		return { shouldIntercept: false, reason: 'external-target' };
+	}
+
+	if (options.reloadAttribute && link.hasAttribute(options.reloadAttribute)) {
+		return { shouldIntercept: false, reason: 'explicit-reload' };
+	}
+	if (link.hasAttribute('download')) {
+		return { shouldIntercept: false, reason: 'download' };
+	}
+
+	const href = link.getAttribute('href');
+	if (!href || href.startsWith('#') || href.startsWith('javascript:')) {
+		return { shouldIntercept: false, reason: 'invalid-href' };
+	}
+
+	const url = new URL(href, window.location.origin);
+	if (url.origin !== window.location.origin) {
+		return { shouldIntercept: false, reason: 'cross-origin' };
+	}
+	if (isStaticAssetHref(href)) {
+		return { shouldIntercept: false, reason: 'static-asset' };
+	}
+	if (isSamePageHashNavigationHref(href)) {
+		return { shouldIntercept: false, reason: 'same-page-hash' };
+	}
+
+	return { shouldIntercept: true, href };
+}
+
+/**
+ * Returns the href when SPA navigation should intercept the click, otherwise `null`.
+ */
+export function getNavigableHrefFromClick(
+	event: MouseEvent | PointerEvent,
+	link: HTMLAnchorElement,
+	options: LinkNavigationPolicyOptions,
+): string | null {
+	const decision = getLinkNavigationDecision(event, link, options);
+	return decision.shouldIntercept ? decision.href : null;
+}
+
+/**
+ * Returns whether a link is eligible for hover or viewport prefetch.
+ */
+export function shouldPrefetchLink(link: HTMLAnchorElement, options: LinkNavigationPolicyOptions): boolean {
+	if (options.noPrefetchAttribute && link.hasAttribute(options.noPrefetchAttribute)) {
+		return false;
+	}
+	if (options.reloadAttribute && link.hasAttribute(options.reloadAttribute)) {
+		return false;
+	}
+	if (link.hasAttribute('download')) {
+		return false;
+	}
+
+	const href = link.getAttribute('href');
+	if (!href || href.startsWith('#') || href.startsWith('javascript:')) {
+		return false;
+	}
+	if (isStaticAssetHref(href)) {
+		return false;
+	}
+
+	try {
+		const url = new URL(href, window.location.origin);
+		if (url.origin !== window.location.origin) {
+			return false;
+		}
+
+		const currentPath = window.location.pathname + window.location.search;
+		const targetPath = url.pathname + url.search;
+		return currentPath !== targetPath;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * @remarks
+ * Prefetch and SPA fetches request HTML. Static markdown, plain text, and other
+ * asset responses must not be parsed as documents.
+ */
+export function isHtmlPageResponse(response: Response): boolean {
+	const contentType = response.headers.get('Content-Type');
+	if (!contentType) {
+		return true;
+	}
+
+	const normalized = contentType.split(';')[0]?.trim().toLowerCase() ?? '';
+	return normalized === 'text/html' || normalized === 'application/xhtml+xml';
+}
+
+/**
+ * @remarks
+ * Servers should send `text/html`. When the type is missing or the runtime
+ * defaults to `text/plain` (common in tests), a document-shaped body is accepted.
+ */
+export async function assertHtmlPageResponse(response: Response): Promise<void> {
+	if (isHtmlPageResponse(response)) {
+		return;
+	}
+
+	const contentType = response.headers.get('Content-Type');
+	const normalized = contentType?.split(';')[0]?.trim().toLowerCase() ?? '';
+
+	if (normalized === 'text/plain' || normalized === '') {
+		const sample = (await response.clone().text()).trimStart();
+		if (sample.startsWith('<')) {
+			return;
+		}
+	}
+
+	throw new Error(`Expected HTML page response, received ${contentType ?? 'unknown content type'}`);
+}

--- a/packages/core/src/utils/server-utils.module.ts
+++ b/packages/core/src/utils/server-utils.module.ts
@@ -1,3 +1,5 @@
+import { hasKnownStaticExtension } from './static-file-extensions.ts';
+
 const ContentTypeMap = new Map<string, string>([
 	['jpg', 'image/jpeg'],
 	['jpeg', 'image/jpeg'],
@@ -54,10 +56,7 @@ export const getContentType = (file: string): string => {
  * @param file - The file name or path.
  * @returns true if the extension is recognized.
  */
-export const hasKnownExtension = (file: string): boolean => {
-	const extension = file.split('.').pop();
-	return extension !== undefined && ContentTypeMap.has(extension);
-};
+export const hasKnownExtension = hasKnownStaticExtension;
 
 /**
  * A module for server utilities.

--- a/packages/core/src/utils/static-file-extensions.ts
+++ b/packages/core/src/utils/static-file-extensions.ts
@@ -1,0 +1,55 @@
+/**
+ * Known static asset extensions served directly from disk.
+ *
+ * @remarks
+ * Keep this list aligned with server static-file handling and client routers
+ * that must bypass SPA navigation for same-origin asset links.
+ */
+export const STATIC_FILE_EXTENSIONS = new Set([
+	'jpg',
+	'jpeg',
+	'png',
+	'gif',
+	'bmp',
+	'svg',
+	'tiff',
+	'webp',
+	'avif',
+	'ico',
+	'mp3',
+	'ogg',
+	'wav',
+	'mp4',
+	'webm',
+	'ogv',
+	'mov',
+	'txt',
+	'md',
+	'html',
+	'css',
+	'js',
+	'mjs',
+	'json',
+	'map',
+	'xml',
+	'webmanifest',
+	'wasm',
+	'csv',
+	'ttf',
+	'woff',
+	'woff2',
+	'otf',
+	'eot',
+	'gz',
+	'zip',
+	'pdf',
+	'doc',
+]);
+
+/**
+ * Returns whether a path or filename ends with a known static asset extension.
+ */
+export function hasKnownStaticExtension(fileOrPath: string): boolean {
+	const extension = fileOrPath.split('.').pop();
+	return extension !== undefined && STATIC_FILE_EXTENSIONS.has(extension);
+}

--- a/packages/react-router/src/navigation.ts
+++ b/packages/react-router/src/navigation.ts
@@ -6,6 +6,12 @@
 /// <reference types="@ecopages/core/declarations" />
 
 import { getEcoDocumentOwner } from '@ecopages/core/router/navigation-coordinator';
+import {
+	assertHtmlPageResponse,
+	getLinkNavigationDecision,
+	isSamePageHashNavigationHref,
+	type LinkNavigationDecision,
+} from '@ecopages/core/router/link-navigation-policy';
 import { ensurePageConfigLayouts } from '@ecopages/core/eco/page-layout-normalization';
 import { type ComponentType } from 'react';
 import { isReactPageHydrationAssetSrc } from './hydration-assets.ts';
@@ -47,75 +53,21 @@ type LoadPageModuleFromDocumentOptions = {
 	moduleUrlOverride?: string;
 };
 
-export type InterceptDecision =
-	| { shouldIntercept: true }
-	| {
-			shouldIntercept: false;
-			reason:
-				| 'modified-click'
-				| 'non-left-click'
-				| 'external-target'
-				| 'explicit-reload'
-				| 'download'
-				| 'invalid-href'
-				| 'cross-origin'
-				| 'same-page-hash';
-	  };
+export type InterceptDecision = LinkNavigationDecision;
 
-export function isSamePageHashNavigationHref(href: string): boolean {
-	if (!href) {
-		return false;
-	}
-
-	const currentUrl = new URL(window.location.href);
-	const targetUrl = new URL(href, currentUrl);
-
-	return (
-		targetUrl.origin === currentUrl.origin &&
-		targetUrl.hash.length > 0 &&
-		targetUrl.pathname === currentUrl.pathname &&
-		targetUrl.search === currentUrl.search
-	);
-}
+export { isSamePageHashNavigationHref };
 
 /**
  * Determines whether a link click should be intercepted for client-side navigation.
- *
- * Standard SPA navigation rules:
- * - Modified clicks (Cmd/Ctrl/Shift/Alt) open in new tab
- * - Non-left clicks use default browser behavior
- * - External targets, downloads, and cross-origin links navigate normally
- *
- * @returns Object indicating whether to intercept and the reason if not
  */
 export function getInterceptDecision(
 	event: MouseEvent,
 	link: HTMLAnchorElement,
 	options: Required<EcoRouterOptions>,
 ): InterceptDecision {
-	if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
-		return { shouldIntercept: false, reason: 'modified-click' };
-	}
-	if (event.button !== 0) return { shouldIntercept: false, reason: 'non-left-click' };
-
-	const target = link.getAttribute('target');
-	if (target && target !== '_self') return { shouldIntercept: false, reason: 'external-target' };
-
-	if (link.hasAttribute(options.reloadAttribute)) return { shouldIntercept: false, reason: 'explicit-reload' };
-	if (link.hasAttribute('download')) return { shouldIntercept: false, reason: 'download' };
-
-	const href = link.getAttribute('href');
-	if (!href || href.startsWith('#') || href.startsWith('javascript:')) {
-		return { shouldIntercept: false, reason: 'invalid-href' };
-	}
-
-	const url = new URL(href, window.location.origin);
-	if (url.origin !== window.location.origin) return { shouldIntercept: false, reason: 'cross-origin' };
-	if (isSamePageHashNavigationHref(href)) {
-		return { shouldIntercept: false, reason: 'same-page-hash' };
-	}
-
-	return { shouldIntercept: true };
+	return getLinkNavigationDecision(event, link, {
+		reloadAttribute: options.reloadAttribute,
+	});
 }
 
 /**
@@ -301,6 +253,7 @@ export async function fetchPageDocument(
 				Accept: 'text/html',
 			},
 		});
+		await assertHtmlPageResponse(res);
 		const html = await res.text();
 
 		const finalUrl = new URL(res.url || url, window.location.origin);

--- a/packages/react-router/test/navigation.test.browser.ts
+++ b/packages/react-router/test/navigation.test.browser.ts
@@ -4,12 +4,24 @@ import {
 	extractProps,
 	extractComponentUrl,
 	fetchPageDocument,
+	getInterceptDecision,
 	isSamePageHashNavigationHref,
 	loadPageModule,
 	loadPageModuleFromDocument,
 	shouldInterceptClick,
 } from '../src/navigation';
 import { DEFAULT_OPTIONS } from '../src/types';
+
+function htmlPageResponse(body: string, init: ResponseInit = {}): Response {
+	return new Response(body, {
+		status: 200,
+		...init,
+		headers: {
+			'Content-Type': 'text/html; charset=utf-8',
+			...(init.headers ?? {}),
+		},
+	});
+}
 
 function createMockDocument(html: string): Document {
 	return new DOMParser().parseFromString(html, 'text/html');
@@ -410,7 +422,7 @@ describe('loadPageModule', () => {
 
 	it('should return null when component URL cannot be extracted', async () => {
 		const mockHtml = '<html><body>No scripts</body></html>';
-		fetchSpy.mockResolvedValueOnce(new Response(mockHtml, { status: 200 }));
+		fetchSpy.mockResolvedValueOnce(htmlPageResponse(mockHtml));
 
 		const result = await loadPageModule('/test');
 
@@ -420,7 +432,7 @@ describe('loadPageModule', () => {
 
 	it('should log when a marked react-router document is missing a component URL', async () => {
 		const mockHtml = `<html ${ECO_DOCUMENT_OWNER_ATTRIBUTE}="react-router"><body>No scripts</body></html>`;
-		fetchSpy.mockResolvedValueOnce(new Response(mockHtml, { status: 200 }));
+		fetchSpy.mockResolvedValueOnce(htmlPageResponse(mockHtml));
 
 		const result = await loadPageModule('/test');
 
@@ -449,7 +461,7 @@ describe('loadPageModule', () => {
 
 	it('should fetch and parse a navigation document without loading a module', async () => {
 		const mockHtml = '<html><body><main>Outside React</main></body></html>';
-		fetchSpy.mockResolvedValueOnce(new Response(mockHtml, { status: 200 }));
+		fetchSpy.mockResolvedValueOnce(htmlPageResponse(mockHtml));
 
 		const result = await fetchPageDocument('/docs');
 
@@ -463,7 +475,7 @@ describe('loadPageModule', () => {
 
 	it('should request navigation documents as HTML', async () => {
 		const mockHtml = '<html><body><main>Docs</main></body></html>';
-		fetchSpy.mockResolvedValueOnce(new Response(mockHtml, { status: 200 }));
+		fetchSpy.mockResolvedValueOnce(htmlPageResponse(mockHtml));
 
 		await fetchPageDocument('/docs');
 
@@ -597,6 +609,20 @@ describe('shouldInterceptClick', () => {
 		const result = shouldInterceptClick(event, link, options);
 
 		expect(result).toBe(false);
+	});
+
+	it('should not intercept links to static asset files', () => {
+		for (const href of ['/skill.txt', '/skill/reference/full-stack.md']) {
+			const link = createLink(href);
+			links.push(link);
+			const event = createMouseEvent();
+
+			expect(shouldInterceptClick(event, link, options)).toBe(false);
+			expect(getInterceptDecision(event, link, options)).toEqual({
+				shouldIntercept: false,
+				reason: 'static-asset',
+			});
+		}
 	});
 
 	it('should not intercept links with reload attribute', () => {


### PR DESCRIPTION
## Summary
- Add `@ecopages/core/router/link-navigation-policy` with shared link interception, prefetch eligibility, and HTML response guards
- Wire browser-router (`canInterceptLink`, `fetchPage`, prefetch) and react-router (`getInterceptDecision`, `fetchPageDocument`) to the core policy
- Add `hasKnownStaticExtension` for server static detection; static asset hrefs bypass SPA navigation

## Audit
- NF-1, BUG-1, BUG-3, Move-1
- Source: `.audit/client-navigation-stack/2026-07-07-1628/`

## Test plan
- `pnpm exec vitest run packages/core/src/router/client/link-navigation-policy.test.browser.ts`
- `pnpm exec vitest run packages/react-router/test/navigation.test.browser.ts`
- `pnpm exec vitest run packages/browser-router/test/eco-router.test.browser.ts`
- Click `/skill.txt` → full document load (not SPA parse)
- Prefetch skips static asset links

## Preserve
- Existing `link-intent` export signatures
- `eco:*` event payloads unchanged