### PR TITLE
refactor(route-renderer): render pages only in document shell

### DIFF
--- a/packages/core/src/route-renderer/GRAPH.md
+++ b/packages/core/src/route-renderer/GRAPH.md
@@ -42,23 +42,17 @@ flowchart TD
   C --> D[ownershipValidationService.validate]
   D --> E[resolvePageData]
   E --> F[ownershipValidationService.validate + throwIfOwnershipInvalid]
-  F --> G[resolveDependencies]
-  G --> H[buildPageBrowserGraph]
-  H --> I{shouldRenderPageComponent?}
-  I -- Yes --> J[renderPageComponent]
-  I -- No --> K[skip page-root render]
-  J --> L[merge component assets]
-  K --> L
-  L --> M[collect injector and eager SSR lazy assets]
-  M --> N[build pagePackage and prepared render options]
-  N --> O[callbacks.render]
-  O --> P[capture rendered body as html]
-  P --> Q[inspect unresolved marker artifacts]
-  Q --> R{unresolved eco-marker remains?}
-  R -- Yes --> S[throw unresolved artifact error]
-  R -- No --> T[stamp root or document attributes when needed]
-  T --> U[htmlTransformer transform]
-  U --> V[final body and cache strategy]
+  F --> G[resolveDependencies + buildPageBrowserGraph]
+  G --> H[collect injector and eager SSR lazy assets]
+  H --> I[build pagePackage and prepared render options]
+  I --> J[IntegrationRenderer.render via document shell]
+  J --> K[capture rendered body as html]
+  K --> L[inspect unresolved marker artifacts]
+  L --> M{unresolved eco-marker remains?}
+  M -- Yes --> N[throw unresolved artifact error]
+  M -- No --> O[stamp document attributes when needed]
+  O --> P[htmlTransformer transform]
+  P --> Q[final body and cache strategy]
 ```
 
 ## 3) Mixed-Integration Render Model
@@ -124,7 +118,7 @@ The most useful reading order is:
 2. `orchestration/route-render-orchestrator.ts`
 3. `orchestration/integration-renderer.ts`
 4. `orchestration/ownership-validation.service.ts`
-5. `orchestration/ownership-planning.service.ts`
+5. `orchestration/component-graph.ts`
 6. `orchestration/component-render-context.ts`
 7. `orchestration/foreign-subtree-execution.service.ts`
 8. `page-loading/page-module-loader.ts`
@@ -137,7 +131,7 @@ The most useful reading order is:
 - `packages/core/src/route-renderer/orchestration/route-render-orchestrator.ts`
 - `packages/core/src/route-renderer/orchestration/integration-renderer.ts`
 - `packages/core/src/route-renderer/orchestration/ownership-validation.service.ts`
-- `packages/core/src/route-renderer/orchestration/ownership-planning.service.ts`
+- `packages/core/src/route-renderer/orchestration/component-graph.ts`
 - `packages/core/src/route-renderer/orchestration/component-render-context.ts`
 - `packages/core/src/route-renderer/orchestration/foreign-subtree-execution.service.ts`
 - `packages/core/src/route-renderer/page-loading/page-module-loader.ts`

--- a/packages/core/src/route-renderer/README.md
+++ b/packages/core/src/route-renderer/README.md
@@ -72,7 +72,7 @@ The route-render contract is:
 3. `RouteRenderOrchestrator.prepareRenderOptions()` loads the page module, validates ownership (fail-fast), resolves page data, resolves dependencies, and builds the page browser graph.
 4. The integration renderer performs page, layout, and document-shell rendering. When it encounters a foreign child, it delegates that child back to the owning renderer.
 5. If a renderer needs queued handoff, it emits internal foreign-subtree tokens and resolves them before returning final HTML.
-6. `RouteRenderOrchestrator.executePrepared()` captures the final body, rejects unresolved `<eco-marker>` artifacts, stamps root or document attributes when needed, and runs the HTML transformer.
+6. `RouteRenderOrchestrator.executePrepared()` captures the final body, rejects unresolved `<eco-marker>` artifacts, stamps document attributes when needed, and runs the HTML transformer.
 
 Important:
 

--- a/packages/core/src/route-renderer/orchestration/document-shell-render.service.test.ts
+++ b/packages/core/src/route-renderer/orchestration/document-shell-render.service.test.ts
@@ -4,6 +4,7 @@ import { eco } from '../../eco/eco.ts';
 import {
 	composeDocumentShell,
 	composeSequentialLayoutChildren,
+	applyDocumentShellAttributeStamping,
 	type DocumentShellComposeChildrenContext,
 } from './document-shell-render.service.ts';
 
@@ -187,5 +188,34 @@ describe('document-shell-render.service', () => {
 			children: '<page />',
 			integrationContext: { rendererCache },
 		});
+	});
+
+	it('stamps component-root and document attributes through applyDocumentShellAttributeStamping', () => {
+		const stamped = applyDocumentShellAttributeStamping(
+			'<html><body><main>Page</main></body></html>',
+			{
+				applyAttributesToFirstBodyElement: (html, attributes) =>
+					html.replace(
+						'<main',
+						`<main ${Object.entries(attributes)
+							.map(([key, value]) => `${key}="${value}"`)
+							.join(' ')}`,
+					),
+				applyAttributesToHtmlElement: (html, attributes) =>
+					html.replace(
+						'<html',
+						`<html ${Object.entries(attributes)
+							.map(([key, value]) => `${key}="${value}"`)
+							.join(' ')}`,
+					),
+			},
+			{
+				componentRootAttributes: { 'data-eco-component-id': 'eco-page-root' },
+				documentAttributes: { 'data-eco-document-owner': 'react-router' },
+			},
+		);
+
+		expect(stamped).toContain('<html data-eco-document-owner="react-router"><body>');
+		expect(stamped).toContain('<main data-eco-component-id="eco-page-root">Page</main>');
 	});
 });

--- a/packages/core/src/route-renderer/orchestration/integration-renderer.test.ts
+++ b/packages/core/src/route-renderer/orchestration/integration-renderer.test.ts
@@ -1282,33 +1282,24 @@ describe('IntegrationRenderer', () => {
 			expect(body).toContain('<main>Stream Body</main>');
 		});
 
-		it('should include renderComponent assets and apply root attributes', async () => {
+		it('should apply document attributes during route finalization', async () => {
 			const appConfig = {
 				...AppConfig,
 			} as EcoPagesAppConfig;
 
-			const renderer = new TestIntegrationRenderer({
+			class DocumentAttributeRenderer extends TestIntegrationRenderer {
+				protected override getDocumentAttributes(): Record<string, string> | undefined {
+					return { 'data-eco-document-owner': 'react-router' };
+				}
+			}
+
+			const renderer = new DocumentAttributeRenderer({
 				appConfig,
 				assetProcessingService: AssetService,
 				runtimeOrigin: 'http://localhost:3000',
 			});
 
 			renderer.RenderedBody = '<html><body><main>Test Page</main></body></html>';
-			renderer.MockComponentRenderResult = {
-				html: '<main>Test Page</main>',
-				canAttachAttributes: true,
-				rootTag: 'main',
-				integrationName: 'test-renderer',
-				rootAttributes: { 'data-eco-component-id': 'eco-page-root' },
-				assets: [
-					{
-						kind: 'script',
-						srcUrl: '/assets/island.js',
-						position: 'head',
-					} as ProcessedAsset,
-				],
-			};
-
 			renderer.PageModule = {
 				default: (() => '<main>Test Page</main>') as unknown as EcoPageComponent<any>,
 			};
@@ -1322,10 +1313,8 @@ describe('IntegrationRenderer', () => {
 			});
 
 			const body = await new Response(result.body as BodyInit).text();
-			expect(body).toContain('<main data-eco-component-id="eco-page-root">Test Page</main>');
-
-			const processedDeps = (renderer as any).htmlTransformer.getProcessedDependencies();
-			expect(processedDeps.some((dep: ProcessedAsset) => dep.srcUrl === '/assets/island.js')).toBe(true);
+			expect(body).toContain('<html data-eco-document-owner="react-router"><body>');
+			expect(body).toContain('<main>Test Page</main>');
 		});
 
 		it('should not force render nested dependency components without resolved props context', async () => {
@@ -1398,7 +1387,7 @@ describe('IntegrationRenderer', () => {
 			expect((explicitRenderer.renderComponent as any).mock.calls).toHaveLength(0);
 
 			const body = await new Response(result.body as BodyInit).text();
-			expect(body).toContain('<main data-eco-component-id="eco-page-root">Test Page</main>');
+			expect(body).toContain('<main>Test Page</main>');
 
 			const processedDeps = (renderer as any).htmlTransformer.getProcessedDependencies();
 			expect(processedDeps.some((dep: ProcessedAsset) => dep.srcUrl === '/assets/nested-explicit.js')).toBe(

--- a/packages/core/src/route-renderer/orchestration/integration-renderer.ts
+++ b/packages/core/src/route-renderer/orchestration/integration-renderer.ts
@@ -9,7 +9,6 @@ import type {
 	ComponentRenderInput,
 	ComponentRenderResult,
 	EcoComponent,
-	EcoComponentDependencies,
 	EcoFunctionComponent,
 	EcoPageFile,
 	EcoPagesElement,
@@ -667,24 +666,6 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 	}
 
 	/**
-	 * Returns the HTML path from the provided file path.
-	 * It extracts the path relative to the pages directory and removes the 'index' part if present.
-	 *
-	 * @param file - The file path to extract the HTML path from.
-	 * @returns The extracted HTML path.
-	 */
-	protected getHtmlPath({ file }: { file: string }): string {
-		const pagesDir = this.appConfig.absolutePaths.pagesDir;
-		const pagesIndex = file.indexOf(pagesDir);
-		if (pagesIndex === -1) return file;
-		const startIndex = file.indexOf(pagesDir) + pagesDir.length;
-		const endIndex = file.lastIndexOf('/');
-		const path = file.substring(startIndex, endIndex);
-		if (path === '/index') return '';
-		return path;
-	}
-
-	/**
 	 * Returns the HTML template component.
 	 * It imports the HTML template from the specified path in the app configuration.
 	 *
@@ -751,59 +732,6 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 	}
 
 	/**
-	 * Extracts the dependencies from the provided component configuration.
-	 * It resolves the paths for scripts and stylesheets based on the component directory.
-	 *
-	 * @param componentDir - The component directory path.
-	 * @param scripts - The scripts to extract.
-	 * @param stylesheets - The stylesheets to extract.
-	 * @returns The extracted dependencies.
-	 */
-	protected extractDependencies({
-		componentDir,
-		scripts,
-		stylesheets,
-	}: {
-		componentDir: string;
-	} & EcoComponentDependencies): EcoComponentDependencies {
-		const scriptsPaths = [
-			...new Set(
-				(scripts ?? [])
-					.filter((script) => (typeof script === 'string' ? true : !script.lazy))
-					.map((script) => (typeof script === 'string' ? script : script.src))
-					.filter((script): script is string => Boolean(script))
-					.map((script) => this.resolveDependencyPath(componentDir, script)),
-			),
-		];
-
-		const stylesheetsPaths = [
-			...new Set(
-				(stylesheets ?? [])
-					.map((style) => (typeof style === 'string' ? style : style.src))
-					.filter((style): style is string => Boolean(style))
-					.map((style) => this.resolveDependencyPath(componentDir, style)),
-			),
-		];
-
-		return {
-			scripts: scriptsPaths,
-			stylesheets: stylesheetsPaths,
-		};
-	}
-
-	/**
-	 * Resolves lazy script paths to public asset URLs.
-	 * Converts source paths to their final bundled output paths.
-	 *
-	 * @param componentDir - The component directory path.
-	 * @param scripts - The lazy script paths to resolve.
-	 * @returns Comma-separated string of resolved public script paths.
-	 */
-	protected resolveLazyScripts(componentDir: string, scripts: string[]): string {
-		return this.dependencyResolverService.resolveLazyScripts(componentDir, scripts);
-	}
-
-	/**
 	 * Collects the dependencies for the provided components.
 	 * Combines component-specific dependencies with global integration dependencies.
 	 *
@@ -843,12 +771,9 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 			resolveRouteDependencies: (input) => this.resolveRouteDependencies(input),
 			importPageFile: (file) => this.importPageFile(file),
 			collectPageBrowserGraphContribution: (context) => this.collectPageBrowserGraphContribution(context),
-			resolveRoutePageComponentRender: (input) => this.resolveRoutePageComponentRender(input),
 			renderRouteBody: (renderOptions) => this.renderRouteBody(renderOptions),
 			getDocumentAttributes: (renderOptions) => this.getDocumentAttributes(renderOptions),
 			getHtmlDocumentContributions: (options) => this.getHtmlDocumentContributions(options),
-			applyAttributesToFirstBodyElement: (html, attributes) =>
-				this.applyAttributesToFirstBodyElement(html, attributes),
 			applyAttributesToHtmlElement: (html, attributes) => this.applyAttributesToHtmlElement(html, attributes),
 			transformRouteResponse: (response, htmlContributions, pagePackage) =>
 				this.transformRouteResponse(response, htmlContributions, pagePackage),
@@ -891,29 +816,6 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 		};
 	}
 
-	protected async resolveRoutePageComponentRender(input: {
-		Page: EcoComponent;
-		Layout?: EcoComponent;
-		props: Record<string, unknown>;
-		routeOptions: RouteRendererOptions;
-	}): Promise<ComponentRenderResult | undefined> {
-		if (!this.shouldRenderPageComponent({ Page: input.Page, Layout: input.Layout, options: input.routeOptions })) {
-			return undefined;
-		}
-
-		return this.renderComponentWithForeignChildren({
-			component: input.Page,
-			props: {
-				...input.props,
-				params: input.routeOptions.params || {},
-				query: input.routeOptions.query || {},
-			},
-			integrationContext: {
-				componentInstanceId: 'eco-page-root',
-			},
-		});
-	}
-
 	protected async renderRouteBody(renderOptions: IntegrationRendererRenderOptions<C>): Promise<RouteRendererBody> {
 		return this.render(renderOptions);
 	}
@@ -950,29 +852,13 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 	}
 
 	/**
-	 * Controls whether the page root should be rendered through `renderComponent()`
-	 * during route option preparation in component-capable modes.
-	 *
-	 * Integrations that already own page-level hydration (for example router-driven
-	 * React rendering) can override this and return `false` to avoid duplicate root
-	 * mount assets and competing hydration entrypoints.
-	 */
-	protected shouldRenderPageComponent(_input: {
-		Page: EcoComponent;
-		Layout?: EcoComponent;
-		options: RouteRendererOptions;
-	}): boolean {
-		return true;
-	}
-
-	/**
 	 * Executes the integration renderer with the provided options.
 	 *
 	 * Execution flow:
 	 * 1. Build normalized render options (`prepareRenderOptions`).
 	 * 2. Render the route body once.
 	 * 3. Reject unresolved route-level eco-marker artifacts.
-	 * 4. Optionally apply root attributes for page/component root boundaries.
+	 * 4. Optionally apply document attributes for integration-owned document boundaries.
 	 * 5. Run HTML transformer with final dependency set.
 	 *
 	 * Stream-safety note: the first render result is normalized to a string once,

--- a/packages/core/src/route-renderer/orchestration/integration-route-render-adapter.ts
+++ b/packages/core/src/route-renderer/orchestration/integration-route-render-adapter.ts
@@ -1,7 +1,6 @@
 import type { ProcessedAsset } from '../../services/assets/asset-processing-service/index.ts';
 import type { HtmlDocumentContribution } from '../../services/html/html-transformer.service.ts';
 import type {
-	ComponentRenderResult,
 	EcoComponent,
 	EcoPageFile,
 	IntegrationRendererRenderOptions,
@@ -32,19 +31,12 @@ export type IntegrationRouteRenderAdapterHost<C> = {
 	collectPageBrowserGraphContribution(
 		context: PageBrowserGraphContributionContext,
 	): Promise<PageBrowserGraphContribution | undefined>;
-	resolveRoutePageComponentRender(input: {
-		Page: EcoComponent;
-		Layout?: EcoComponent;
-		props: Record<string, unknown>;
-		routeOptions: RouteRendererOptions;
-	}): Promise<ComponentRenderResult | undefined>;
 	renderRouteBody(renderOptions: IntegrationRendererRenderOptions<C>): Promise<RouteRendererBody>;
 	getDocumentAttributes(renderOptions: IntegrationRendererRenderOptions<C>): Record<string, string> | undefined;
 	getHtmlDocumentContributions(options: {
 		renderOptions: IntegrationRendererRenderOptions<C>;
 		partial: boolean;
 	}): HtmlDocumentContribution[] | undefined;
-	applyAttributesToFirstBodyElement(html: string, attributes: Record<string, string>): string;
 	applyAttributesToHtmlElement(html: string, attributes: Record<string, string>): string;
 	transformRouteResponse(
 		response: Response,
@@ -69,15 +61,12 @@ export function createIntegrationRouteRenderAdapter<C>(
 				(file) => host.importPageFile(file),
 				(context) => host.collectPageBrowserGraphContribution(context),
 			),
-		resolveRoutePageComponentRender: (input) => host.resolveRoutePageComponentRender(input),
 		renderRouteBody: (renderOptions) => host.renderRouteBody(renderOptions),
 		getRouteHtmlFinalization: (renderOptions) =>
 			buildRouteHtmlFinalization({
 				renderOptions,
 				getDocumentAttributes: (options) => host.getDocumentAttributes(options),
 				getHtmlDocumentContributions: (options) => host.getHtmlDocumentContributions(options),
-				applyAttributesToFirstBodyElement: (html, attributes) =>
-					host.applyAttributesToFirstBodyElement(html, attributes),
 				applyAttributesToHtmlElement: (html, attributes) => host.applyAttributesToHtmlElement(html, attributes),
 			}),
 		transformRouteResponse: (response, htmlContributions, pagePackage) =>

--- a/packages/core/src/route-renderer/orchestration/route-html-finalization.service.test.ts
+++ b/packages/core/src/route-renderer/orchestration/route-html-finalization.service.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IntegrationRendererRenderOptions } from '../../types/public-types.ts';
+import { buildRouteHtmlFinalization } from './route-html-finalization.service.ts';
+
+describe('route-html-finalization.service', () => {
+	it('returns an empty plan when no document attributes or contributions exist', () => {
+		const plan = buildRouteHtmlFinalization({
+			renderOptions: {} as IntegrationRendererRenderOptions,
+			getDocumentAttributes: () => undefined,
+			getHtmlDocumentContributions: () => undefined,
+			applyAttributesToHtmlElement: (html) => html,
+		});
+
+		expect(plan).toEqual({});
+	});
+
+	it('stamps document attributes on the captured route HTML', () => {
+		const applyAttributesToHtmlElement = vi.fn((html: string, attributes: Record<string, string>) => {
+			return html.replace(
+				'<html',
+				`<html ${Object.entries(attributes)
+					.map(([key, value]) => `${key}="${value}"`)
+					.join(' ')}`,
+			);
+		});
+
+		const plan = buildRouteHtmlFinalization({
+			renderOptions: {} as IntegrationRendererRenderOptions,
+			getDocumentAttributes: () => ({ 'data-eco-document-owner': 'react-router' }),
+			getHtmlDocumentContributions: () => [{ placement: 'head-append', html: '<meta name="test" />' }],
+			applyAttributesToHtmlElement,
+		});
+
+		expect(plan.htmlContributions).toEqual([{ placement: 'head-append', html: '<meta name="test" />' }]);
+		expect(plan.finalizeHtml?.('<html><body><main>Page</main></body></html>')).toContain(
+			'data-eco-document-owner="react-router"',
+		);
+		expect(applyAttributesToHtmlElement).toHaveBeenCalledWith('<html><body><main>Page</main></body></html>', {
+			'data-eco-document-owner': 'react-router',
+		});
+	});
+});

--- a/packages/core/src/route-renderer/orchestration/route-html-finalization.service.ts
+++ b/packages/core/src/route-renderer/orchestration/route-html-finalization.service.ts
@@ -9,7 +9,6 @@ export type RouteHtmlFinalizationContext<C> = {
 		renderOptions: IntegrationRendererRenderOptions<C>;
 		partial: boolean;
 	}) => HtmlDocumentContribution[] | undefined;
-	applyAttributesToFirstBodyElement: (html: string, attributes: Record<string, string>) => string;
 	applyAttributesToHtmlElement: (html: string, attributes: Record<string, string>) => string;
 };
 
@@ -18,17 +17,9 @@ export type RouteHtmlFinalizationContext<C> = {
  */
 export function buildRouteHtmlFinalization<C>(context: RouteHtmlFinalizationContext<C>): RouteHtmlFinalization {
 	const { renderOptions } = context;
-	const componentRootAttributes =
-		renderOptions.componentRender?.canAttachAttributes &&
-		renderOptions.componentRender.rootAttributes &&
-		Object.keys(renderOptions.componentRender.rootAttributes).length > 0
-			? (renderOptions.componentRender.rootAttributes as Record<string, string>)
-			: undefined;
 	const documentAttributes = context.getDocumentAttributes(renderOptions);
 	const htmlContributions = context.getHtmlDocumentContributions({ renderOptions, partial: false });
-	const hasStructuralFinalization =
-		(componentRootAttributes && Object.keys(componentRootAttributes).length > 0) ||
-		(documentAttributes && Object.keys(documentAttributes).length > 0);
+	const hasStructuralFinalization = documentAttributes && Object.keys(documentAttributes).length > 0;
 
 	if (!hasStructuralFinalization && (!htmlContributions || htmlContributions.length === 0)) {
 		return {};
@@ -37,17 +28,11 @@ export function buildRouteHtmlFinalization<C>(context: RouteHtmlFinalizationCont
 	return {
 		htmlContributions,
 		finalizeHtml: (html) => {
-			let renderedHtml = html;
-
-			if (componentRootAttributes) {
-				renderedHtml = context.applyAttributesToFirstBodyElement(renderedHtml, componentRootAttributes);
+			if (!documentAttributes || Object.keys(documentAttributes).length === 0) {
+				return html;
 			}
 
-			if (documentAttributes) {
-				renderedHtml = context.applyAttributesToHtmlElement(renderedHtml, documentAttributes);
-			}
-
-			return renderedHtml;
+			return context.applyAttributesToHtmlElement(html, documentAttributes);
 		},
 	};
 }

--- a/packages/core/src/route-renderer/orchestration/route-prepared-options.builder.ts
+++ b/packages/core/src/route-renderer/orchestration/route-prepared-options.builder.ts
@@ -1,6 +1,5 @@
 import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 import type {
-	ComponentRenderResult,
 	EcoComponent,
 	EcoPageComponent,
 	EcoPageFile,
@@ -36,18 +35,9 @@ export function buildPreparedRenderOptions<C = unknown>(input: {
 	resolvedDependencies: ProcessedAsset[];
 	allDependencies: ProcessedAsset[];
 	pageBrowserGraph?: PageBrowserGraphResult;
-	componentRender?: ComponentRenderResult;
 	appConfig: EcoPagesAppConfig;
 }): IntegrationRendererRenderOptions<C> {
-	const {
-		routeOptions,
-		resolvedInputs,
-		resolvedDependencies,
-		allDependencies,
-		pageBrowserGraph,
-		componentRender,
-		appConfig,
-	} = input;
+	const { routeOptions, resolvedInputs, resolvedDependencies, allDependencies, pageBrowserGraph, appConfig } = input;
 	const { Page, HtmlTemplate, Layouts, Layout, layoutEntries, props, metadata, integrationSpecificProps } =
 		resolvedInputs;
 
@@ -72,7 +62,6 @@ export function buildPreparedRenderOptions<C = unknown>(input: {
 		...routeOptions,
 		resolvedDependencies,
 		pagePackage,
-		componentRender,
 		HtmlTemplate: HtmlTemplate as EcoComponent<HtmlTemplateProps, C>,
 		Layouts,
 		Layout,

--- a/packages/core/src/route-renderer/orchestration/route-render-orchestrator.prepare-render-options.test.ts
+++ b/packages/core/src/route-renderer/orchestration/route-render-orchestrator.prepare-render-options.test.ts
@@ -46,17 +46,6 @@ function createFlowAdapter<C>(input: {
 	) => Promise<{ props: Record<string, unknown>; metadata: PageMetadataProps }>;
 	resolveDependencies: (components: (EcoComponent | Partial<EcoComponent>)[]) => Promise<ProcessedAsset[]>;
 	collectPageBrowserGraphContribution: (routeFile: string) => Promise<PageBrowserGraphContribution | undefined>;
-	shouldRenderPageComponent: (input: {
-		Page: EcoComponent;
-		Layout?: EcoComponent;
-		options: RouteRendererOptions;
-	}) => boolean;
-	renderPageComponent: (input: {
-		Page: EcoComponent;
-		Layout?: EcoComponent;
-		props: Record<string, unknown>;
-		routeOptions: RouteRendererOptions;
-	}) => Promise<any>;
 }): RouteRenderOrchestratorAdapter<C> {
 	return {
 		name: 'ghtml',
@@ -76,11 +65,6 @@ function createFlowAdapter<C>(input: {
 				props,
 				metadata,
 				integrationSpecificProps: pageModule.integrationSpecificProps,
-				shouldRenderPageComponent: input.shouldRenderPageComponent({
-					Page: pageModule.Page as EcoComponent,
-					Layout,
-					options: routeOptions,
-				}),
 			};
 		},
 		resolveRouteDependencies: async ({ components }) => ({
@@ -88,19 +72,6 @@ function createFlowAdapter<C>(input: {
 		}),
 		collectPageBrowserGraphContribution: async (routeFile) =>
 			await input.collectPageBrowserGraphContribution(routeFile),
-		resolveRoutePageComponentRender: async (renderInput) => {
-			if (
-				!input.shouldRenderPageComponent({
-					Page: renderInput.Page,
-					Layout: renderInput.Layout,
-					options: renderInput.routeOptions,
-				})
-			) {
-				return undefined;
-			}
-
-			return await input.renderPageComponent(renderInput);
-		},
 		renderRouteBody: async () => '',
 		getRouteHtmlFinalization: () => ({}),
 		transformRouteResponse: async (response) => await response.text(),
@@ -146,11 +117,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 		const integrationDependency = {
 			kind: 'script',
 			srcUrl: '/assets/react-runtime.js',
-			position: 'head',
-		} as ProcessedAsset;
-		const componentAsset = {
-			kind: 'script',
-			srcUrl: '/assets/page-root.js',
 			position: 'head',
 		} as ProcessedAsset;
 		const resolvedDependency = {
@@ -210,14 +176,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 				}),
 				resolveDependencies: async () => [resolvedDependency],
 				collectPageBrowserGraphContribution: async () => ({ assets: [pageDependency] }),
-				shouldRenderPageComponent: () => true,
-				renderPageComponent: async () => ({
-					html: '<main>Page</main>',
-					canAttachAttributes: true,
-					rootTag: 'main',
-					integrationName: 'ghtml',
-					assets: [componentAsset],
-				}),
 			}),
 		);
 
@@ -225,71 +183,15 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 		expect(result.pageLocals).toEqual({ user: 'andee' });
 		expect(result.pageProps).toEqual({ title: 'Hello', params: { slug: 'hello' }, query: { preview: '1' } });
 		expect((result as typeof result & { layoutMode?: string }).layoutMode).toBe('full');
-		expect(result.componentRender?.assets).toEqual([componentAsset]);
 		expect(result.pagePackage).toEqual(
 			expect.objectContaining({
-				assets: expect.arrayContaining([
-					resolvedDependency,
-					integrationDependency,
-					pageDependency,
-					componentAsset,
-				]),
+				assets: expect.arrayContaining([resolvedDependency, integrationDependency, pageDependency]),
 				pageBrowserGraph: {
 					entryAssets: [pageDependency],
 					chunkAssets: [],
 				},
 			}),
 		);
-	});
-
-	it('renders page-root output directly during preparation', async () => {
-		const assetProcessingService = {
-			processDependencies: vi.fn(async () => []),
-		} as unknown as AssetProcessingService;
-		const appConfig = {
-			cache: { defaultStrategy: 'static' },
-			integrations: [],
-		} as unknown as EcoPagesAppConfig;
-		const flow = new RouteRenderOrchestrator(appConfig, assetProcessingService);
-		const HtmlTemplate = (() => '<html></html>') as EcoComponent<HtmlTemplateProps>;
-		const DeferredChild = eco.component<{}, string>({
-			integration: 'react',
-			render: () => '<span>Deferred</span>',
-		});
-		const Page = (() => '<main>Page</main>') as unknown as EcoPageComponent<any>;
-
-		const result = await flow.prepareRenderOptions(
-			{ file: '/app/pages/index.tsx', params: {}, query: {} } as unknown as RouteRendererOptions,
-			createFlowAdapter({
-				resolvePageModule: async () => ({
-					Page,
-					integrationSpecificProps: {},
-				}),
-				getHtmlTemplate: async () => HtmlTemplate,
-				resolvePageData: async () => ({
-					props: {},
-					metadata: { title: 'Page', description: 'Page description' },
-				}),
-				resolveDependencies: async () => [],
-				collectPageBrowserGraphContribution: async () => ({ assets: [] }),
-				shouldRenderPageComponent: () => true,
-				renderPageComponent: async () => ({
-					html: DeferredChild({}),
-					canAttachAttributes: true,
-					rootTag: 'span',
-					integrationName: 'ghtml',
-				}),
-			}),
-		);
-
-		expect(result.componentRender).toEqual(
-			expect.objectContaining({
-				canAttachAttributes: true,
-				rootTag: 'span',
-				integrationName: 'ghtml',
-			}),
-		);
-		expect(result.componentRender?.html).toBe('<span>Deferred</span>');
 	});
 
 	it('inlines the global injector bootstrap when resolved lazy triggers are present', async () => {
@@ -340,8 +242,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 				}),
 				resolveDependencies: async () => [],
 				collectPageBrowserGraphContribution: async () => ({ assets: [] }),
-				shouldRenderPageComponent: () => false,
-				renderPageComponent: vi.fn(),
 			}),
 		);
 
@@ -401,8 +301,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 			}),
 			resolveDependencies: async () => [],
 			collectPageBrowserGraphContribution,
-			shouldRenderPageComponent: () => false,
-			renderPageComponent: vi.fn(),
 		});
 
 		await flow.prepareRenderOptions(
@@ -460,8 +358,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 			}),
 			resolveDependencies: async () => [],
 			collectPageBrowserGraphContribution,
-			shouldRenderPageComponent: () => false,
-			renderPageComponent: vi.fn(),
 		});
 
 		await flow.prepareRenderOptions(
@@ -528,8 +424,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 					],
 					assets: [chunkAsset],
 				}),
-				shouldRenderPageComponent: () => false,
-				renderPageComponent: vi.fn(),
 			}),
 		);
 
@@ -619,8 +513,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 				}),
 				resolveDependencies: async () => [],
 				collectPageBrowserGraphContribution,
-				shouldRenderPageComponent: () => false,
-				renderPageComponent: vi.fn(),
 			}),
 			name: 'react' as const,
 		});
@@ -712,8 +604,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 				}),
 				resolveDependencies: async () => [],
 				collectPageBrowserGraphContribution,
-				shouldRenderPageComponent: () => false,
-				renderPageComponent: vi.fn(),
 			}),
 			name: 'react' as const,
 		});
@@ -814,8 +704,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 				}),
 				resolveDependencies: async () => [],
 				collectPageBrowserGraphContribution,
-				shouldRenderPageComponent: () => false,
-				renderPageComponent: vi.fn(),
 			}),
 			name: 'react' as const,
 		});
@@ -907,8 +795,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 				}),
 				resolveDependencies: async () => [],
 				collectPageBrowserGraphContribution,
-				shouldRenderPageComponent: () => false,
-				renderPageComponent: vi.fn(),
 			}),
 			name: 'react' as const,
 		});
@@ -1002,8 +888,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 				}),
 				resolveDependencies: async () => [],
 				collectPageBrowserGraphContribution,
-				shouldRenderPageComponent: () => false,
-				renderPageComponent: vi.fn(),
 			}),
 			name: 'react' as const,
 		});
@@ -1092,8 +976,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 					}),
 					resolveDependencies: async () => [],
 					collectPageBrowserGraphContribution,
-					shouldRenderPageComponent: () => false,
-					renderPageComponent: vi.fn(),
 				}),
 				name: 'react' as const,
 			},
@@ -1110,7 +992,7 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 		);
 	});
 
-	it('should guard page locals for static pages and skip page-root rendering when disabled', async () => {
+	it('should guard page locals for static pages', async () => {
 		const assetProcessingService = {
 			processDependencies: vi.fn(async () => []),
 		} as unknown as AssetProcessingService;
@@ -1121,7 +1003,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 		const flow = new RouteRenderOrchestrator(appConfig, assetProcessingService);
 		const HtmlTemplate = (() => '<html></html>') as EcoComponent<HtmlTemplateProps>;
 		const Page = (() => '<main>Page</main>') as unknown as EcoPageComponent<any>;
-		const renderPageComponent = vi.fn();
 
 		const result = await flow.prepareRenderOptions(
 			{
@@ -1142,15 +1023,11 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 				}),
 				resolveDependencies: async () => [],
 				collectPageBrowserGraphContribution: async () => ({ assets: [] }),
-				shouldRenderPageComponent: () => false,
-				renderPageComponent,
 			}),
 		);
 
 		expect(result.locals).toBeUndefined();
 		expect(() => Reflect.get(result.pageLocals as object, 'guarded')).toThrow(LocalsAccessError);
-		expect(result.componentRender).toBeUndefined();
-		expect(renderPageComponent).not.toHaveBeenCalled();
 	});
 
 	it('eagerly emits lazy SSR component scripts for shared non-owning routes', async () => {
@@ -1208,8 +1085,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 				}),
 				resolveDependencies: async () => [],
 				collectPageBrowserGraphContribution: async () => ({ assets: [] }),
-				shouldRenderPageComponent: () => false,
-				renderPageComponent: vi.fn(),
 			}),
 		);
 
@@ -1281,8 +1156,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 				}),
 				resolveDependencies: async () => [],
 				collectPageBrowserGraphContribution: async () => ({ assets: [] }),
-				shouldRenderPageComponent: () => false,
-				renderPageComponent: vi.fn(),
 			}),
 		);
 
@@ -1340,8 +1213,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 					}),
 					resolveDependencies: async () => [],
 					collectPageBrowserGraphContribution: async () => ({ assets: [] }),
-					shouldRenderPageComponent: () => false,
-					renderPageComponent: vi.fn(),
 				}),
 			),
 		).resolves.toEqual(
@@ -1364,8 +1235,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 				}),
 				resolveDependencies: async () => [],
 				collectPageBrowserGraphContribution: async () => ({ assets: [] }),
-				shouldRenderPageComponent: () => false,
-				renderPageComponent: vi.fn(),
 			}),
 		);
 
@@ -1407,8 +1276,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 				}),
 				resolveDependencies: async () => [],
 				collectPageBrowserGraphContribution: async () => ({ assets: [] }),
-				shouldRenderPageComponent: () => false,
-				renderPageComponent: vi.fn(),
 			}),
 		);
 
@@ -1461,8 +1328,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 					}),
 					resolveDependencies: async () => [],
 					collectPageBrowserGraphContribution: async () => ({ assets: [] }),
-					shouldRenderPageComponent: () => false,
-					renderPageComponent: vi.fn(),
 				}),
 			),
 		).rejects.toThrow(
@@ -1521,8 +1386,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 						return [];
 					},
 					collectPageBrowserGraphContribution: async () => ({ assets: [] }),
-					shouldRenderPageComponent: () => false,
-					renderPageComponent: vi.fn(),
 				}),
 				name: 'react',
 			},

--- a/packages/core/src/route-renderer/orchestration/route-render-orchestrator.test.ts
+++ b/packages/core/src/route-renderer/orchestration/route-render-orchestrator.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest';
 import type {
 	EcoComponent,
 	HtmlTemplateProps,
+	IntegrationRendererRenderOptions,
 	PageBrowserGraphContribution,
 	PageMetadataProps,
 	RouteRendererBody,
 	RouteRendererOptions,
 } from '../../types/public-types.ts';
+import { buildRouteHtmlFinalization } from './route-html-finalization.service.ts';
 import {
 	type RouteHtmlFinalization,
 	type RouteRenderOrchestratorAdapter,
@@ -31,17 +33,6 @@ function createFlowAdapter(input: {
 	) => Promise<{ props: Record<string, unknown>; metadata: PageMetadataProps }>;
 	resolveDependencies: (components: (EcoComponent | Partial<EcoComponent>)[]) => Promise<any[]>;
 	collectPageBrowserGraphContribution: (routeFile: string) => Promise<PageBrowserGraphContribution | undefined>;
-	shouldRenderPageComponent: (input: {
-		Page: EcoComponent;
-		Layout?: EcoComponent;
-		options: RouteRendererOptions;
-	}) => boolean;
-	renderPageComponent: (input: {
-		Page: EcoComponent;
-		Layout?: EcoComponent;
-		props: Record<string, unknown>;
-		routeOptions: RouteRendererOptions;
-	}) => Promise<any>;
 	renderRouteBody: () => Promise<RouteRendererBody>;
 	getRouteHtmlFinalization?: () => RouteHtmlFinalization;
 	transformRouteResponse: (response: Response) => Promise<RouteRendererBody>;
@@ -64,11 +55,6 @@ function createFlowAdapter(input: {
 				props,
 				metadata,
 				integrationSpecificProps: pageModule.integrationSpecificProps,
-				shouldRenderPageComponent: input.shouldRenderPageComponent({
-					Page: pageModule.Page,
-					Layout,
-					options: routeOptions,
-				}),
 			};
 		},
 		resolveRouteDependencies: async ({ components }) => ({
@@ -76,19 +62,6 @@ function createFlowAdapter(input: {
 		}),
 		collectPageBrowserGraphContribution: async (routeFile) =>
 			await input.collectPageBrowserGraphContribution(routeFile),
-		resolveRoutePageComponentRender: async (renderInput) => {
-			if (
-				!input.shouldRenderPageComponent({
-					Page: renderInput.Page,
-					Layout: renderInput.Layout,
-					options: renderInput.routeOptions,
-				})
-			) {
-				return undefined;
-			}
-
-			return await input.renderPageComponent(renderInput);
-		},
 		renderRouteBody: input.renderRouteBody,
 		getRouteHtmlFinalization: input.getRouteHtmlFinalization ?? (() => ({})),
 		transformRouteResponse: input.transformRouteResponse,
@@ -123,7 +96,7 @@ describe('RouteRenderOrchestrator', () => {
 		expect(result.html).toContain('<main>Streamed</main>');
 	});
 
-	it('preserves streamed bodies when no foreign-subtree resolution or attribute stamping is required', async () => {
+	it('executes prepared route renders and preserves cache strategy', async () => {
 		const flow = new RouteRenderOrchestrator(appConfig, assetProcessingService);
 		const encoder = new TextEncoder();
 		const HtmlTemplate = (() => '<html></html>') as EcoComponent<HtmlTemplateProps>;
@@ -142,12 +115,6 @@ describe('RouteRenderOrchestrator', () => {
 				resolvePageData: async () => ({ props: {}, metadata: appConfig.defaultMetadata }),
 				resolveDependencies: async () => [],
 				collectPageBrowserGraphContribution: async () => undefined,
-				shouldRenderPageComponent: () => true,
-				renderPageComponent: async () => ({
-					html: '<main>Page</main>',
-					canAttachAttributes: true,
-					integrationName: 'ghtml',
-				}),
 				renderRouteBody: async () =>
 					new ReadableStream({
 						start(controller) {
@@ -164,7 +131,7 @@ describe('RouteRenderOrchestrator', () => {
 		expect(await new Response(result.body as BodyInit).text()).toContain('<main>Streamed</main>');
 	});
 
-	it('applies root and document attributes to fully resolved route HTML', async () => {
+	it('applies document attributes to fully resolved route HTML', async () => {
 		const flow = new RouteRenderOrchestrator(appConfig, assetProcessingService);
 		const HtmlTemplate = (() => '<html></html>') as EcoComponent<HtmlTemplateProps>;
 		const Page = (() => '<main>Page</main>') as EcoComponent<Record<string, unknown>>;
@@ -182,27 +149,27 @@ describe('RouteRenderOrchestrator', () => {
 				resolvePageData: async () => ({ props: {}, metadata: appConfig.defaultMetadata }),
 				resolveDependencies: async () => [],
 				collectPageBrowserGraphContribution: async () => undefined,
-				shouldRenderPageComponent: () => true,
-				renderPageComponent: async () => ({
-					html: '<main>Page</main>',
-					canAttachAttributes: true,
-					integrationName: 'ghtml',
-					rootAttributes: { 'data-eco-component-id': 'eco-page-root' },
-				}),
 				renderRouteBody: async () => '<html><body><main>Resolved</main></body></html>',
-				getRouteHtmlFinalization: () => ({
-					finalizeHtml: (html) =>
-						html
-							.replace('<html', '<html data-eco-document-owner="react-router"')
-							.replace('<main', '<main data-eco-component-id="eco-page-root"'),
-				}),
+				getRouteHtmlFinalization: () =>
+					buildRouteHtmlFinalization({
+						renderOptions: {} as IntegrationRendererRenderOptions,
+						getDocumentAttributes: () => ({ 'data-eco-document-owner': 'react-router' }),
+						getHtmlDocumentContributions: () => undefined,
+						applyAttributesToHtmlElement: (html, attributes) =>
+							html.replace(
+								'<html',
+								`<html ${Object.entries(attributes)
+									.map(([key, value]) => `${key}="${value}"`)
+									.join(' ')}`,
+							),
+					}),
 				transformRouteResponse: async (response) => await response.text(),
 			}),
 		);
 
 		expect(result.cacheStrategy).toEqual({ revalidate: 60 });
 		expect(result.body).toContain('<html data-eco-document-owner="react-router"><body>');
-		expect(result.body).toContain('<main data-eco-component-id="eco-page-root">Resolved</main>');
+		expect(result.body).toContain('<main>Resolved</main>');
 	});
 
 	it('throws when route HTML contains escaped unresolved eco-marker artifacts', async () => {
@@ -223,12 +190,6 @@ describe('RouteRenderOrchestrator', () => {
 					resolvePageData: async () => ({ props: {}, metadata: appConfig.defaultMetadata }),
 					resolveDependencies: async () => [],
 					collectPageBrowserGraphContribution: async () => undefined,
-					shouldRenderPageComponent: () => true,
-					renderPageComponent: async () => ({
-						html: '<main>Page</main>',
-						canAttachAttributes: true,
-						integrationName: 'ghtml',
-					}),
 					renderRouteBody: async () =>
 						'<html><body>&amp;lt;eco-marker data-eco-node-id=&quot;n_2&quot; data-eco-component-ref=&quot;page-component&quot; data-eco-props-ref=&quot;p_2&quot;&amp;gt;&amp;lt;/eco-marker&amp;gt;</body></html>',
 					transformRouteResponse: async (response) => await response.text(),
@@ -255,12 +216,6 @@ describe('RouteRenderOrchestrator', () => {
 					resolvePageData: async () => ({ props: {}, metadata: appConfig.defaultMetadata }),
 					resolveDependencies: async () => [],
 					collectPageBrowserGraphContribution: async () => undefined,
-					shouldRenderPageComponent: () => true,
-					renderPageComponent: async () => ({
-						html: '<main>Page</main>',
-						canAttachAttributes: true,
-						integrationName: 'ghtml',
-					}),
 					renderRouteBody: async () =>
 						'<html><body><eco-marker data-eco-node-id="n_1" data-eco-component-ref="unexpected-marker" data-eco-props-ref="p_1"></eco-marker></body></html>',
 					transformRouteResponse: async (response) => await response.text(),

--- a/packages/core/src/route-renderer/orchestration/route-render-orchestrator.ts
+++ b/packages/core/src/route-renderer/orchestration/route-render-orchestrator.ts
@@ -1,6 +1,5 @@
 import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 import type {
-	ComponentRenderResult,
 	EcoComponent,
 	EcoPageComponent,
 	EcoPageFile,
@@ -73,15 +72,6 @@ export interface RouteRenderOrchestratorAdapter<C> {
 	 */
 	collectPageBrowserGraphContribution(routeFile: string): Promise<PageBrowserGraphContribution | undefined>;
 	/**
-	 * Resolves the optional page-root render through the foreign-child-aware component contract.
-	 */
-	resolveRoutePageComponentRender(input: {
-		Page: EcoComponent;
-		Layout?: EcoComponent;
-		props: Record<string, unknown>;
-		routeOptions: RouteRendererOptions;
-	}): Promise<ComponentRenderResult | undefined>;
-	/**
 	 * Executes the Integration-specific route render.
 	 */
 	renderRouteBody(renderOptions: IntegrationRendererRenderOptions<C>): Promise<RouteRendererBody>;
@@ -146,8 +136,8 @@ export class RouteRenderOrchestrator {
 	 * Builds normalized route render options before the integration render runs.
 	 *
 	 * This preparation step validates route-root ownership, resolves page data,
-	 * collects processed assets, captures optional page-root render metadata, and
-	 * produces the page package consumed by downstream HTML transformation.
+	 * collects processed assets, and produces the page package consumed by downstream
+	 * HTML transformation.
 	 */
 	async prepareRenderOptions<C = unknown>(
 		routeOptions: RouteRendererOptions,
@@ -166,7 +156,7 @@ export class RouteRenderOrchestrator {
 		throwIfOwnershipInvalid(validationErrors);
 
 		const componentsToResolve = [HtmlTemplate, ...Layouts, Page];
-		const [{ resolvedDependencies }, pageBrowserGraph, componentRender] = await Promise.all([
+		const [{ resolvedDependencies }, pageBrowserGraph] = await Promise.all([
 			adapter.resolveRouteDependencies({
 				components: componentsToResolve,
 			}),
@@ -175,22 +165,12 @@ export class RouteRenderOrchestrator {
 				integrationName: adapter.name,
 				collectContribution: async (routeFile) => await adapter.collectPageBrowserGraphContribution(routeFile),
 			}),
-			adapter.resolveRoutePageComponentRender({
-				Page: Page as EcoComponent,
-				Layout,
-				props: resolvedInputs.props,
-				routeOptions,
-			}),
 		]);
 
 		const allDependencies = [
 			...resolvedDependencies,
 			...collectUsedIntegrationDependenciesFromGraph(this.appConfig, componentsToResolve, adapter.name),
 		];
-
-		if (componentRender?.assets?.length) {
-			allDependencies.push(...componentRender.assets);
-		}
 
 		const triggers = collectResolvedLazyTriggersFromGraph(componentsToResolve, adapter.name);
 		const [globalAssets, eagerSsrLazyAssets] = await Promise.all([
@@ -207,7 +187,6 @@ export class RouteRenderOrchestrator {
 			resolvedDependencies,
 			allDependencies,
 			pageBrowserGraph,
-			componentRender,
 			appConfig: this.appConfig,
 		});
 	}

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -934,7 +934,6 @@ export type IntegrationRendererRenderOptions<C = EcoPagesElement> = RouteRendere
 	dependencies?: EcoComponentDependencies;
 	resolvedDependencies: ProcessedAsset[];
 	pagePackage?: PagePackageResult;
-	componentRender?: ComponentRenderResult;
 	pageProps?: Record<string, unknown>;
 	cacheStrategy?: CacheStrategy;
 	pageLocals?: RequestLocals;

--- a/packages/integrations/lit/src/lit-renderer.ts
+++ b/packages/integrations/lit/src/lit-renderer.ts
@@ -103,10 +103,6 @@ export class LitRenderer extends IntegrationRenderer<EcoPagesElement> {
 		};
 	}
 
-	protected override shouldRenderPageComponent(): boolean {
-		return false;
-	}
-
 	private isLitManagedComponent(component: EcoComponent | undefined): boolean {
 		return component?.config?.integration === this.name || component?.config?.__eco?.integration === this.name;
 	}

--- a/packages/integrations/react/src/react-renderer.ts
+++ b/packages/integrations/react/src/react-renderer.ts
@@ -197,10 +197,6 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 		});
 	}
 
-	protected override shouldRenderPageComponent(): boolean {
-		return false;
-	}
-
 	/**
 	 * Reads the declared integration name for a component or layout.
 	 *


### PR DESCRIPTION
## Summary
Remove the duplicate preparation-time Page render so each route renders its Page only through the document shell.

## What changed
Deletes the prepared `componentRender` channel, its finalization logic, integration overrides, and unused renderer helpers. Retains foreign-subtree attribute handling, document attributes, and the integration adapter boundary. Adds focused coverage for document finalization and the single-render route path.

## How to verify
1. Run `pnpm exec vitest run --project shared-core packages/core/src/route-renderer`.
2. Run `pnpm run typecheck`.
3. Run `pnpm run test:vitest`.

## Notes
Base branch: `refactor/simplify-build-architecture`.