### PR TITLE
refactor(nav): shared navigation-scripts in core

### DIFF
--- a/packages/browser-router/src/client/services/dom-swapper.ts
+++ b/packages/browser-router/src/client/services/dom-swapper.ts
@@ -5,16 +5,16 @@
  */
 
 import morphdom from 'morphdom';
+import {
+	RERUN_SRC_ATTR,
+	collectRerunScripts,
+	flushPendingRerunScripts,
+	isNonExecutableHeadScript,
+	shouldPersistExecutableInlineHeadScript,
+	type PendingRerunScript,
+} from '@ecopages/core/client/navigation-scripts';
 
 const DEFAULT_PERSIST_ATTR = 'data-eco-persist';
-
-type PendingRerunScript = {
-	parent: 'head' | 'body';
-	attributes: Array<[string, string]>;
-	textContent: string;
-	src: string | null;
-	scriptId: string | null;
-};
 
 type PendingHeadScript = {
 	attributes: Array<[string, string]>;
@@ -23,10 +23,6 @@ type PendingHeadScript = {
 	scriptId: string | null;
 	replaceExisting: boolean;
 };
-
-type RerunScriptCallback = () => void;
-
-const RERUN_SRC_ATTR = 'data-eco-rerun-src';
 
 /**
  * Checks if element has a persist attribute (custom or default).
@@ -70,7 +66,6 @@ export class DomSwapper {
 	private persistAttribute: string;
 	private pendingHeadScripts: PendingHeadScript[] = [];
 	private pendingRerunScripts: PendingRerunScript[] = [];
-	private rerunNonce = 0;
 
 	constructor(persistAttribute: string) {
 		this.persistAttribute = persistAttribute;
@@ -155,7 +150,7 @@ export class DomSwapper {
 	 */
 	morphHead(newDocument: Document): void {
 		this.pendingHeadScripts = [];
-		this.pendingRerunScripts = this.collectRerunScripts(newDocument);
+		this.pendingRerunScripts = collectRerunScripts(newDocument);
 		this.removeStaleHeadScripts(newDocument);
 
 		/** Update the document title if it has changed. */
@@ -212,7 +207,7 @@ export class DomSwapper {
 			const existingScript = this.findExistingHeadScript(script);
 
 			if (scriptId && existingScript) {
-				if (!this.isNonExecutableHeadScript(script)) {
+				if (!isNonExecutableHeadScript(script)) {
 					continue;
 				}
 
@@ -284,47 +279,7 @@ export class DomSwapper {
 
 		this.pendingHeadScripts = [];
 
-		for (const script of this.pendingRerunScripts) {
-			const targetParent = script.parent === 'body' ? document.body : document.head;
-			const registeredRerun = this.getRegisteredRerunScript(script.scriptId);
-			const replacement = document.createElement('script');
-			const shouldBustModuleSrc = this.isExternalModuleRerunScript(script) && !registeredRerun;
-
-			for (const [name, value] of script.attributes) {
-				if (name === 'data-eco-rerun') {
-					continue;
-				}
-
-				if (name === 'src' && shouldBustModuleSrc) {
-					replacement.setAttribute(RERUN_SRC_ATTR, value);
-					replacement.setAttribute('src', this.createRerunScriptUrl(value));
-					continue;
-				}
-
-				replacement.setAttribute(name, value);
-			}
-
-			replacement.textContent = script.textContent;
-
-			const existingScript = this.findExistingRerunScript(targetParent, script);
-
-			if (registeredRerun) {
-				if (!existingScript) {
-					targetParent.appendChild(replacement);
-				}
-
-				registeredRerun();
-				continue;
-			}
-
-			if (existingScript) {
-				existingScript.replaceWith(replacement);
-				continue;
-			}
-
-			targetParent.appendChild(replacement);
-		}
-
+		flushPendingRerunScripts(this.pendingRerunScripts);
 		this.pendingRerunScripts = [];
 	}
 
@@ -464,22 +419,6 @@ export class DomSwapper {
 	}
 
 	/**
-	 * Collects all `data-eco-rerun` scripts from the incoming document.
-	 *
-	 * These scripts are re-executed after each navigation so their side-effects
-	 * (event listeners, DOM bootstraps) bind against the new page content.
-	 */
-	private collectRerunScripts(newDocument: Document): PendingRerunScript[] {
-		return Array.from(newDocument.querySelectorAll<HTMLScriptElement>('script[data-eco-rerun]')).map((script) => ({
-			parent: script.closest('body') ? 'body' : 'head',
-			attributes: Array.from(script.attributes).map((attr) => [attr.name, attr.value]),
-			textContent: script.textContent ?? '',
-			src: script.getAttribute('src'),
-			scriptId: script.getAttribute('data-eco-script-id'),
-		}));
-	}
-
-	/**
 	 * Removes head scripts that are no longer present in the incoming document.
 	 *
 	 * Persisted scripts and executable inline scripts with stable identifiers
@@ -502,59 +441,12 @@ export class DomSwapper {
 				continue;
 			}
 
-			if (this.shouldPersistExecutableInlineHeadScript(script)) {
+			if (shouldPersistExecutableInlineHeadScript(script)) {
 				continue;
 			}
 
 			script.remove();
 		}
-	}
-
-	/**
-	 * Determines whether an inline head script should survive navigation.
-	 *
-	 * Only identified (`data-eco-script-id` or `id`), executable inline scripts
-	 * are persisted. External scripts and rerun scripts are never persisted here
-	 * because they have their own lifecycle management.
-	 */
-	private shouldPersistExecutableInlineHeadScript(script: HTMLScriptElement): boolean {
-		const scriptId = script.getAttribute('data-eco-script-id') || script.getAttribute('id');
-		if (!scriptId) {
-			return false;
-		}
-
-		if (script.hasAttribute('data-eco-rerun')) {
-			return false;
-		}
-
-		if (script.getAttribute(RERUN_SRC_ATTR) || script.getAttribute('src')) {
-			return false;
-		}
-
-		return !this.isNonExecutableHeadScript(script);
-	}
-
-	/**
-	 * Returns whether a script is non-executable (e.g. `type="application/json"`).
-	 *
-	 * Non-executable scripts are data carriers (JSON-LD, page data) that can be
-	 * safely replaced without side-effects, unlike executable scripts that would
-	 * re-run their bootstrap logic.
-	 */
-	private isNonExecutableHeadScript(script: HTMLScriptElement): boolean {
-		const type = (script.getAttribute('type') ?? '').trim().toLowerCase();
-
-		if (!type) {
-			return false;
-		}
-
-		return ![
-			'application/javascript',
-			'application/ecmascript',
-			'module',
-			'text/ecmascript',
-			'text/javascript',
-		].includes(type);
 	}
 
 	/**
@@ -632,67 +524,6 @@ export class DomSwapper {
 				(candidate) => this.getHeadScriptKey(candidate) === scriptKey,
 			) ?? null
 		);
-	}
-
-	/**
-	 * Finds an existing rerun script in the given root by `data-eco-script-id` or
-	 * by matching `src` and `textContent`.
-	 */
-	private findExistingRerunScript(root: HTMLElement, script: PendingRerunScript): HTMLScriptElement | null {
-		const scripts = Array.from(root.querySelectorAll<HTMLScriptElement>('script'));
-
-		if (script.scriptId) {
-			return (
-				scripts.find((candidate) => candidate.getAttribute('data-eco-script-id') === script.scriptId) ?? null
-			);
-		}
-
-		return (
-			scripts.find(
-				(candidate) =>
-					(candidate.getAttribute(RERUN_SRC_ATTR) ?? candidate.getAttribute('src')) === script.src &&
-					(candidate.textContent ?? '') === script.textContent,
-			) ?? null
-		);
-	}
-
-	/**
-	 * Returns whether a rerun script is an external ES module (`type="module"` with `src`).
-	 *
-	 * Module scripts are cached by URL, so re-execution requires cache-busting
-	 * via a query parameter nonce.
-	 */
-	private isExternalModuleRerunScript(script: PendingRerunScript): boolean {
-		if (!script.src) {
-			return false;
-		}
-
-		return script.attributes.some(([name, value]) => name === 'type' && value === 'module');
-	}
-
-	private getRegisteredRerunScript(scriptId: string | null): RerunScriptCallback | null {
-		if (!scriptId) {
-			return null;
-		}
-
-		const runtimeWindow = window as Window &
-			typeof globalThis & {
-				__ECO_PAGES__?: {
-					rerunScripts?: Record<string, RerunScriptCallback | undefined>;
-				};
-			};
-
-		return runtimeWindow.__ECO_PAGES__?.rerunScripts?.[scriptId] ?? null;
-	}
-
-	/**
-	 * Appends a nonce query parameter to a script URL to bust the browser's
-	 * module cache and force re-execution on navigation.
-	 */
-	private createRerunScriptUrl(src: string): string {
-		const url = new URL(src, document.baseURI);
-		url.searchParams.set('__eco_rerun', String(++this.rerunNonce));
-		return url.toString();
 	}
 
 	/**

--- a/packages/browser-router/test/dom-swapper.service.test.browser.ts
+++ b/packages/browser-router/test/dom-swapper.service.test.browser.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resetRerunNonceForTests } from '@ecopages/core/client/navigation-scripts';
 import { DomSwapper } from '../src/client/services/dom-swapper.ts';
 import { ViewTransitionManager } from '../src/client/services/view-transition-manager.ts';
 
@@ -19,6 +20,7 @@ function resetDocument(): void {
 	document.head.innerHTML = '';
 	document.body.innerHTML = '';
 	document.title = '';
+	resetRerunNonceForTests();
 }
 
 afterEach(() => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -101,6 +101,10 @@
 			"types": "./src/client/view-transitions.ts",
 			"default": "./src/client/view-transitions.ts"
 		},
+		"./client/navigation-scripts": {
+			"types": "./src/client/navigation-scripts/index.ts",
+			"default": "./src/client/navigation-scripts/index.ts"
+		},
 		"./eco": {
 			"browser": "./src/eco/eco.browser.ts",
 			"types": "./src/eco/eco.ts",

--- a/packages/core/src/client/navigation-scripts/classification.ts
+++ b/packages/core/src/client/navigation-scripts/classification.ts
@@ -1,0 +1,59 @@
+/**
+ * Classifies head scripts for navigation-time persistence and execution.
+ * @module
+ */
+
+const EXECUTABLE_SCRIPT_TYPES = new Set([
+	'application/javascript',
+	'application/ecmascript',
+	'module',
+	'text/ecmascript',
+	'text/javascript',
+]);
+
+/**
+ * Returns whether a script tag carries non-executable data (for example JSON-LD).
+ */
+export function isNonExecutableHeadScript(element: Element): boolean {
+	if (element.tagName !== 'SCRIPT') {
+		return false;
+	}
+
+	const type = (element.getAttribute('type') ?? '').trim().toLowerCase();
+	if (!type) {
+		return false;
+	}
+
+	return !EXECUTABLE_SCRIPT_TYPES.has(type);
+}
+
+/**
+ * Returns whether an identified inline head script should survive head diffing.
+ */
+export function shouldPersistExecutableInlineHeadScript(element: Element): boolean {
+	if (element.tagName !== 'SCRIPT') {
+		return false;
+	}
+
+	const scriptId = element.getAttribute('data-eco-script-id') || element.getAttribute('id');
+	if (!scriptId) {
+		return false;
+	}
+
+	if (element.hasAttribute('data-eco-rerun')) {
+		return false;
+	}
+
+	if ((element as HTMLScriptElement).src) {
+		return false;
+	}
+
+	return !isNonExecutableHeadScript(element);
+}
+
+/**
+ * Returns whether a script is queued for rerun after navigation commit.
+ */
+export function isRerunScript(element: Element): element is HTMLScriptElement {
+	return element.tagName === 'SCRIPT' && element.hasAttribute('data-eco-rerun');
+}

--- a/packages/core/src/client/navigation-scripts/index.ts
+++ b/packages/core/src/client/navigation-scripts/index.ts
@@ -1,0 +1,11 @@
+export { isNonExecutableHeadScript, isRerunScript, shouldPersistExecutableInlineHeadScript } from './classification.ts';
+export { RERUN_SRC_ATTR, getRegisteredRerunScript, type RerunScriptCallback } from './registry.ts';
+export {
+	collectRerunScripts,
+	createRerunScriptUrl,
+	findExistingRerunScript,
+	flushPendingRerunScripts,
+	isExternalModuleRerunScript,
+	resetRerunNonceForTests,
+	type PendingRerunScript,
+} from './rerun-queue.ts';

--- a/packages/core/src/client/navigation-scripts/navigation-scripts.test.browser.ts
+++ b/packages/core/src/client/navigation-scripts/navigation-scripts.test.browser.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isNonExecutableHeadScript } from './classification.ts';
+import {
+	collectRerunScripts,
+	createRerunScriptUrl,
+	flushPendingRerunScripts,
+	resetRerunNonceForTests,
+} from './rerun-queue.ts';
+import { RERUN_SRC_ATTR } from './registry.ts';
+
+describe('isNonExecutableHeadScript', () => {
+	it('treats JSON-LD scripts as non-executable', () => {
+		const script = document.createElement('script');
+		script.type = 'application/ld+json';
+		expect(isNonExecutableHeadScript(script)).toBe(true);
+	});
+
+	it('treats untyped scripts as executable', () => {
+		const script = document.createElement('script');
+		expect(isNonExecutableHeadScript(script)).toBe(false);
+	});
+});
+
+describe('collectRerunScripts and flushPendingRerunScripts', () => {
+	afterEach(() => {
+		document.head.replaceChildren();
+		document.body.replaceChildren();
+		resetRerunNonceForTests();
+	});
+
+	it('replays registered rerun callbacks without duplicating script tags', () => {
+		const callback = vi.fn();
+		(window as Window & { __ECO_PAGES__?: { rerunScripts?: Record<string, () => void> } }).__ECO_PAGES__ = {
+			rerunScripts: { 'eco-test': callback },
+		};
+
+		try {
+			flushPendingRerunScripts([
+				{
+					parent: 'head',
+					attributes: [
+						['data-eco-rerun', ''],
+						['data-eco-script-id', 'eco-test'],
+					],
+					textContent: '',
+					src: null,
+					scriptId: 'eco-test',
+				},
+			]);
+
+			expect(callback).toHaveBeenCalledOnce();
+			expect(document.head.querySelector('script[data-eco-script-id="eco-test"]')).toBeNull();
+		} finally {
+			delete (window as Window & { __ECO_PAGES__?: unknown }).__ECO_PAGES__;
+		}
+	});
+
+	it('cache-busts external module rerun scripts', () => {
+		const html = '<html><head><script data-eco-rerun src="/app.js" type="module"></script></head></html>';
+		const parsed = new DOMParser().parseFromString(html, 'text/html');
+		const scripts = collectRerunScripts(parsed);
+
+		flushPendingRerunScripts(scripts);
+
+		const inserted = document.head.querySelector(`script[${RERUN_SRC_ATTR}]`);
+		expect(inserted?.getAttribute('src')).toMatch(/__eco_rerun=1/);
+		expect(inserted?.getAttribute(RERUN_SRC_ATTR)).toBe('/app.js');
+	});
+
+	it('appends a unique nonce on each module rerun url', () => {
+		const first = createRerunScriptUrl('/app.js');
+		const second = createRerunScriptUrl('/app.js');
+		expect(first).not.toBe(second);
+	});
+});

--- a/packages/core/src/client/navigation-scripts/registry.ts
+++ b/packages/core/src/client/navigation-scripts/registry.ts
@@ -1,0 +1,27 @@
+/**
+ * `__ECO_PAGES__.rerunScripts` registry access for navigation reruns.
+ * @module
+ */
+
+export type RerunScriptCallback = () => void;
+
+/** Attribute storing the original module `src` after cache-busting. */
+export const RERUN_SRC_ATTR = 'data-eco-rerun-src';
+
+/**
+ * Returns a registered in-memory rerun callback for the given script id.
+ */
+export function getRegisteredRerunScript(scriptId: string | null): RerunScriptCallback | null {
+	if (!scriptId) {
+		return null;
+	}
+
+	const runtimeWindow = window as Window &
+		typeof globalThis & {
+			__ECO_PAGES__?: {
+				rerunScripts?: Record<string, RerunScriptCallback | undefined>;
+			};
+		};
+
+	return runtimeWindow.__ECO_PAGES__?.rerunScripts?.[scriptId] ?? null;
+}

--- a/packages/core/src/client/navigation-scripts/rerun-queue.ts
+++ b/packages/core/src/client/navigation-scripts/rerun-queue.ts
@@ -74,6 +74,10 @@ export function createRerunScriptUrl(src: string): string {
 
 /**
  * Replays queued rerun scripts after the incoming page body is in place.
+ *
+ * @remarks
+ * Flushed elements keep `data-eco-rerun` so head cleanup does not treat them
+ * as persistable inline scripts on the next navigation.
  */
 export function flushPendingRerunScripts(scripts: readonly PendingRerunScript[]): void {
 	for (const script of scripts) {
@@ -83,10 +87,6 @@ export function flushPendingRerunScripts(scripts: readonly PendingRerunScript[])
 		const shouldBustModuleSrc = isExternalModuleRerunScript(script) && !registeredRerun;
 
 		for (const [name, value] of script.attributes) {
-			if (name === 'data-eco-rerun') {
-				continue;
-			}
-
 			if (name === 'src' && shouldBustModuleSrc) {
 				replacement.setAttribute(RERUN_SRC_ATTR, value);
 				replacement.setAttribute('src', createRerunScriptUrl(value));

--- a/packages/core/src/client/navigation-scripts/rerun-queue.ts
+++ b/packages/core/src/client/navigation-scripts/rerun-queue.ts
@@ -1,0 +1,125 @@
+/**
+ * Queueing and replay of `data-eco-rerun` scripts after navigation.
+ * @module
+ */
+
+import { RERUN_SRC_ATTR, getRegisteredRerunScript } from './registry.ts';
+
+export type PendingRerunScript = {
+	parent: 'head' | 'body';
+	attributes: Array<[string, string]>;
+	textContent: string;
+	src: string | null;
+	scriptId: string | null;
+};
+
+let rerunNonce = 0;
+
+/**
+ * Collects rerun scripts from an incoming document.
+ */
+export function collectRerunScripts(
+	document: Document,
+	filter?: (script: HTMLScriptElement) => boolean,
+): PendingRerunScript[] {
+	return Array.from(document.querySelectorAll<HTMLScriptElement>('script[data-eco-rerun]'))
+		.filter((script) => (filter ? filter(script) : true))
+		.map((script) => ({
+			parent: script.closest('body') ? 'body' : 'head',
+			attributes: Array.from(script.attributes).map((attribute) => [attribute.name, attribute.value]),
+			textContent: script.textContent ?? '',
+			src: script.getAttribute('src'),
+			scriptId: script.getAttribute('data-eco-script-id'),
+		}));
+}
+
+/**
+ * Returns whether a rerun script is an external ES module that needs cache busting.
+ */
+export function isExternalModuleRerunScript(script: PendingRerunScript): boolean {
+	if (!script.src) {
+		return false;
+	}
+
+	return script.attributes.some(([name, value]) => name === 'type' && value === 'module');
+}
+
+/**
+ * Finds an existing rerun script in `root` by id or by src and inline content.
+ */
+export function findExistingRerunScript(root: ParentNode, script: PendingRerunScript): HTMLScriptElement | null {
+	const scripts = Array.from(root.querySelectorAll<HTMLScriptElement>('script'));
+
+	if (script.scriptId) {
+		return scripts.find((candidate) => candidate.getAttribute('data-eco-script-id') === script.scriptId) ?? null;
+	}
+
+	return (
+		scripts.find(
+			(candidate) =>
+				(candidate.getAttribute(RERUN_SRC_ATTR) ?? candidate.getAttribute('src')) === script.src &&
+				(candidate.textContent ?? '') === script.textContent,
+		) ?? null
+	);
+}
+
+/**
+ * Appends a nonce query parameter so module scripts re-execute after navigation.
+ */
+export function createRerunScriptUrl(src: string): string {
+	const url = new URL(src, document.baseURI);
+	url.searchParams.set('__eco_rerun', String(++rerunNonce));
+	return url.toString();
+}
+
+/**
+ * Replays queued rerun scripts after the incoming page body is in place.
+ */
+export function flushPendingRerunScripts(scripts: readonly PendingRerunScript[]): void {
+	for (const script of scripts) {
+		const targetParent = script.parent === 'body' ? document.body : document.head;
+		const registeredRerun = getRegisteredRerunScript(script.scriptId);
+		const replacement = document.createElement('script');
+		const shouldBustModuleSrc = isExternalModuleRerunScript(script) && !registeredRerun;
+
+		for (const [name, value] of script.attributes) {
+			if (name === 'data-eco-rerun') {
+				continue;
+			}
+
+			if (name === 'src' && shouldBustModuleSrc) {
+				replacement.setAttribute(RERUN_SRC_ATTR, value);
+				replacement.setAttribute('src', createRerunScriptUrl(value));
+				continue;
+			}
+
+			replacement.setAttribute(name, value);
+		}
+
+		replacement.textContent = script.textContent;
+
+		const existingScript = findExistingRerunScript(targetParent, script);
+
+		if (registeredRerun) {
+			const needsScriptElement = isExternalModuleRerunScript(script);
+			if (!existingScript && needsScriptElement) {
+				targetParent.appendChild(replacement);
+			}
+
+			registeredRerun();
+			continue;
+		}
+
+		if (existingScript) {
+			existingScript.replaceWith(replacement);
+			continue;
+		}
+
+		targetParent.appendChild(replacement);
+	}
+}
+
+/** @remarks Test-only reset for nonce sequencing. */
+export function resetRerunNonceForTests(): void {
+	rerunNonce = 0;
+}

--- a/packages/react-router/src/head-morpher.ts
+++ b/packages/react-router/src/head-morpher.ts
@@ -4,70 +4,22 @@
  * @module
  */
 
+import {
+	RERUN_SRC_ATTR,
+	collectRerunScripts,
+	flushPendingRerunScripts,
+	isNonExecutableHeadScript,
+	isRerunScript,
+	shouldPersistExecutableInlineHeadScript,
+} from '@ecopages/core/client/navigation-scripts';
 import { isReactRouterPageBootstrapAssetSrc } from './hydration-assets.ts';
 
 const PRESERVE_SELECTORS = ['meta[charset]', '[data-eco-persist]'];
-const RERUN_SRC_ATTR = 'data-eco-rerun-src';
-
-type PendingRerunScript = {
-	attributes: Array<[string, string]>;
-	textContent: string;
-	scriptId: string | null;
-	src: string | null;
-};
-
-type RerunScriptCallback = () => void;
 
 export type HeadMorphResult = {
 	cleanup: () => void;
 	flushRerunScripts: () => void;
 };
-
-let rerunNonce = 0;
-
-function isNonExecutableHeadScript(el: Element): boolean {
-	if (el.tagName !== 'SCRIPT') {
-		return false;
-	}
-
-	const type = (el.getAttribute('type') ?? '').trim().toLowerCase();
-	if (!type) {
-		return false;
-	}
-
-	return ![
-		'application/javascript',
-		'application/ecmascript',
-		'module',
-		'text/ecmascript',
-		'text/javascript',
-	].includes(type);
-}
-
-function shouldPersistExecutableInlineHeadScript(el: Element): boolean {
-	if (el.tagName !== 'SCRIPT') {
-		return false;
-	}
-
-	const scriptId = el.getAttribute('data-eco-script-id') || el.getAttribute('id');
-	if (!scriptId) {
-		return false;
-	}
-
-	if (el.hasAttribute('data-eco-rerun')) {
-		return false;
-	}
-
-	if ((el as HTMLScriptElement).src) {
-		return false;
-	}
-
-	return !isNonExecutableHeadScript(el);
-}
-
-function isRerunScript(el: Element): el is HTMLScriptElement {
-	return el.tagName === 'SCRIPT' && el.hasAttribute('data-eco-rerun');
-}
 
 function isReactRouterPageBootstrapScriptId(scriptId: string | null): boolean {
 	return !!scriptId && scriptId.startsWith('ecopages-react-') && !scriptId.startsWith('ecopages-react-island-');
@@ -123,12 +75,10 @@ function getHeadElementKey(el: Element): string | null {
 
 /**
  * Morphs the current document head to match the new document's head.
- * Now splits the process into adding new elements and returning a cleanup function
- * to remove old ones. This is crucial for View Transitions to ensure styles
- * don't disappear before the "old" snapshot is taken.
  *
- * @param newDocument - The parsed document from the navigation target
- * @returns Promise that resolves to cleanup and rerun hooks when new stylesheets have loaded
+ * @remarks
+ * Returns cleanup and rerun hooks separately so callers can defer head removal
+ * until after a view-transition snapshot captures the old styles.
  */
 export async function morphHead(newDocument: Document): Promise<HeadMorphResult> {
 	const currentHead = document.head;
@@ -138,36 +88,18 @@ export async function morphHead(newDocument: Document): Promise<HeadMorphResult>
 	const newElements = new Map<string, Element>();
 	const stylesheetPromises: Promise<void>[] = [];
 	const elementsToRemove: Element[] = [];
-	const pendingRerunScripts = Array.from(newHead.querySelectorAll<HTMLScriptElement>('script[data-eco-rerun]'))
-		.filter((script) => !isHydrationScript(script))
-		.map((script) => ({
-			attributes: Array.from(script.attributes).map((attr) => [attr.name, attr.value] as [string, string]),
-			textContent: script.textContent ?? '',
-			scriptId: script.getAttribute('data-eco-script-id'),
-			src: script.getAttribute('src'),
-		}));
+	const pendingRerunScripts = collectRerunScripts(newDocument, (script) => !isHydrationScript(script));
 
-	/**
-	 * First, map existing head elements by their keys
-	 * to enable efficient diffing.
-	 */
 	for (const el of Array.from(currentHead.children)) {
 		const key = getHeadElementKey(el);
 		if (key) currentElements.set(key, el);
 	}
 
-	/**
-	 * Next, map new head elements by their keys.
-	 * This allows us to see which elements are new, updated, or removed.
-	 */
 	for (const el of Array.from(newHead.children)) {
 		const key = getHeadElementKey(el);
 		if (key) newElements.set(key, el);
 	}
 
-	/**
-	 * Now, iterate over new elements to add or update them in the current head.
-	 */
 	for (const [key, newEl] of newElements) {
 		const currentEl = currentElements.get(key);
 
@@ -176,20 +108,12 @@ export async function morphHead(newDocument: Document): Promise<HeadMorphResult>
 		}
 
 		if (!currentEl) {
-			/**
-			 * Skip hydration scripts during SPA navigation to prevent re-mounting.
-			 * The EcoRouter is already running and handles page updates internally.
-			 */
 			if (newEl.tagName === 'SCRIPT' && isHydrationScript(newEl as HTMLScriptElement)) {
 				continue;
 			}
 
 			const cloned = newEl.cloneNode(true) as Element;
 
-			/**
-			 * If the new element is a stylesheet, we need to wait for it to load
-			 * before considering the head morph complete. This prevents FOUC.
-			 */
 			if (cloned.tagName === 'LINK' && (cloned as HTMLLinkElement).rel === 'stylesheet') {
 				const loadPromise = new Promise<void>((resolve) => {
 					(cloned as HTMLLinkElement).onload = () => resolve();
@@ -208,9 +132,6 @@ export async function morphHead(newDocument: Document): Promise<HeadMorphResult>
 		}
 	}
 
-	/**
-	 * Finally, handle any new elements without keys (e.g., inline scripts/styles)
-	 */
 	for (const newEl of Array.from(newHead.children)) {
 		const key = getHeadElementKey(newEl);
 		if (!key && !isRerunScript(newEl)) {
@@ -218,17 +139,10 @@ export async function morphHead(newDocument: Document): Promise<HeadMorphResult>
 		}
 	}
 
-	/**
-	 * Wait for all new stylesheets to load before proceeding.
-	 */
 	if (stylesheetPromises.length > 0) {
 		await Promise.all(stylesheetPromises);
 	}
 
-	/**
-	 * Identify and prepare to remove any old elements
-	 * that are no longer present in the new head.
-	 */
 	for (const [key, el] of currentElements) {
 		if (!newElements.has(key)) {
 			const shouldPreserve = PRESERVE_SELECTORS.some((sel) => el.matches(sel));
@@ -238,11 +152,6 @@ export async function morphHead(newDocument: Document): Promise<HeadMorphResult>
 		}
 	}
 
-	/**
-	 * Return a cleanup function to remove old elements.
-	 * This allows the caller to control when the removal happens,
-	 * which is important for View Transitions.
-	 */
 	return {
 		cleanup: () => {
 			for (const el of elementsToRemove) {
@@ -250,85 +159,7 @@ export async function morphHead(newDocument: Document): Promise<HeadMorphResult>
 			}
 		},
 		flushRerunScripts: () => {
-			for (const script of pendingRerunScripts) {
-				const registeredRerun = getRegisteredRerunScript(script.scriptId);
-				const replacement = document.createElement('script');
-				const shouldBustModuleSrc = isExternalModuleRerunScript(script) && !registeredRerun;
-
-				for (const [name, value] of script.attributes) {
-					if (name === 'src' && shouldBustModuleSrc) {
-						replacement.setAttribute(RERUN_SRC_ATTR, value);
-						replacement.setAttribute('src', createRerunScriptUrl(value));
-						continue;
-					}
-
-					replacement.setAttribute(name, value);
-				}
-
-				replacement.textContent = script.textContent;
-
-				const existingScript = findExistingRerunScript(script);
-				if (registeredRerun) {
-					if (!existingScript) {
-						document.head.appendChild(replacement);
-					}
-
-					registeredRerun();
-					continue;
-				}
-
-				if (existingScript) {
-					existingScript.replaceWith(replacement);
-					continue;
-				}
-
-				document.head.appendChild(replacement);
-			}
+			flushPendingRerunScripts(pendingRerunScripts);
 		},
 	};
-}
-
-function findExistingRerunScript(script: PendingRerunScript): HTMLScriptElement | null {
-	const scripts = Array.from(document.head.querySelectorAll<HTMLScriptElement>('script'));
-
-	if (script.scriptId) {
-		return scripts.find((candidate) => candidate.getAttribute('data-eco-script-id') === script.scriptId) ?? null;
-	}
-
-	return (
-		scripts.find(
-			(candidate) =>
-				(candidate.getAttribute(RERUN_SRC_ATTR) ?? candidate.getAttribute('src')) === script.src &&
-				(candidate.textContent ?? '') === script.textContent,
-		) ?? null
-	);
-}
-
-function isExternalModuleRerunScript(script: PendingRerunScript): boolean {
-	if (!script.src) {
-		return false;
-	}
-
-	return script.attributes.some(([name, value]) => name === 'type' && value === 'module');
-}
-
-function getRegisteredRerunScript(scriptId: string | null): RerunScriptCallback | null {
-	if (!scriptId) {
-		return null;
-	}
-
-	const runtimeWindow = window as Window &
-		typeof globalThis & {
-			__ECO_PAGES__?: {
-				rerunScripts?: Record<string, RerunScriptCallback | undefined>;
-			};
-		};
-
-	return runtimeWindow.__ECO_PAGES__?.rerunScripts?.[scriptId] ?? null;
-}
-
-function createRerunScriptUrl(src: string): string {
-	const url = new URL(src, document.baseURI);
-	url.searchParams.set('__eco_rerun', String(++rerunNonce));
-	return url.toString();
 }


### PR DESCRIPTION
## Summary
- Add `@ecopages/core/client/navigation-scripts` for rerun classification, registry access, and flush queue
- Wire `dom-swapper` and `head-morpher` to the shared module; remove duplicated rerun logic

## Test plan
- `pnpm exec vitest run packages/core/src/client/navigation-scripts/navigation-scripts.test.browser.ts`
- `pnpm exec vitest run packages/browser-router/test/dom-swapper.service.test.browser.ts`
- `pnpm exec vitest run packages/react-router/test/navigation.test.browser.ts`