### PR TITLE
fix(core): load route page modules through integration renderers

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to `@ecopages/core` are documented here.
 
 ### Bug Fixes
 
-- Fixed server bundle externalization so native addons (e.g. Tailwind platform binaries) and app-declared packages load correctly from installed dependencies.
+- Fixed RouteRegistry static path expansion to load page modules through integration renderers so Radiant SSR setup runs before JSX page imports during build.
 - Fixed app-owned server module loading so integration loaders (including React MDX) participate during request-time and static generation.
 - Fixed Node and Bun adapter stability for preview, static generation, HMR, and mixed-integration rendering across built-in integrations.
 - Fixed grouped page-browser graph builds so sibling routes reuse shared assets without cross-route leakage or stale partial caches.
@@ -49,6 +49,7 @@ All notable changes to `@ecopages/core` are documented here.
 ### Tests
 
 - Added regression coverage for `RouteRegistry`, explicit static routes, mixed boundaries, Node fallback, and cross-runtime invalidation.
+- Added regression coverage for RouteRegistry page module loading through integration renderers during static path expansion.
 
 ---
 

--- a/packages/core/src/adapters/shared/server-adapter.test.ts
+++ b/packages/core/src/adapters/shared/server-adapter.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, test } from 'vitest';
+import { afterEach, test, vi } from 'vitest';
 import { ConfigBuilder } from '../../config/config-builder.ts';
 import type { ServerAdapterResult } from '../abstract/server-adapter.ts';
 import type { ApiHandler } from '../../types/public-types.ts';
@@ -131,4 +131,34 @@ test('SharedServerAdapter falls back to the route handler when no API handler ma
 
 	assert.equal(response.status, 200);
 	assert.equal(await response.text(), 'filesystem');
+});
+
+test('RouteRegistry page module adapter loads page modules through integration renderers', async () => {
+	const rootDir = createTempRoot('ecopages-route-registry-page-module-adapter');
+	const config = await new ConfigBuilder().setRootDir(rootDir).build();
+	const adapter = new TestSharedServerAdapter('', rootDir);
+	(adapter as unknown as { appConfig: typeof config }).appConfig = config;
+
+	const loadPageModule = vi.fn(async () => ({
+		default: {
+			staticPaths: async () => ({ paths: [] }),
+		},
+	}));
+	const getPageRenderer = vi.fn(() => ({
+		loadPageModule,
+		execute: vi.fn(),
+	}));
+	(adapter as unknown as { routeRendererFactory: { getPageRenderer: typeof getPageRenderer } }).routeRendererFactory =
+		{ getPageRenderer };
+
+	const pageModuleAdapter = (
+		adapter as unknown as {
+			createRouteRegistryPageModuleAdapter: () => { loadPageModule: (filePath: string) => Promise<unknown> };
+		}
+	).createRouteRegistryPageModuleAdapter();
+	const result = await pageModuleAdapter.loadPageModule('/pages/blog/[slug].tsx');
+
+	assert.deepEqual(getPageRenderer.mock.calls, [['/pages/blog/[slug].tsx']]);
+	assert.deepEqual(loadPageModule.mock.calls, [['/pages/blog/[slug].tsx']]);
+	assert.equal(typeof (result as { staticPaths?: unknown }).staticPaths, 'function');
 });

--- a/packages/core/src/adapters/shared/server-adapter.ts
+++ b/packages/core/src/adapters/shared/server-adapter.ts
@@ -61,8 +61,21 @@ export abstract class SharedServerAdapter<
 		staticRoutes: StaticRoute[];
 		hmrManager?: any;
 	}): Promise<void> {
+		this.ensureRouteRendererFactory();
 		await this.initSharedRouter();
 		this.configureSharedResponseHandlers(options.staticRoutes, options.hmrManager);
+	}
+
+	private ensureRouteRendererFactory(): void {
+		if (this.routeRendererFactory) {
+			return;
+		}
+
+		this.routeRendererFactory = new RouteRendererFactory({
+			appConfig: this.appConfig,
+			rendererModules: this.appConfig.runtime?.rendererModuleContext,
+			runtimeOrigin: this.runtimeOrigin,
+		});
 	}
 
 	protected createSharedWatchRefreshCallback(options: {
@@ -114,18 +127,13 @@ export abstract class SharedServerAdapter<
 	}
 
 	private createRouteRegistryPageModuleAdapter(): RouteRegistryPageModuleAdapter {
-		const serverModuleTranspiler = getAppServerModuleTranspiler(this.appConfig);
+		this.ensureRouteRendererFactory();
 
 		return {
 			loadPageModule: async (filePath) => {
-				const module = (await serverModuleTranspiler.importModule({
-					filePath,
-					outdir: path.join(resolveInternalExecutionDir(this.appConfig), '.server-route-modules'),
-					externalPackages: true,
-					transpileErrorMessage: (details) => `Error transpiling route module: ${details}`,
-					noOutputMessage: (targetFilePath) =>
-						`No transpiled output generated for route module: ${targetFilePath}`,
-				})) as EcoPageFile;
+				const module = (await this.routeRendererFactory
+					.getPageRenderer(filePath)
+					.loadPageModule(filePath)) as EcoPageFile;
 
 				const page = module.default;
 
@@ -152,11 +160,7 @@ export abstract class SharedServerAdapter<
 	 * @param hmrManager - The runtime-specific Hot Module Replacement orchestrator (if watching).
 	 */
 	protected configureSharedResponseHandlers(staticRoutes: StaticRoute[], hmrManager?: any): void {
-		this.routeRendererFactory = new RouteRendererFactory({
-			appConfig: this.appConfig,
-			rendererModules: this.appConfig.runtime?.rendererModuleContext,
-			runtimeOrigin: this.runtimeOrigin,
-		});
+		this.ensureRouteRendererFactory();
 
 		const { fileSystemResponseMatcher, explicitStaticRouteMatcher } =
 			this.createSharedResponseHandlerDependencies(staticRoutes);


### PR DESCRIPTION
## Summary

- RouteRegistry static path expansion loads page modules through `RouteRendererFactory.loadPageModule()` instead of the raw server module transpiler.
- Ensures integration-owned SSR setup (e.g. Radiant light-dom shim) runs before JSX page imports during build.
- Adds regression test in `server-adapter.test.ts`.

## Why split

This is a core merge blocker for docs builds that import Radiant components. It is independent of the content-processor docs migration.

## Test plan

- [x] `pnpm exec vitest run --project shared-core packages/core/src/adapters/shared/server-adapter.test.ts`
- [x] Full vitest suite (1824 tests)
- [x] `apps/docs` build passes without `installLightDomShim()` in `app.ts`