### PR TITLE
fix(hmr): hot-reload declared client script entrypoints

### DIFF
--- a/e2e/playwright/define-isolated-fixture.ts
+++ b/e2e/playwright/define-isolated-fixture.ts
@@ -11,7 +11,7 @@ import { getEcopagesServerReadySignal } from './isolated-dev-server-ready.ts';
 export const crossIntegrationSourceDir = 'playground/kitchen-sink';
 export const isolatedAppLauncher = 'node e2e/scripts/playwright/run-isolated-app.mjs';
 
-export const crossIntegrationHmrMatch = `${crossIntegrationSourceDir}/e2e/includes-hmr.test.e2e.ts`;
+export const crossIntegrationHmrMatch = `${crossIntegrationSourceDir}/e2e/*-hmr.test.e2e.ts`;
 
 const CROSS_INTEGRATION_DEV_TEST_TIMEOUT_MS = 90_000;
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -148,6 +148,10 @@
 			"types": "./src/dev/client-bridge-registry.ts",
 			"default": "./src/dev/client-bridge-registry.ts"
 		},
+		"./dev/hmr-manager-registry": {
+			"types": "./src/dev/hmr-manager-registry.ts",
+			"default": "./src/dev/hmr-manager-registry.ts"
+		},
 		"./dev/dev-client-ownership": {
 			"types": "./src/dev/dev-client-ownership.ts",
 			"default": "./src/dev/dev-client-ownership.ts"

--- a/packages/core/src/adapters/bun/server-adapter.ts
+++ b/packages/core/src/adapters/bun/server-adapter.ts
@@ -40,6 +40,7 @@ import {
 } from '../shared/runtime-server-lifecycle.ts';
 import { ClientBridge } from './client-bridge.ts';
 import { setAppDevClientBridge } from '../../dev/client-bridge-registry.ts';
+import { setAppHmrManager } from '../../dev/hmr-manager-registry.ts';
 import { HmrManager } from './hmr-manager.ts';
 import { BunStaticPreviewHost } from './static-preview-host.ts';
 
@@ -799,6 +800,7 @@ export async function createBunServerAdapter(params: BunServerAdapterParams): Pr
 	const bridge = params.bridge ?? new ClientBridge();
 	const hmrManager = params.hmrManager ?? new HmrManager({ appConfig: params.appConfig, bridge });
 	setAppDevClientBridge(params.appConfig, bridge);
+	setAppHmrManager(params.appConfig, hmrManager);
 	const previewHost = params.previewHost ?? new BunStaticPreviewHost();
 
 	const adapter = new BunServerAdapter({

--- a/packages/core/src/adapters/node/server-adapter-dependencies.ts
+++ b/packages/core/src/adapters/node/server-adapter-dependencies.ts
@@ -1,6 +1,7 @@
 import { WebSocketServer } from 'ws';
 import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 import { setAppDevClientBridge } from '../../dev/client-bridge-registry.ts';
+import { setAppHmrManager } from '../../dev/hmr-manager-registry.ts';
 import { NodeClientBridge } from './node-client-bridge.ts';
 import { NodeHmrManager } from './node-hmr-manager.ts';
 
@@ -20,6 +21,7 @@ export class DefaultNodeServerDevRuntimeFactory implements NodeServerDevRuntimeF
 		const bridge = new NodeClientBridge();
 		const hmrManager = new NodeHmrManager({ appConfig: options.appConfig, bridge });
 		setAppDevClientBridge(options.appConfig, bridge);
+		setAppHmrManager(options.appConfig, hmrManager);
 
 		return {
 			websocketServer,

--- a/packages/core/src/adapters/shared/hmr-entrypoint-registrar.ts
+++ b/packages/core/src/adapters/shared/hmr-entrypoint-registrar.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import { fileSystem } from '@ecopages/file-system';
-import { appLogger } from '../../global/app-logger.ts';
-import { RESOLVED_ASSETS_DIR } from '../../config/constants.ts';
+import { removeStaleHmrEntrypointOutput, resolveHmrEntrypointOutputPaths } from '../../hmr/hmr-entrypoint-output.ts';
 
 /**
  * Shared runtime state used while registering HMR-owned entrypoints.
@@ -91,7 +90,7 @@ export class HmrEntrypointRegistrar {
 		const { outputPath, outputUrl } = this.getEntrypointOutput(entrypointPath);
 
 		this.options.watchedFiles.set(entrypointPath, outputUrl);
-		this.removeStaleEntrypointOutput(outputPath);
+		removeStaleHmrEntrypointOutput(outputPath, 'HMR');
 
 		await registrationOptions.emit(entrypointPath, outputPath);
 
@@ -118,32 +117,6 @@ export class HmrEntrypointRegistrar {
 	}
 
 	private getEntrypointOutput(entrypointPath: string): { outputPath: string; outputUrl: string } {
-		const relativePath = path.relative(this.options.srcDir, entrypointPath);
-		const relativePathJs = relativePath.replace(/\.(tsx?|jsx?|mdx?)$/, '.js');
-		const encodedPathJs = this.encodeDynamicSegments(relativePathJs);
-		const urlPath = encodedPathJs.split(path.sep).join('/');
-
-		return {
-			outputUrl: `/${path.join(RESOLVED_ASSETS_DIR, '_hmr', urlPath)}`,
-			outputPath: path.join(this.options.distDir, urlPath),
-		};
-	}
-
-	private removeStaleEntrypointOutput(outputPath: string): void {
-		if (!fileSystem.exists(outputPath)) {
-			return;
-		}
-
-		try {
-			fileSystem.remove(outputPath);
-		} catch (error) {
-			appLogger.warn(
-				`[HMR] Failed to remove stale entrypoint output ${outputPath}: ${error instanceof Error ? error.message : String(error)}`,
-			);
-		}
-	}
-
-	private encodeDynamicSegments(filepath: string): string {
-		return filepath.replace(/\[([^\]]+)\]/g, '_$1_');
+		return resolveHmrEntrypointOutputPaths(this.options.srcDir, this.options.distDir, entrypointPath);
 	}
 }

--- a/packages/core/src/adapters/shared/runtime-server-lifecycle.ts
+++ b/packages/core/src/adapters/shared/runtime-server-lifecycle.ts
@@ -7,6 +7,8 @@ import { disposeAppBuildRuntime } from '../../build/build-runtime.ts';
 import { getAppBrowserBuildPlugins } from '../../build/build-adapter.ts';
 import type { ProjectWatcher } from '../../watchers/project-watcher.ts';
 import { copyRuntimePublicDirIfChanged } from './copy-runtime-public-dir.ts';
+import { clearAppDevClientBridge } from '../../dev/client-bridge-registry.ts';
+import { clearAppHmrManager } from '../../dev/hmr-manager-registry.ts';
 import { injectHmrRuntimeIntoHtmlResponse, isHtmlResponse, shouldInjectHmrHtmlResponse } from './hmr-html-response.ts';
 
 /**
@@ -73,5 +75,7 @@ export async function disposeDevResources(options: {
 	await disposeAppBuildRuntime(options.appConfig);
 	options.hmrManager?.stop();
 	options.bridge?.destroy();
+	clearAppDevClientBridge(options.appConfig);
+	clearAppHmrManager(options.appConfig);
 	await options.previewHost.stop();
 }

--- a/packages/core/src/adapters/shared/shared-hmr-manager.ts
+++ b/packages/core/src/adapters/shared/shared-hmr-manager.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { RESOLVED_ASSETS_DIR } from '../../config/constants.ts';
+import { resolveHmrEntrypointOutputPaths } from '../../hmr/hmr-entrypoint-output.ts';
 import { requireBuildRuntime } from '../../build/build-runtime.ts';
 import type { DefaultHmrContext, EcoPagesAppConfig, IHmrManager, IClientBridge } from '../../types/internal-types.ts';
 import type { EcoBuildPlugin } from '../../build/build-types.ts';
@@ -241,25 +242,31 @@ export abstract class SharedHmrManager implements IHmrManager {
 	}
 
 	/**
-	 * Returns the emitted HMR script output when the artifact already exists on disk.
+	 * Returns the emitted HMR script output when the entrypoint is already registered
+	 * and its browser bundle exists on disk.
 	 *
-	 * SSR must not block on entrypoint registration when a previous build already
-	 * produced the browser bundle.
+	 * @remarks
+	 * Disk artifacts alone are not enough: a fresh dev session must still register
+	 * the entrypoint so file watchers can rebuild it on change.
 	 */
 	public getResolvedScriptOutput(entrypointPath: string): { outputUrl: string; outputPath: string } | undefined {
 		const normalizedEntrypoint = path.resolve(entrypointPath);
-		const relativePath = path.relative(this.appConfig.absolutePaths.srcDir, normalizedEntrypoint);
-		const relativePathJs = relativePath.replace(/\.(tsx?|jsx?|mdx?)$/, '.js').replace(/\[([^\]]+)\]/g, '_$1_');
-		const urlPath = relativePathJs.split(path.sep).join('/');
-		const outputPath = path.join(this.distDir, urlPath);
+
+		if (!this.watchedFiles.has(normalizedEntrypoint)) {
+			return undefined;
+		}
+
+		const { outputPath, outputUrl: derivedOutputUrl } = resolveHmrEntrypointOutputPaths(
+			this.appConfig.absolutePaths.srcDir,
+			this.distDir,
+			normalizedEntrypoint,
+		);
 
 		if (!fileSystem.exists(outputPath)) {
 			return undefined;
 		}
 
-		const outputUrl =
-			this.watchedFiles.get(normalizedEntrypoint) ??
-			`/${path.join(RESOLVED_ASSETS_DIR, '_hmr', urlPath).split(path.sep).join('/')}`;
+		const outputUrl = this.watchedFiles.get(normalizedEntrypoint) ?? derivedOutputUrl;
 
 		return { outputUrl, outputPath };
 	}

--- a/packages/core/src/dev/hmr-manager-registry.ts
+++ b/packages/core/src/dev/hmr-manager-registry.ts
@@ -1,0 +1,19 @@
+/**
+ * Per-app registry for the shared HMR manager used by host-owned dev clients.
+ */
+import type { EcoPagesAppConfig } from '../types/public-types.ts';
+import type { IHmrManager } from '../types/public-types.ts';
+
+const appHmrManagers = new WeakMap<EcoPagesAppConfig, IHmrManager>();
+
+export function setAppHmrManager(appConfig: EcoPagesAppConfig, hmrManager: IHmrManager): void {
+	appHmrManagers.set(appConfig, hmrManager);
+}
+
+export function getAppHmrManager(appConfig: EcoPagesAppConfig): IHmrManager | undefined {
+	return appHmrManagers.get(appConfig);
+}
+
+export function clearAppHmrManager(appConfig: EcoPagesAppConfig): void {
+	appHmrManagers.delete(appConfig);
+}

--- a/packages/core/src/hmr/hmr-entrypoint-output.test.ts
+++ b/packages/core/src/hmr/hmr-entrypoint-output.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { resolveHmrEntrypointOutputPaths } from './hmr-entrypoint-output.ts';
+
+describe('resolveHmrEntrypointOutputPaths', () => {
+	it('maps script entrypoints to _hmr output paths', () => {
+		const srcDir = '/app/src';
+		const distDir = '/app/.eco/assets/_hmr';
+
+		expect(
+			resolveHmrEntrypointOutputPaths(
+				srcDir,
+				distDir,
+				'/app/src/components/script-hmr/script-hmr-marker.eco.tsx',
+			),
+		).toEqual({
+			outputUrl: '/assets/_hmr/components/script-hmr/script-hmr-marker.eco.js',
+			outputPath: path.join(distDir, 'components/script-hmr/script-hmr-marker.eco.js'),
+		});
+	});
+
+	it('encodes dynamic route segments in output paths', () => {
+		const srcDir = '/app/src';
+		const distDir = '/app/.eco/assets/_hmr';
+
+		expect(resolveHmrEntrypointOutputPaths(srcDir, distDir, '/app/src/pages/blog/[slug].tsx')).toEqual({
+			outputUrl: '/assets/_hmr/pages/blog/_slug_.js',
+			outputPath: path.join(distDir, 'pages/blog/_slug_.js'),
+		});
+	});
+});

--- a/packages/core/src/hmr/hmr-entrypoint-output.ts
+++ b/packages/core/src/hmr/hmr-entrypoint-output.ts
@@ -1,0 +1,47 @@
+import path from 'node:path';
+import { fileSystem } from '@ecopages/file-system';
+import { RESOLVED_ASSETS_DIR } from '../config/constants.ts';
+import { appLogger } from '../global/app-logger.ts';
+
+export function encodeHmrDynamicSegments(filepath: string): string {
+	return filepath.replace(/\[([^\]]+)\]/g, '_$1_');
+}
+
+/**
+ * Resolves the on-disk and browser URL targets for one HMR script entrypoint.
+ */
+export function resolveHmrEntrypointOutputPaths(
+	srcDir: string,
+	distDir: string,
+	entrypointPath: string,
+): { outputPath: string; outputUrl: string } {
+	const normalizedEntrypoint = path.resolve(entrypointPath);
+	const relativePath = path.relative(srcDir, normalizedEntrypoint);
+	const relativePathJs = relativePath.replace(/\.(tsx?|jsx?|mdx?)$/, '.js');
+	const encodedPathJs = encodeHmrDynamicSegments(relativePathJs);
+	const urlPath = encodedPathJs.split(path.sep).join('/');
+
+	return {
+		outputUrl: `/${path.join(RESOLVED_ASSETS_DIR, '_hmr', urlPath).split(path.sep).join('/')}`,
+		outputPath: path.join(distDir, urlPath),
+	};
+}
+
+/**
+ * @remarks
+ * Rebuilds must delete the previous artifact so browser-hmr does not reuse a
+ * stale bundle when the source file changed.
+ */
+export function removeStaleHmrEntrypointOutput(outputPath: string, scope: string): void {
+	if (!fileSystem.exists(outputPath)) {
+		return;
+	}
+
+	try {
+		fileSystem.remove(outputPath);
+	} catch (error) {
+		appLogger.warn(
+			`[${scope}] Failed to remove stale entrypoint output ${outputPath}: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}

--- a/packages/core/src/hmr/strategies/js-hmr-strategy.integration.test.ts
+++ b/packages/core/src/hmr/strategies/js-hmr-strategy.integration.test.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { installBuildRuntime } from '../../build/build-runtime.ts';
+import { ConfigBuilder } from '../../config/config-builder.ts';
+import { HmrManager as BunHmrManager } from '../../adapters/bun/hmr-manager.ts';
+import type { ClientBridgeEvent } from '../../types/public-types.ts';
+import { resolveInternalWorkDir } from '../../utils/resolve-work-dir.ts';
+
+const tempRoots: string[] = [];
+
+function createTempRoot(prefix: string): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+	tempRoots.push(root);
+	return root;
+}
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+describe('JsHmrStrategy integration', () => {
+	it('rebuilds a registered integration-suffixed script entrypoint on source change', async () => {
+		const rootDir = createTempRoot('js-hmr-integration');
+		const componentsDir = path.join(rootDir, 'src', 'components', 'script-hmr');
+		fs.mkdirSync(componentsDir, { recursive: true });
+
+		const entrypointPath = path.join(componentsDir, 'widget.script.eco.tsx');
+		const writeMarker = (marker: string) => {
+			fs.writeFileSync(
+				entrypointPath,
+				`export const marker = ${JSON.stringify(marker)};\nconsole.log(${JSON.stringify(marker)});\n`,
+				'utf8',
+			);
+		};
+
+		writeMarker('BASELINE');
+
+		const config = await new ConfigBuilder().setRootDir(rootDir).setIntegrations([]).build();
+		config.templatesExt = ['.eco.tsx'];
+
+		const broadcasts: ClientBridgeEvent[] = [];
+		using manager = new BunHmrManager({
+			appConfig: config,
+			bridge: {
+				subscriberCount: 0,
+				broadcast: (event: ClientBridgeEvent) => {
+					broadcasts.push(event);
+				},
+			} as never,
+		});
+
+		manager.setEnabled(true);
+		installBuildRuntime(config);
+
+		await manager.registerScriptEntrypoint(entrypointPath);
+
+		expect(manager.getWatchedFiles().has(path.resolve(entrypointPath))).toBe(true);
+
+		const outputPath = path.join(
+			resolveInternalWorkDir(config),
+			'assets',
+			'_hmr',
+			'components',
+			'script-hmr',
+			'widget.script.eco.js',
+		);
+
+		expect(fs.existsSync(outputPath)).toBe(true);
+		expect(fs.readFileSync(outputPath, 'utf8')).toContain('BASELINE');
+
+		writeMarker('UPDATED');
+		broadcasts.length = 0;
+		await manager.handleFileChange(entrypointPath);
+
+		expect(broadcasts.length).toBeGreaterThan(0);
+		expect(fs.readFileSync(outputPath, 'utf8')).toContain('UPDATED');
+		expect(broadcasts.some((event) => event.type === 'reload' || event.type === 'update')).toBe(true);
+	});
+});

--- a/packages/core/src/hmr/strategies/js-hmr-strategy.test.ts
+++ b/packages/core/src/hmr/strategies/js-hmr-strategy.test.ts
@@ -95,6 +95,19 @@ describe('JsHmrStrategy', () => {
 			expect(strategy.matches(entrypoint)).toBe(true);
 		});
 
+		it('returns true for registered script entrypoints that share an integration template extension', () => {
+			const entrypoint = path.join(SRC_DIR, 'components', 'widget.script.tsx');
+			const devGraphService = new InMemoryDevGraphService();
+			const context = createMockContext({
+				getWatchedFiles: () => new Map([[entrypoint, '/_hmr/widget.script.js']]),
+				getEntrypointDependencyGraph: () => devGraphService,
+				getTemplateExtensions: () => ['.tsx'],
+			});
+			const strategy = new JsHmrStrategy(context);
+
+			expect(strategy.matches(entrypoint)).toBe(true);
+		});
+
 		it('returns true for .js files in src directory', () => {
 			const context = createMockContext({
 				getWatchedFiles: () => new Map([[path.join(SRC_DIR, 'entry.ts'), '/output.js']]),

--- a/packages/core/src/hmr/strategies/js-hmr-strategy.ts
+++ b/packages/core/src/hmr/strategies/js-hmr-strategy.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { fileSystem } from '@ecopages/file-system';
 import { HmrStrategy, HmrStrategyType, type HmrAction } from '../hmr-strategy.ts';
 import { appLogger } from '../../global/app-logger.ts';
+import { removeStaleHmrEntrypointOutput, resolveHmrEntrypointOutputPaths } from '../hmr-entrypoint-output.ts';
 import type { EcoBuildPlugin } from '../../build/build-types.ts';
 import type { BrowserBundleExecutor } from '../../services/assets/browser-bundle.service.ts';
 import type { EntrypointDependencyGraph } from '../../services/runtime-state/entrypoint-dependency-graph.service.ts';
@@ -118,17 +119,19 @@ export class JsHmrStrategy extends HmrStrategy {
 	 * Matches if:
 	 * 1. There are registered entrypoints to rebuild
 	 * 2. The changed file is a JS/TS file in the src directory
+	 * 3. Registered entrypoints always match, even when they share an integration template extension
 	 *
 	 * @param filePath - Absolute path to the changed file
 	 * @returns True if this file should trigger entrypoint rebuilds
 	 */
 	matches(filePath: string): boolean {
 		const watchedFiles = this.context.getWatchedFiles();
-		const isJsTs = /\.(ts|tsx|js|jsx)$/.test(filePath);
-		const isInSrc = filePath.startsWith(this.context.getSrcDir());
+		const resolvedPath = path.resolve(filePath);
+		const isJsTs = /\.(ts|tsx|js|jsx)$/.test(resolvedPath);
+		const isInSrc = resolvedPath.startsWith(this.context.getSrcDir());
 		const isIntegrationTemplate = this.context
 			.getTemplateExtensions()
-			.some((extension) => filePath.endsWith(extension));
+			.some((extension) => resolvedPath.endsWith(extension));
 
 		if (watchedFiles.size === 0) {
 			return false;
@@ -138,12 +141,12 @@ export class JsHmrStrategy extends HmrStrategy {
 			return false;
 		}
 
-		if (isIntegrationTemplate) {
-			return false;
+		if (watchedFiles.has(resolvedPath)) {
+			return true;
 		}
 
-		if (watchedFiles.has(filePath)) {
-			return true;
+		if (isIntegrationTemplate) {
+			return false;
 		}
 
 		return true;
@@ -173,7 +176,7 @@ export class JsHmrStrategy extends HmrStrategy {
 		const dependencyHits = this.context.getEntrypointDependencyGraph().getDependencyEntrypoints(filePath);
 		const hasDependencyHit = dependencyHits.size > 0;
 		const impactedEntrypoints = hasDependencyHit
-			? Array.from(dependencyHits).filter((entrypoint) => watchedFiles.has(entrypoint))
+			? Array.from(dependencyHits).filter((entrypoint) => watchedFiles.has(path.resolve(entrypoint)))
 			: Array.from(watchedFiles.keys());
 		const buildableEntrypoints = impactedEntrypoints.filter(
 			(entrypoint) => this.context.shouldProcessEntrypoint?.(entrypoint) ?? true,
@@ -185,6 +188,10 @@ export class JsHmrStrategy extends HmrStrategy {
 
 		if (buildableEntrypoints.length === 0) {
 			return { type: 'none' };
+		}
+
+		for (const entrypoint of buildableEntrypoints) {
+			this.removeStaleEntrypointOutput(this.resolveEntrypointOutputPath(entrypoint));
 		}
 
 		const buildResult = await this.bundleEntrypoints(buildableEntrypoints);
@@ -205,10 +212,7 @@ export class JsHmrStrategy extends HmrStrategy {
 				this.context.getEntrypointDependencyGraph().setEntrypointDependencies(entrypoint, entrypointDeps);
 			}
 
-			const srcDir = this.context.getSrcDir();
-			const relativePath = path.relative(srcDir, entrypoint);
-			const relativePathJs = relativePath.replace(/\.(tsx?|jsx?|mdx?)$/, '.js');
-			const outputPath = path.join(this.context.getDistDir(), relativePathJs);
+			const outputPath = this.resolveEntrypointOutputPath(entrypoint);
 
 			const result = await this.processOutput(outputPath, outputUrl);
 			if (result.success) {
@@ -241,6 +245,15 @@ export class JsHmrStrategy extends HmrStrategy {
 		return { type: 'none' };
 	}
 
+	private resolveEntrypointOutputPath(entrypointPath: string): string {
+		return resolveHmrEntrypointOutputPaths(this.context.getSrcDir(), this.context.getDistDir(), entrypointPath)
+			.outputPath;
+	}
+
+	private removeStaleEntrypointOutput(outputPath: string): void {
+		removeStaleHmrEntrypointOutput(outputPath, 'JsHmrStrategy');
+	}
+
 	/**
 	 * Bundles one or more entrypoints in a single build invocation.
 	 * Uses the source directory as the output base so that the directory structure
@@ -250,6 +263,34 @@ export class JsHmrStrategy extends HmrStrategy {
 		entrypoints: string[],
 	): Promise<{ success: boolean; dependencies?: Map<string, string[]> }> {
 		try {
+			if (entrypoints.length === 1) {
+				const entrypoint = entrypoints[0]!;
+				const outputPath = this.resolveEntrypointOutputPath(entrypoint);
+				const naming = path.relative(this.context.getDistDir(), outputPath).split(path.sep).join('/');
+				const result = await this.context.getBrowserBundleService().bundle({
+					profile: 'hmr-entrypoint',
+					entrypoints: [entrypoint],
+					outdir: this.context.getDistDir(),
+					naming,
+					plugins: this.context.getPlugins(),
+					minify: false,
+				});
+
+				if (!result.success) {
+					appLogger.error('[JsHmrStrategy] Entrypoint build failed:', result.logs);
+					return { success: false };
+				}
+
+				const dependencies = new Map<string, string[]>();
+				if (result.dependencyGraph?.entrypoints) {
+					for (const [resolvedEntrypoint, deps] of Object.entries(result.dependencyGraph.entrypoints)) {
+						dependencies.set(path.resolve(resolvedEntrypoint), deps);
+					}
+				}
+
+				return { success: true, dependencies };
+			}
+
 			const result = await this.context.getBrowserBundleService().bundle({
 				profile: 'hmr-entrypoint',
 				entrypoints,

--- a/packages/core/src/services/assets/asset-processing-service/processors/script/file-script.processor.test.ts
+++ b/packages/core/src/services/assets/asset-processing-service/processors/script/file-script.processor.test.ts
@@ -58,10 +58,12 @@ describe('FileScriptProcessor', () => {
 		test('should reuse an existing HMR artifact without blocking on registration', async () => {
 			const processor = new FileScriptProcessor({ appConfig: createMockConfig() });
 			const registerScriptEntrypoint = vi.fn(async () => '/assets/_hmr/script.js');
+			const scriptPath = '/test/project/src/script.ts';
 			const HmrManager = {
 				isEnabled: () => true,
 				registerScriptEntrypoint,
 				getDistDir: () => '/test/project/.eco/public/assets/_hmr',
+				getWatchedFiles: () => new Map([[scriptPath, '/assets/_hmr/script.js']]),
 				getResolvedScriptOutput: () => ({
 					outputUrl: '/assets/_hmr/script.js',
 					outputPath: '/test/project/.eco/public/assets/_hmr/script.js',
@@ -72,7 +74,7 @@ describe('FileScriptProcessor', () => {
 			const dep: FileScriptAsset = {
 				kind: 'script',
 				source: 'file',
-				filepath: '/test/project/src/script.ts',
+				filepath: scriptPath,
 				inline: false,
 			};
 
@@ -81,6 +83,31 @@ describe('FileScriptProcessor', () => {
 			expect(registerScriptEntrypoint).not.toHaveBeenCalled();
 			expect(result.srcUrl).toBe('/assets/_hmr/script.js');
 			expect(result.filepath).toBe('/test/project/.eco/public/assets/_hmr/script.js');
+		});
+
+		test('should register stale on-disk HMR artifacts that are not yet watched', async () => {
+			const processor = new FileScriptProcessor({ appConfig: createMockConfig() });
+			const registerScriptEntrypoint = vi.fn(async () => '/assets/_hmr/script.js');
+			const scriptPath = '/test/project/src/script.ts';
+			const HmrManager = {
+				isEnabled: () => true,
+				registerScriptEntrypoint,
+				getDistDir: () => '/test/project/.eco/public/assets/_hmr',
+				getWatchedFiles: () => new Map(),
+				getResolvedScriptOutput: () => undefined,
+			} as unknown as IHmrManager;
+			processor.setHmrManager(HmrManager);
+
+			const dep: FileScriptAsset = {
+				kind: 'script',
+				source: 'file',
+				filepath: scriptPath,
+				inline: false,
+			};
+
+			await processor.process(dep);
+
+			expect(registerScriptEntrypoint).toHaveBeenCalledWith(scriptPath);
 		});
 
 		test('should delegate to HMR manager when enabled and not inline and preserve excludeFromHtml', async () => {

--- a/packages/vite-plugin/src/ecopages-hot-update.test.ts
+++ b/packages/vite-plugin/src/ecopages-hot-update.test.ts
@@ -8,6 +8,7 @@ function createApi() {
 		appConfig: {
 			additionalWatchPaths: [],
 			templatesExt: [],
+			processors: new Map(),
 			absolutePaths: {
 				componentsDir: '/app/src/components',
 				includesDir: '/app/src/includes',
@@ -339,31 +340,91 @@ describe('ecopagesHotUpdate', () => {
 		);
 	});
 
-	it('returns an empty hot-update result when the host owns the dev client', () => {
+	it('returns an empty hot-update result when the host owns the dev client', async () => {
 		const api = createApi();
 		api.appConfig.runtime = { devClientOwner: 'host' };
 		api.markDevHostReady();
+		const handleFileChange = vi.fn(async () => {});
+		const { setAppHmrManager } = await import('@ecopages/core/dev/hmr-manager-registry');
+		setAppHmrManager(api.appConfig, {
+			isEnabled: () => true,
+			handleFileChange,
+		} as never);
+
 		const plugin = ecopagesHotUpdate(api);
 		const send = vi.fn();
-		const modules = [{ id: 'page' }];
-		const server = createHotUpdateServer(send);
-
-		const result = callPluginHook(
-			plugin.hotUpdate,
-			{
-				environment: {
-					name: 'client',
-					moduleGraph: { invalidateModule: vi.fn() },
+		const listeners = new Map<string, Set<(file: string) => void>>();
+		const server = {
+			watcher: {
+				add: vi.fn(),
+				on(event: string, listener: (file: string) => void) {
+					const bucket = listeners.get(event) ?? new Set();
+					bucket.add(listener);
+					listeners.set(event, bucket);
 				},
-			} as never,
-			{
-				file: '/app/src/pages/index.kita.tsx',
-				modules,
-				server: server as never,
+				off(event: string, listener: (file: string) => void) {
+					listeners.get(event)?.delete(listener);
+				},
 			},
-		);
+			environments: {
+				client: { hot: { send } },
+				ssr: { moduleGraph: { getModulesByFile: () => undefined } },
+			},
+			hot: { send },
+		};
 
-		expect(result).toEqual([]);
-		expect(send).not.toHaveBeenCalled();
+		callPluginHook(plugin.configureServer, {} as never, server as never);
+
+		for (const listener of listeners.get('change') ?? []) {
+			listener('/app/src/pages/index.kita.tsx');
+		}
+
+		await Promise.resolve();
+
+		expect(handleFileChange).toHaveBeenCalledWith('/app/src/pages/index.kita.tsx');
+	});
+
+	it('dispatches script changes through the host HMR manager when the host owns the dev client', async () => {
+		const api = createApi();
+		api.appConfig.runtime = { devClientOwner: 'host' };
+		api.markDevHostReady();
+		const handleFileChange = vi.fn(async () => {});
+		const { setAppHmrManager } = await import('@ecopages/core/dev/hmr-manager-registry');
+		setAppHmrManager(api.appConfig, {
+			isEnabled: () => true,
+			handleFileChange,
+		} as never);
+
+		const plugin = ecopagesHotUpdate(api);
+		const send = vi.fn();
+		const listeners = new Map<string, Set<(file: string) => void>>();
+		const server = {
+			watcher: {
+				add: vi.fn(),
+				on(event: string, listener: (file: string) => void) {
+					const bucket = listeners.get(event) ?? new Set();
+					bucket.add(listener);
+					listeners.set(event, bucket);
+				},
+				off(event: string, listener: (file: string) => void) {
+					listeners.get(event)?.delete(listener);
+				},
+			},
+			environments: {
+				client: { hot: { send } },
+				ssr: { moduleGraph: { getModulesByFile: () => undefined } },
+			},
+			hot: { send },
+		};
+
+		callPluginHook(plugin.configureServer, {} as never, server as never);
+
+		for (const listener of listeners.get('change') ?? []) {
+			listener('/app/src/components/theme-toggle.script.tsx');
+		}
+
+		await Promise.resolve();
+
+		expect(handleFileChange).toHaveBeenCalledWith('/app/src/components/theme-toggle.script.tsx');
 	});
 });

--- a/packages/vite-plugin/src/ecopages-hot-update.ts
+++ b/packages/vite-plugin/src/ecopages-hot-update.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import type { EnvironmentModuleNode, HotUpdateOptions, ViteDevServer } from 'vite';
 import { hostOwnsDevClient } from '@ecopages/core/dev/dev-client-ownership';
+import { getAppHmrManager } from '@ecopages/core/dev/hmr-manager-registry';
 import { createDevelopmentHostRuntime } from '@ecopages/core/dev/host-runtime';
 import type { DevelopmentHostRuntime } from '@ecopages/core/dev/host-runtime';
 import type { EcopagesPluginApi } from './plugin-api.ts';
@@ -39,6 +40,15 @@ type ProcessFileChangeOptions = {
 	clientModules?: EnvironmentModuleNode[];
 	invalidateClientModule?: (module: EnvironmentModuleNode) => void;
 };
+
+function dispatchHostOwnedHmr(api: EcopagesPluginApi, file: string): void {
+	void api.getDevHostReady().then(async () => {
+		const hmrManager = getAppHmrManager(api.appConfig);
+		if (hmrManager?.isEnabled()) {
+			await hmrManager.handleFileChange(file);
+		}
+	});
+}
 
 function processEcopagesFileChange(
 	file: string,
@@ -100,6 +110,7 @@ function processEcopagesFileChange(
 	}
 
 	if (hostOwnsClient()) {
+		dispatchHostOwnedHmr(api, file);
 		return [];
 	}
 

--- a/playground/kitchen-sink/e2e/script-hmr.test.e2e.ts
+++ b/playground/kitchen-sink/e2e/script-hmr.test.e2e.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+import { createHmrPhaseTimer, gotoPath, startEcopagesHmrConnectionWatch, trackRuntimeErrors } from './test-support';
+
+const SCRIPT_MARKER_FILE = fileURLToPath(
+	new URL('../src/components/script-hmr/script-hmr-marker.eco.tsx', import.meta.url),
+);
+const SCRIPT_HMR_BASELINE = 'SCRIPT_HMR_BASELINE';
+const SCRIPT_HMR_UPDATED = 'SCRIPT_HMR_UPDATED';
+const SCRIPT_HMR_TIMEOUT_MS = 8_000;
+
+function getScriptMarkerFile(projectMetadata: Record<string, unknown> | undefined) {
+	const isolatedAppDir = typeof projectMetadata?.isolatedAppDir === 'string' ? projectMetadata.isolatedAppDir : null;
+
+	if (!isolatedAppDir) {
+		return SCRIPT_MARKER_FILE;
+	}
+
+	return path.join(isolatedAppDir, 'src/components/script-hmr/script-hmr-marker.eco.tsx');
+}
+
+function patchScriptMarker(content: string, marker: string) {
+	return content.replace(SCRIPT_HMR_BASELINE, marker);
+}
+
+test.describe('Declared client script HMR @hmr', () => {
+	let originalScriptMarker = '';
+	let scriptMarkerFile = SCRIPT_MARKER_FILE;
+
+	test.describe.configure({ mode: 'serial' });
+
+	// oxlint-disable-next-line no-empty-pattern
+	test.beforeAll(async ({}, testInfo) => {
+		scriptMarkerFile = getScriptMarkerFile(testInfo.project.metadata as Record<string, unknown> | undefined);
+		originalScriptMarker = fs.readFileSync(SCRIPT_MARKER_FILE, 'utf-8');
+	});
+
+	test.afterAll(() => {
+		fs.writeFileSync(scriptMarkerFile, originalScriptMarker, 'utf-8');
+	});
+
+	test('reloads with an updated registered script entrypoint', async ({ page }, testInfo) => {
+		const timer = createHmrPhaseTimer(`${testInfo.project.name} :: script entrypoint`);
+		const runtime = trackRuntimeErrors(page);
+		const hmrReady = startEcopagesHmrConnectionWatch(page);
+
+		await gotoPath(page, '/script-hmr');
+		timer.mark('navigation-ready');
+		await hmrReady;
+		timer.mark('hmr-connected');
+		await expect(page.getByTestId('page-script-hmr')).toBeVisible();
+		await expect(page.getByTestId('script-hmr-marker')).toHaveText(SCRIPT_HMR_BASELINE);
+
+		fs.writeFileSync(scriptMarkerFile, patchScriptMarker(originalScriptMarker, SCRIPT_HMR_UPDATED), 'utf-8');
+		timer.mark('mutation-applied');
+		await expect(page.getByTestId('script-hmr-marker')).toHaveText(SCRIPT_HMR_UPDATED, {
+			timeout: SCRIPT_HMR_TIMEOUT_MS,
+		});
+		timer.mark('marker-updated');
+
+		runtime.assertClean();
+	});
+});

--- a/playground/kitchen-sink/src/components/script-hmr/script-hmr-host.eco.tsx
+++ b/playground/kitchen-sink/src/components/script-hmr/script-hmr-host.eco.tsx
@@ -1,0 +1,11 @@
+/** @jsxImportSource @ecopages/jsx */
+import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+
+export const ScriptHmrHost = eco.component<{}, JsxRenderable>({
+	integration: 'ecopages-jsx',
+	dependencies: {
+		scripts: ['./script-hmr-marker.eco.tsx'],
+	},
+	render: () => <script-hmr-marker />,
+});

--- a/playground/kitchen-sink/src/components/script-hmr/script-hmr-marker.eco.tsx
+++ b/playground/kitchen-sink/src/components/script-hmr/script-hmr-marker.eco.tsx
@@ -1,0 +1,18 @@
+/** @jsxImportSource @ecopages/jsx */
+import { RadiantElement } from '@ecopages/radiant';
+import { customElement } from '@ecopages/radiant/decorators/custom-element';
+
+@customElement('script-hmr-marker')
+export class ScriptHmrMarker extends RadiantElement {
+	override render() {
+		return <span data-testid="script-hmr-marker">SCRIPT_HMR_BASELINE</span>;
+	}
+}
+
+declare global {
+	namespace JSX {
+		interface IntrinsicElements {
+			'script-hmr-marker': HtmlTag;
+		}
+	}
+}

--- a/playground/kitchen-sink/src/pages/script-hmr.eco.tsx
+++ b/playground/kitchen-sink/src/pages/script-hmr.eco.tsx
@@ -1,0 +1,23 @@
+/** @jsxImportSource @ecopages/jsx */
+import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+import { BaseLayout } from '@/layouts/base-layout';
+import { ScriptHmrHost } from '@/components/script-hmr/script-hmr-host.eco';
+
+export default eco.page<{}, JsxRenderable>({
+	integration: 'ecopages-jsx',
+	dependencies: {
+		components: [BaseLayout, ScriptHmrHost],
+	},
+	layout: BaseLayout,
+	metadata: () => ({
+		title: 'Script HMR Fixture',
+		description: 'Validates declared client script entrypoints rebuild during development.',
+	}),
+	render: () => (
+		<section class="card space-y-4" data-testid="page-script-hmr">
+			<h1 class="font-display text-3xl font-semibold tracking-tight">Script HMR fixture</h1>
+			<ScriptHmrHost />
+		</section>
+	),
+});


### PR DESCRIPTION
## Summary

- Fix client script HMR for declared `dependencies.scripts` entrypoints: registered paths now match `JsHmrStrategy` even when they share integration template extensions (e.g. `.eco.tsx`), stale on-disk `_hmr` artifacts no longer skip registration, and rebuilds clear stale output before bundling.
- Wire host-owned Vite dev clients to the app HMR manager via a new `hmr-manager-registry`, mirroring the existing client-bridge registry.
- Extract shared `resolveHmrEntrypointOutputPaths` helper and add kitchen-sink script-HMR E2E coverage.

## Test plan

- [x] `pnpm exec vitest run --project shared-core hmr-entrypoint-output js-hmr-strategy`
- [x] Pre-commit: 1775 vitest tests, lint, typecheck
- [x] Kitchen-sink `script-hmr.test.e2e.ts` (cross-integration HMR)
- [x] CI cross-integration HMR suite