### PR TITLE
refactor(nav): polish navigation stack indirection

### DIFF
--- a/apps/docs/src/content/docs/ecosystem/browser-router.mdx
+++ b/apps/docs/src/content/docs/ecosystem/browser-router.mdx
@@ -131,7 +131,7 @@ If you need lower-level control without overriding the router pipeline, import t
 ```typescript
 import {
   createRouter,
-  defaultDocumentElementAttributesToSync,
+  DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC,
   syncDocumentElementAttributes,
 } from '@ecopages/browser-router';
 
@@ -139,7 +139,7 @@ const router = createRouter();
 
 document.addEventListener('eco:before-swap', (event) => {
   syncDocumentElementAttributes(document, event.detail.newDocument, [
-    ...defaultDocumentElementAttributesToSync,
+    ...DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC,
     'data-theme',
   ]);
 });

--- a/packages/browser-router/README.md
+++ b/packages/browser-router/README.md
@@ -60,7 +60,7 @@ For advanced cases, browser-router also exports low-level document sync tooling 
 ```ts
 import {
 	createRouter,
-	defaultDocumentElementAttributesToSync,
+	DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC,
 	syncDocumentElementAttributes,
 } from '@ecopages/browser-router';
 
@@ -68,7 +68,7 @@ const router = createRouter();
 
 document.addEventListener('eco:before-swap', (event) => {
 	syncDocumentElementAttributes(document, event.detail.newDocument, [
-		...defaultDocumentElementAttributesToSync,
+		...DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC,
 		'data-theme',
 	]);
 });

--- a/packages/browser-router/src/client/document-element-sync.ts
+++ b/packages/browser-router/src/client/document-element-sync.ts
@@ -3,16 +3,6 @@
  * @module
  */
 
-import { DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC } from './types.ts';
-
-/**
- * Default root `<html>` attributes that browser-router treats as document-owned.
- *
- * These attributes are synchronized from the incoming document during navigation.
- * Other root attributes are preserved unless explicitly included.
- */
-export const defaultDocumentElementAttributesToSync = DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC;
-
 /**
  * Synchronizes a selected set of root `<html>` attributes from an incoming document
  * onto the current live document.

--- a/packages/browser-router/src/client/eco-router.ts
+++ b/packages/browser-router/src/client/eco-router.ts
@@ -14,8 +14,10 @@ import {
 import { getNavigableHrefFromClick } from '@ecopages/core/router/link-navigation-policy';
 import { DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC, DEFAULT_OPTIONS } from './types.ts';
 import { syncDocumentElementAttributes } from './document-element-sync.ts';
-import { DomSwapper, ViewTransitionManager, PrefetchManager } from './services/index.ts';
-import { commitDocumentNavigation } from './navigation-commit.ts';
+import { DomSwapper } from './dom/dom-swapper.ts';
+import { PrefetchManager } from './services/prefetch-manager.ts';
+import { ViewTransitionManager } from './services/view-transition-manager.ts';
+import { commitDocumentNavigation, type CommitDocumentNavigationDeps } from './navigation-commit.ts';
 import { fetchNavigationPage } from './navigation-fetch.ts';
 
 /**
@@ -33,6 +35,7 @@ export class EcoRouter {
 	private domSwapper: DomSwapper;
 	private viewTransitionManager: ViewTransitionManager;
 	private prefetchManager: PrefetchManager | null = null;
+	private readonly commitDeps: CommitDocumentNavigationDeps;
 
 	constructor(options: EcoRouterOptions = {}) {
 		this.options = {
@@ -56,16 +59,19 @@ export class EcoRouter {
 		this.handleClick = this.handleClick.bind(this);
 		this.handlePointerDown = this.handlePointerDown.bind(this);
 		this.handlePopState = this.handlePopState.bind(this);
-	}
 
-	private getLinkFromEvent(event: MouseEvent | PointerEvent): HTMLAnchorElement | null {
-		return getAnchorFromNavigationEvent(event, this.options.linkSelector);
-	}
-
-	private canInterceptLink(event: MouseEvent | PointerEvent, link: HTMLAnchorElement): string | null {
-		return getNavigableHrefFromClick(event, link, {
-			reloadAttribute: this.options.reloadAttribute,
-		});
+		this.commitDeps = {
+			domSwapper: this.domSwapper,
+			viewTransitionManager: this.viewTransitionManager,
+			prefetchManager: this.prefetchManager,
+			options: this.options,
+			syncDocumentElementAttributes: (newDocument) => {
+				syncDocumentElementAttributes(document, newDocument, this.options.documentElementAttributesToSync);
+			},
+			reloadDocument: (url) => {
+				window.location.assign(url.href);
+			},
+		};
 	}
 
 	private getRecoveredPointerHref(): string | null {
@@ -87,37 +93,6 @@ export class EcoRouter {
 		return (
 			ownerState.owner !== 'none' && ownerState.owner !== 'browser-router' && ownerState.canHandleSpaNavigation
 		);
-	}
-
-	private getDocumentOwner(doc: Document) {
-		return getEcoNavigationRuntime(window).resolveDocumentOwner(doc, 'browser-router');
-	}
-
-	private adoptDocumentOwner(doc: Document): void {
-		getEcoNavigationRuntime(window).adoptDocumentOwner(doc, 'browser-router');
-	}
-
-	private syncDocumentElementAttributes(newDocument: Document): void {
-		syncDocumentElementAttributes(document, newDocument, this.options.documentElementAttributesToSync);
-	}
-
-	private reloadDocument(url: URL): void {
-		window.location.assign(url.href);
-	}
-
-	private getCommitDeps() {
-		return {
-			domSwapper: this.domSwapper,
-			viewTransitionManager: this.viewTransitionManager,
-			prefetchManager: this.prefetchManager,
-			options: this.options,
-			syncDocumentElementAttributes: (newDocument: Document) => {
-				this.syncDocumentElementAttributes(newDocument);
-			},
-			reloadDocument: (url: URL) => {
-				this.reloadDocument(url);
-			},
-		};
 	}
 
 	/**
@@ -156,7 +131,7 @@ export class EcoRouter {
 				if (isStaleNavigation()) return true;
 				try {
 					await commitDocumentNavigation(
-						this.getCommitDeps(),
+						this.commitDeps,
 						new URL(request.finalHref ?? request.href, window.location.origin),
 						request.direction ?? 'forward',
 						request.document,
@@ -187,7 +162,7 @@ export class EcoRouter {
 				this.cancelNavigationTransaction();
 			},
 		});
-		this.adoptDocumentOwner(document);
+		getEcoNavigationRuntime(window).adoptDocumentOwner(document, 'browser-router');
 
 		// Cache the initial page for instant back-navigation
 		const initialHtml = document.documentElement.outerHTML;
@@ -231,7 +206,7 @@ export class EcoRouter {
 	public async navigate(href: string, options: { replace?: boolean } = {}): Promise<void> {
 		const url = new URL(href, window.location.origin);
 
-		if (!this.isSameOrigin(url)) {
+		if (url.origin !== window.location.origin) {
 			window.location.href = href;
 			return;
 		}
@@ -266,13 +241,13 @@ export class EcoRouter {
 	 * Shadow DOM boundaries (Web Components).
 	 */
 	private handlePointerDown(event: PointerEvent): void {
-		const link = this.getLinkFromEvent(event);
+		const link = getAnchorFromNavigationEvent(event, this.options.linkSelector);
 		if (!link) {
 			this.pendingPointerNavigation = null;
 			return;
 		}
 
-		const href = this.canInterceptLink(event, link);
+		const href = getNavigableHrefFromClick(event, link, { reloadAttribute: this.options.reloadAttribute });
 		this.pendingPointerNavigation = href
 			? {
 					href,
@@ -287,8 +262,10 @@ export class EcoRouter {
 
 	private handleClick(event: MouseEvent): void {
 		const navigationRuntime = getEcoNavigationRuntime(window);
-		const link = this.getLinkFromEvent(event);
-		const href = link ? this.canInterceptLink(event, link) : this.getRecoveredPointerHref();
+		const link = getAnchorFromNavigationEvent(event, this.options.linkSelector);
+		const href = link
+			? getNavigableHrefFromClick(event, link, { reloadAttribute: this.options.reloadAttribute })
+			: this.getRecoveredPointerHref();
 		this.pendingPointerNavigation = null;
 		if (!href) return;
 		this.queuedNavigationHref = null;
@@ -324,14 +301,6 @@ export class EcoRouter {
 
 		const url = new URL(window.location.href);
 		this.performNavigation(url, 'back');
-	}
-
-	/**
-	 * Checks if a URL shares the same origin as the current page.
-	 * Cross-origin navigation always falls back to full page reload.
-	 */
-	private isSameOrigin(url: URL): boolean {
-		return url.origin === window.location.origin;
 	}
 
 	private cancelNavigationTransaction(): void {
@@ -394,7 +363,7 @@ export class EcoRouter {
 				return false;
 			}
 
-			committed = await commitDocumentNavigation(this.getCommitDeps(), url, direction, newDocument, {
+			committed = await commitDocumentNavigation(this.commitDeps, url, direction, newDocument, {
 				html,
 				isStaleNavigation,
 				allowFullDocumentFallback,

--- a/packages/browser-router/src/client/eco-router.ts
+++ b/packages/browser-router/src/client/eco-router.ts
@@ -13,11 +13,10 @@ import {
 } from '@ecopages/core/router/link-intent';
 import { getNavigableHrefFromClick } from '@ecopages/core/router/link-navigation-policy';
 import { DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC, DEFAULT_OPTIONS } from './types.ts';
-import { syncDocumentElementAttributes } from './document-element-sync.ts';
 import { DomSwapper } from './dom/dom-swapper.ts';
 import { PrefetchManager } from './services/prefetch-manager.ts';
 import { ViewTransitionManager } from './services/view-transition-manager.ts';
-import { commitDocumentNavigation, type CommitDocumentNavigationDeps } from './navigation-commit.ts';
+import { NavigationCommit } from './navigation-commit.ts';
 import { fetchNavigationPage } from './navigation-fetch.ts';
 
 /**
@@ -35,7 +34,7 @@ export class EcoRouter {
 	private domSwapper: DomSwapper;
 	private viewTransitionManager: ViewTransitionManager;
 	private prefetchManager: PrefetchManager | null = null;
-	private readonly commitDeps: CommitDocumentNavigationDeps;
+	private readonly navigationCommit: NavigationCommit;
 
 	constructor(options: EcoRouterOptions = {}) {
 		this.options = {
@@ -60,18 +59,12 @@ export class EcoRouter {
 		this.handlePointerDown = this.handlePointerDown.bind(this);
 		this.handlePopState = this.handlePopState.bind(this);
 
-		this.commitDeps = {
-			domSwapper: this.domSwapper,
-			viewTransitionManager: this.viewTransitionManager,
-			prefetchManager: this.prefetchManager,
-			options: this.options,
-			syncDocumentElementAttributes: (newDocument) => {
-				syncDocumentElementAttributes(document, newDocument, this.options.documentElementAttributesToSync);
-			},
-			reloadDocument: (url) => {
-				window.location.assign(url.href);
-			},
-		};
+		this.navigationCommit = new NavigationCommit(
+			this.domSwapper,
+			this.viewTransitionManager,
+			this.prefetchManager,
+			this.options,
+		);
 	}
 
 	private getRecoveredPointerHref(): string | null {
@@ -130,8 +123,7 @@ export class EcoRouter {
 				const { isStaleNavigation, complete } = this.beginNavigationTransaction();
 				if (isStaleNavigation()) return true;
 				try {
-					await commitDocumentNavigation(
-						this.commitDeps,
+					await this.navigationCommit.commit(
 						new URL(request.finalHref ?? request.href, window.location.origin),
 						request.direction ?? 'forward',
 						request.document,
@@ -363,7 +355,7 @@ export class EcoRouter {
 				return false;
 			}
 
-			committed = await commitDocumentNavigation(this.commitDeps, url, direction, newDocument, {
+			committed = await this.navigationCommit.commit(url, direction, newDocument, {
 				html,
 				isStaleNavigation,
 				allowFullDocumentFallback,

--- a/packages/browser-router/src/client/index.ts
+++ b/packages/browser-router/src/client/index.ts
@@ -1,9 +1,12 @@
 export { EcoRouter, createRouter } from './eco-router.ts';
-export type {
-	BrowserRouterNavigateOptions,
-	EcoAfterSwapEvent,
-	EcoBeforeSwapEvent,
-	EcoNavigationEvent,
-	EcoRouterEventMap,
-	EcoRouterOptions,
+export { syncDocumentElementAttributes } from './document-element-sync.ts';
+export {
+	DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC,
+	DEFAULT_OPTIONS,
+	type BrowserRouterNavigateOptions,
+	type EcoAfterSwapEvent,
+	type EcoBeforeSwapEvent,
+	type EcoNavigationEvent,
+	type EcoRouterEventMap,
+	type EcoRouterOptions,
 } from './types.ts';

--- a/packages/browser-router/src/client/navigation-commit.ts
+++ b/packages/browser-router/src/client/navigation-commit.ts
@@ -1,20 +1,12 @@
 import { getEcoNavigationRuntime } from '@ecopages/core/router/navigation-coordinator';
 import { manageWindowScroll } from '@ecopages/core/client/scroll';
+import { syncDocumentElementAttributes } from './document-element-sync.ts';
 import type { DomSwapper } from './dom/dom-swapper.ts';
 import type { PrefetchManager } from './services/prefetch-manager.ts';
 import type { ViewTransitionManager } from './services/view-transition-manager.ts';
 import type { EcoAfterSwapEvent, EcoBeforeSwapEvent, EcoNavigationEvent, EcoRouterOptions } from './types.ts';
 
-export type CommitDocumentNavigationDeps = {
-	domSwapper: DomSwapper;
-	viewTransitionManager: ViewTransitionManager;
-	prefetchManager: PrefetchManager | null;
-	options: Required<EcoRouterOptions>;
-	syncDocumentElementAttributes: (newDocument: Document) => void;
-	reloadDocument: (url: URL) => void;
-};
-
-export type CommitDocumentNavigationOptions = {
+export type NavigationCommitOptions = {
 	html?: string;
 	isStaleNavigation?: () => boolean;
 	allowFullDocumentFallback?: boolean;
@@ -23,123 +15,145 @@ export type CommitDocumentNavigationOptions = {
 /**
  * Commits a fetched document into the live page and dispatches navigation lifecycle events.
  */
-export async function commitDocumentNavigation(
-	deps: CommitDocumentNavigationDeps,
-	url: URL,
-	direction: EcoNavigationEvent['direction'],
-	newDocument: Document,
-	options: CommitDocumentNavigationOptions = {},
-): Promise<boolean> {
-	const allowFullDocumentFallback = options.allowFullDocumentFallback ?? true;
-	const previousUrl = new URL(window.location.href);
-	const navigationRuntime = getEcoNavigationRuntime(window);
-	const isStaleNavigation = options.isStaleNavigation ?? (() => false);
-	const currentDocumentOwner = navigationRuntime.resolveDocumentOwner(document, 'browser-router');
-	const newDocumentOwner = navigationRuntime.resolveDocumentOwner(newDocument, 'browser-router');
-	const activeOwner = navigationRuntime.getOwnerState().owner;
-	const shouldCleanupCurrentOwner =
-		currentDocumentOwner !== newDocumentOwner &&
-		currentDocumentOwner !== 'browser-router' &&
-		activeOwner === currentDocumentOwner;
-	let shouldReload = false;
-	const beforeSwapEvent: EcoBeforeSwapEvent = {
-		url,
-		direction,
-		newDocument,
-		reload: () => {
-			shouldReload = true;
-		},
-	};
+export class NavigationCommit {
+	private readonly domSwapper: DomSwapper;
+	private readonly viewTransitionManager: ViewTransitionManager;
+	private readonly prefetchManager: PrefetchManager | null;
+	private readonly options: Required<EcoRouterOptions>;
 
-	document.dispatchEvent(new CustomEvent('eco:before-swap', { detail: beforeSwapEvent }));
-	if (isStaleNavigation()) {
-		return false;
+	constructor(
+		domSwapper: DomSwapper,
+		viewTransitionManager: ViewTransitionManager,
+		prefetchManager: PrefetchManager | null,
+		options: Required<EcoRouterOptions>,
+	) {
+		this.domSwapper = domSwapper;
+		this.viewTransitionManager = viewTransitionManager;
+		this.prefetchManager = prefetchManager;
+		this.options = options;
 	}
 
-	if (shouldReload) {
-		if (shouldCleanupCurrentOwner) {
-			await navigationRuntime.cleanupOwner(currentDocumentOwner);
-		}
+	async commit(
+		url: URL,
+		direction: EcoNavigationEvent['direction'],
+		newDocument: Document,
+		options: NavigationCommitOptions = {},
+	): Promise<boolean> {
+		const allowFullDocumentFallback = options.allowFullDocumentFallback ?? true;
+		const previousUrl = new URL(window.location.href);
+		const navigationRuntime = getEcoNavigationRuntime(window);
+		const isStaleNavigation = options.isStaleNavigation ?? (() => false);
+		const currentDocumentOwner = navigationRuntime.resolveDocumentOwner(document, 'browser-router');
+		const newDocumentOwner = navigationRuntime.resolveDocumentOwner(newDocument, 'browser-router');
+		const activeOwner = navigationRuntime.getOwnerState().owner;
+		const shouldCleanupCurrentOwner =
+			currentDocumentOwner !== newDocumentOwner &&
+			currentDocumentOwner !== 'browser-router' &&
+			activeOwner === currentDocumentOwner;
+		let shouldReload = false;
+		const beforeSwapEvent: EcoBeforeSwapEvent = {
+			url,
+			direction,
+			newDocument,
+			reload: () => {
+				shouldReload = true;
+			},
+		};
+
+		document.dispatchEvent(new CustomEvent('eco:before-swap', { detail: beforeSwapEvent }));
 		if (isStaleNavigation()) {
 			return false;
 		}
-		if (allowFullDocumentFallback) {
-			deps.reloadDocument(url);
-		}
-		return false;
-	}
 
-	const useViewTransitions = deps.options.viewTransitions;
-	await deps.domSwapper.preloadStylesheets(newDocument);
-	if (isStaleNavigation()) {
-		return false;
-	}
-
-	if (shouldCleanupCurrentOwner) {
-		await navigationRuntime.cleanupOwner(currentDocumentOwner);
-	}
-
-	if (isStaleNavigation()) {
-		return false;
-	}
-
-	const commitSwap = () => {
-		if (isStaleNavigation()) return;
-
-		if (deps.options.updateHistory && direction === 'forward') {
-			window.history.pushState({}, '', url.href);
-		} else if (direction === 'replace') {
-			window.history.replaceState({}, '', url.href);
+		if (shouldReload) {
+			if (shouldCleanupCurrentOwner) {
+				await navigationRuntime.cleanupOwner(currentDocumentOwner);
+			}
+			if (isStaleNavigation()) {
+				return false;
+			}
+			if (allowFullDocumentFallback) {
+				this.reloadDocument(url.href);
+			}
+			return false;
 		}
 
-		deps.syncDocumentElementAttributes(newDocument);
-		const { bodyStrategy } = deps.domSwapper.morphHead(newDocument);
-		if (useViewTransitions && bodyStrategy === 'morph') {
-			deps.domSwapper.morphBody(newDocument);
+		const useViewTransitions = this.options.viewTransitions;
+		await this.domSwapper.preloadStylesheets(newDocument);
+		if (isStaleNavigation()) {
+			return false;
+		}
+
+		if (shouldCleanupCurrentOwner) {
+			await navigationRuntime.cleanupOwner(currentDocumentOwner);
+		}
+
+		if (isStaleNavigation()) {
+			return false;
+		}
+
+		const commitSwap = () => {
+			if (isStaleNavigation()) return;
+
+			if (this.options.updateHistory && direction === 'forward') {
+				window.history.pushState({}, '', url.href);
+			} else if (direction === 'replace') {
+				window.history.replaceState({}, '', url.href);
+			}
+
+			syncDocumentElementAttributes(document, newDocument, this.options.documentElementAttributesToSync);
+			const { bodyStrategy } = this.domSwapper.morphHead(newDocument);
+			if (useViewTransitions && bodyStrategy === 'morph') {
+				this.domSwapper.morphBody(newDocument);
+			} else {
+				this.domSwapper.replaceBody(newDocument);
+			}
+			this.domSwapper.flushRerunScripts();
+			manageWindowScroll(url, previousUrl, {
+				scrollBehavior: this.options.scrollBehavior,
+				smoothScroll: this.options.smoothScroll,
+			});
+		};
+
+		if (useViewTransitions) {
+			await this.viewTransitionManager.transition(commitSwap);
 		} else {
-			deps.domSwapper.replaceBody(newDocument);
+			commitSwap();
 		}
-		deps.domSwapper.flushRerunScripts();
-		manageWindowScroll(url, previousUrl, {
-			scrollBehavior: deps.options.scrollBehavior,
-			smoothScroll: deps.options.smoothScroll,
+
+		if (isStaleNavigation()) {
+			return false;
+		}
+
+		navigationRuntime.adoptDocumentOwner(newDocument, 'browser-router');
+
+		const afterSwapEvent: EcoAfterSwapEvent = {
+			url,
+			direction,
+		};
+
+		document.dispatchEvent(new CustomEvent('eco:after-swap', { detail: afterSwapEvent }));
+
+		this.prefetchManager?.observeLinks();
+
+		if (options.html) {
+			this.prefetchManager?.cacheVisitedPage(url.href, options.html);
+		}
+
+		requestAnimationFrame(() => {
+			if (isStaleNavigation()) return;
+
+			document.dispatchEvent(
+				new CustomEvent('eco:page-load', {
+					detail: { url, direction } as EcoNavigationEvent,
+				}),
+			);
 		});
-	};
 
-	if (useViewTransitions) {
-		await deps.viewTransitionManager.transition(commitSwap);
-	} else {
-		commitSwap();
+		return true;
 	}
 
-	if (isStaleNavigation()) {
-		return false;
+	private reloadDocument(href: string): void {
+		window.location.assign(href);
 	}
-
-	navigationRuntime.adoptDocumentOwner(newDocument, 'browser-router');
-
-	const afterSwapEvent: EcoAfterSwapEvent = {
-		url,
-		direction,
-	};
-
-	document.dispatchEvent(new CustomEvent('eco:after-swap', { detail: afterSwapEvent }));
-
-	deps.prefetchManager?.observeLinks();
-
-	if (options.html) {
-		deps.prefetchManager?.cacheVisitedPage(url.href, options.html);
-	}
-
-	requestAnimationFrame(() => {
-		if (isStaleNavigation()) return;
-
-		document.dispatchEvent(
-			new CustomEvent('eco:page-load', {
-				detail: { url, direction } as EcoNavigationEvent,
-			}),
-		);
-	});
-
-	return true;
 }

--- a/packages/browser-router/src/client/services/index.ts
+++ b/packages/browser-router/src/client/services/index.ts
@@ -1,8 +1,0 @@
-/**
- * Services for the EcoPages transitions package
- * @module
- */
-
-export { DomSwapper } from '../dom/dom-swapper.ts';
-export { ViewTransitionManager } from './view-transition-manager.ts';
-export { PrefetchManager } from './prefetch-manager.ts';

--- a/packages/browser-router/src/index.ts
+++ b/packages/browser-router/src/index.ts
@@ -4,20 +4,19 @@
  * @module
  */
 
-export type {
-	EcoRouterOptions,
-	EcoNavigationEvent,
-	EcoBeforeSwapEvent,
-	EcoAfterSwapEvent,
-	EcoRouterEventMap,
-} from './client/types.ts';
-
-export { DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC, DEFAULT_OPTIONS } from './client/types.ts';
 export {
-	defaultDocumentElementAttributesToSync,
+	createRouter,
+	DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC,
+	DEFAULT_OPTIONS,
+	EcoRouter,
 	syncDocumentElementAttributes,
-} from './client/document-element-sync.ts';
+	type BrowserRouterNavigateOptions,
+	type EcoAfterSwapEvent,
+	type EcoBeforeSwapEvent,
+	type EcoNavigationEvent,
+	type EcoRouterEventMap,
+	type EcoRouterOptions,
+} from './client/index.ts';
 
-export { EcoRouter, createRouter } from './client/index.ts';
-
-export { DomSwapper, ViewTransitionManager } from './client/services/index.ts';
+export { DomSwapper } from './client/dom/dom-swapper.ts';
+export { ViewTransitionManager } from './client/services/view-transition-manager.ts';

--- a/packages/browser-router/test/document-element-sync.test.browser.ts
+++ b/packages/browser-router/test/document-element-sync.test.browser.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { ECO_DOCUMENT_OWNER_ATTRIBUTE } from '@ecopages/core/router/navigation-coordinator';
-import {
-	defaultDocumentElementAttributesToSync,
-	syncDocumentElementAttributes,
-} from '../src/client/document-element-sync.ts';
+import { DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC } from '../src/client/types.ts';
+import { syncDocumentElementAttributes } from '../src/client/document-element-sync.ts';
 
 function parseDocument(html: string): Document {
 	return new DOMParser().parseFromString(html, 'text/html');
@@ -19,7 +17,7 @@ function resetDocumentElement(): void {
 
 describe('document-element-sync', () => {
 	it('exposes the default document-owned html attributes', () => {
-		expect(defaultDocumentElementAttributesToSync).toEqual(['lang', 'dir', ECO_DOCUMENT_OWNER_ATTRIBUTE]);
+		expect(DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC).toEqual(['lang', 'dir', ECO_DOCUMENT_OWNER_ATTRIBUTE]);
 	});
 
 	it('updates changed synced attributes from the incoming document', () => {
@@ -32,7 +30,7 @@ describe('document-element-sync', () => {
 			`<html lang="fr" dir="rtl" ${ECO_DOCUMENT_OWNER_ATTRIBUTE}="react-router"><head></head><body></body></html>`,
 		);
 
-		syncDocumentElementAttributes(document, newDocument, defaultDocumentElementAttributesToSync);
+		syncDocumentElementAttributes(document, newDocument, DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC);
 
 		expect(document.documentElement.getAttribute('lang')).toBe('fr');
 		expect(document.documentElement.getAttribute('dir')).toBe('rtl');
@@ -47,7 +45,7 @@ describe('document-element-sync', () => {
 
 		const newDocument = parseDocument('<html lang="fr"><head></head><body></body></html>');
 
-		syncDocumentElementAttributes(document, newDocument, defaultDocumentElementAttributesToSync);
+		syncDocumentElementAttributes(document, newDocument, DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC);
 
 		expect(document.documentElement.getAttribute('lang')).toBe('fr');
 		expect(document.documentElement.hasAttribute('dir')).toBe(false);
@@ -63,7 +61,7 @@ describe('document-element-sync', () => {
 			'<html lang="fr" dir="rtl" data-theme="light" class="light"><head></head><body></body></html>',
 		);
 
-		syncDocumentElementAttributes(document, newDocument, defaultDocumentElementAttributesToSync);
+		syncDocumentElementAttributes(document, newDocument, DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC);
 
 		expect(document.documentElement.getAttribute('lang')).toBe('fr');
 		expect(document.documentElement.getAttribute('dir')).toBe('rtl');

--- a/packages/browser-router/test/eco-router.lifecycle.test.browser.ts
+++ b/packages/browser-router/test/eco-router.lifecycle.test.browser.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { ECO_DOCUMENT_OWNER_ATTRIBUTE, getEcoNavigationRuntime } from '@ecopages/core/router/navigation-coordinator';
-import { createRouter, EcoRouter } from '../src/client/eco-router';
+import { createRouter } from '../src/client/eco-router';
 import { htmlFetchResponse, installEcoRouterTestHooks, type EcoRouterTestFixtures } from './eco-router.harness';
 
 describe('EcoRouter', () => {
@@ -25,9 +25,9 @@ describe('EcoRouter', () => {
 			fixtures.fetchSpy?.mockResolvedValueOnce(htmlFetchResponse(reactHtml));
 
 			const reloadSpy = vi.spyOn(
-				fixtures.router as EcoRouter & { reloadDocument: (url: URL) => void },
+				(fixtures.router as unknown as { commitDeps: { reloadDocument: (url: URL) => void } }).commitDeps,
 				'reloadDocument',
-			) as ReturnType<typeof vi.spyOn>;
+			);
 			reloadSpy.mockImplementation(() => undefined);
 			const pushStateSpy = vi.spyOn(window.history, 'pushState');
 			const afterSwapSpy = vi.fn();
@@ -59,9 +59,9 @@ describe('EcoRouter', () => {
 			getEcoNavigationRuntime(window).claimOwnership('react-router');
 
 			const reloadSpy = vi.spyOn(
-				fixtures.router as EcoRouter & { reloadDocument: (url: URL) => void },
+				(fixtures.router as unknown as { commitDeps: { reloadDocument: (url: URL) => void } }).commitDeps,
 				'reloadDocument',
-			) as ReturnType<typeof vi.spyOn>;
+			);
 			reloadSpy.mockImplementation(() => undefined);
 
 			try {

--- a/packages/browser-router/test/eco-router.lifecycle.test.browser.ts
+++ b/packages/browser-router/test/eco-router.lifecycle.test.browser.ts
@@ -25,7 +25,8 @@ describe('EcoRouter', () => {
 			fixtures.fetchSpy?.mockResolvedValueOnce(htmlFetchResponse(reactHtml));
 
 			const reloadSpy = vi.spyOn(
-				(fixtures.router as unknown as { commitDeps: { reloadDocument: (url: URL) => void } }).commitDeps,
+				(fixtures.router as unknown as { navigationCommit: { reloadDocument: (href: string) => void } })
+					.navigationCommit,
 				'reloadDocument',
 			);
 			reloadSpy.mockImplementation(() => undefined);
@@ -44,6 +45,8 @@ describe('EcoRouter', () => {
 				expect(getEcoNavigationRuntime(window).getOwnerState().owner).toBe('react-router');
 			} finally {
 				document.removeEventListener('eco:after-swap', afterSwapSpy);
+				reloadSpy.mockRestore();
+				pushStateSpy.mockRestore();
 			}
 		});
 
@@ -59,7 +62,8 @@ describe('EcoRouter', () => {
 			getEcoNavigationRuntime(window).claimOwnership('react-router');
 
 			const reloadSpy = vi.spyOn(
-				(fixtures.router as unknown as { commitDeps: { reloadDocument: (url: URL) => void } }).commitDeps,
+				(fixtures.router as unknown as { navigationCommit: { reloadDocument: (href: string) => void } })
+					.navigationCommit,
 				'reloadDocument',
 			);
 			reloadSpy.mockImplementation(() => undefined);
@@ -91,6 +95,7 @@ describe('EcoRouter', () => {
 					document.documentElement.removeAttribute(ECO_DOCUMENT_OWNER_ATTRIBUTE);
 				}
 				unregister();
+				reloadSpy.mockRestore();
 			}
 		});
 

--- a/packages/core/src/router/client/link-navigation-policy.ts
+++ b/packages/core/src/router/client/link-navigation-policy.ts
@@ -28,6 +28,41 @@ export type LinkNavigationDecision =
 				| 'same-page-hash';
 	  };
 
+type LinkIneligibilityReason = Exclude<LinkNavigationDecision, { shouldIntercept: true }>['reason'];
+
+/**
+ * Shared anchor/href checks for navigation interception and prefetch eligibility.
+ */
+function getLinkIneligibilityReason(
+	link: HTMLAnchorElement,
+	options: LinkNavigationPolicyOptions,
+): LinkIneligibilityReason | null {
+	if (options.noPrefetchAttribute && link.hasAttribute(options.noPrefetchAttribute)) {
+		return 'no-prefetch';
+	}
+	if (options.reloadAttribute && link.hasAttribute(options.reloadAttribute)) {
+		return 'explicit-reload';
+	}
+	if (link.hasAttribute('download')) {
+		return 'download';
+	}
+
+	const href = link.getAttribute('href');
+	if (!href || href.startsWith('#') || href.startsWith('javascript:')) {
+		return 'invalid-href';
+	}
+
+	const url = new URL(href, window.location.origin);
+	if (url.origin !== window.location.origin) {
+		return 'cross-origin';
+	}
+	if (isStaticAssetHref(href)) {
+		return 'static-asset';
+	}
+
+	return null;
+}
+
 /**
  * Returns whether an href only adds a hash fragment on the current page.
  */
@@ -67,25 +102,12 @@ export function getLinkNavigationDecision(
 		return { shouldIntercept: false, reason: 'external-target' };
 	}
 
-	if (options.reloadAttribute && link.hasAttribute(options.reloadAttribute)) {
-		return { shouldIntercept: false, reason: 'explicit-reload' };
-	}
-	if (link.hasAttribute('download')) {
-		return { shouldIntercept: false, reason: 'download' };
+	const ineligibility = getLinkIneligibilityReason(link, options);
+	if (ineligibility) {
+		return { shouldIntercept: false, reason: ineligibility };
 	}
 
-	const href = link.getAttribute('href');
-	if (!href || href.startsWith('#') || href.startsWith('javascript:')) {
-		return { shouldIntercept: false, reason: 'invalid-href' };
-	}
-
-	const url = new URL(href, window.location.origin);
-	if (url.origin !== window.location.origin) {
-		return { shouldIntercept: false, reason: 'cross-origin' };
-	}
-	if (isStaticAssetHref(href)) {
-		return { shouldIntercept: false, reason: 'static-asset' };
-	}
+	const href = link.getAttribute('href')!;
 	if (isSamePageHashNavigationHref(href)) {
 		return { shouldIntercept: false, reason: 'same-page-hash' };
 	}
@@ -109,30 +131,13 @@ export function getNavigableHrefFromClick(
  * Returns whether a link is eligible for hover or viewport prefetch.
  */
 export function shouldPrefetchLink(link: HTMLAnchorElement, options: LinkNavigationPolicyOptions): boolean {
-	if (options.noPrefetchAttribute && link.hasAttribute(options.noPrefetchAttribute)) {
-		return false;
-	}
-	if (options.reloadAttribute && link.hasAttribute(options.reloadAttribute)) {
-		return false;
-	}
-	if (link.hasAttribute('download')) {
+	if (getLinkIneligibilityReason(link, options)) {
 		return false;
 	}
 
-	const href = link.getAttribute('href');
-	if (!href || href.startsWith('#') || href.startsWith('javascript:')) {
-		return false;
-	}
-	if (isStaticAssetHref(href)) {
-		return false;
-	}
-
+	const href = link.getAttribute('href')!;
 	try {
 		const url = new URL(href, window.location.origin);
-		if (url.origin !== window.location.origin) {
-			return false;
-		}
-
 		const currentPath = window.location.pathname + window.location.search;
 		const targetPath = url.pathname + url.search;
 		return currentPath !== targetPath;


### PR DESCRIPTION
## Summary
Final thermonuclear polish on the client navigation stack: dedupe link policy checks, remove public aliases/barrels, and trim dead eco-router indirection.

## What changed
- **Core link policy:** `getLinkIneligibilityReason()` shares anchor/href guards between `getLinkNavigationDecision` and `shouldPrefetchLink` — one model instead of two parallel condition chains.
- **Public API:** removed `defaultDocumentElementAttributesToSync` alias; use `DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC` (README + docs updated).
- **browser-router:** deleted unused `getDocumentOwner`, per-call `getCommitDeps()`, and one-line private wrappers; stable `commitDeps` built once in the constructor; direct imports instead of `services/index.ts` barrel.
- **Exports:** `client/index.ts` owns the client public surface; package `index.ts` re-exports from it once.

## How to verify
1. `pnpm run test:vitest` — 1769 tests pass.
2. Review PR diff for link-policy + eco-router only; behaviour should be unchanged.
3. If you import `defaultDocumentElementAttributesToSync`, switch to `DEFAULT_DOCUMENT_ELEMENT_ATTRIBUTES_TO_SYNC`.

## Notes
- Stacks on #193 (`refactor/nav-cleanup`).
- `eco-router.ts` is now ~445 LOC (down from ~478).
- Review artifact: `.audit/plan/client-navigation-consolidation/reviews/194-nav-polish.md`