### PR TITLE
refactor(render): simplify ownership and page-data contracts

### DIFF
--- a/e2e/fixtures/react-router/src/includes/html.tsx
+++ b/e2e/fixtures/react-router/src/includes/html.tsx
@@ -19,7 +19,7 @@ const HtmlTemplate = eco.component<HtmlTemplateProps, ReactNode>({
 					data-eco-rerun="true"
 					data-eco-script-id="shared-chunk-probe"
 				></script>
-				<EcoPropsScript data={pageProps} module={pageModuleUrl} />
+				<EcoPropsScript data={pageProps} moduleUrl={pageModuleUrl} />
 			</Head>
 			<body>{children}</body>
 		</html>

--- a/e2e/fixtures/react-router/src/includes/html.tsx
+++ b/e2e/fixtures/react-router/src/includes/html.tsx
@@ -9,7 +9,7 @@ const HtmlTemplate = eco.component<HtmlTemplateProps, ReactNode>({
 		components: [Head],
 	},
 
-	render: ({ children, metadata, headContent, language = 'en', pageProps }) => (
+	render: ({ children, metadata, headContent, language = 'en', pageProps, pageModuleUrl }) => (
 		<html lang={language}>
 			<Head metadata={metadata}>
 				{headContent}
@@ -19,7 +19,7 @@ const HtmlTemplate = eco.component<HtmlTemplateProps, ReactNode>({
 					data-eco-rerun="true"
 					data-eco-script-id="shared-chunk-probe"
 				></script>
-				<EcoPropsScript data={pageProps} />
+				<EcoPropsScript data={pageProps} module={pageModuleUrl} />
 			</Head>
 			<body>{children}</body>
 		</html>

--- a/examples/blog-react/src/includes/html.tsx
+++ b/examples/blog-react/src/includes/html.tsx
@@ -16,7 +16,7 @@ const HtmlTemplate = eco.html<ReactNode>({
 			<html lang={language}>
 				<Head metadata={metadata}>
 					{headContent}
-					<EcoPropsScript data={pageProps} module={pageModuleUrl} />
+					<EcoPropsScript data={pageProps} moduleUrl={pageModuleUrl} />
 				</Head>
 				<body>{children}</body>
 			</html>

--- a/examples/blog-react/src/includes/html.tsx
+++ b/examples/blog-react/src/includes/html.tsx
@@ -11,12 +11,12 @@ const HtmlTemplate = eco.html<ReactNode>({
 		scripts: [{ content: themeScript }],
 	},
 
-	render: ({ children, metadata, headContent, language = 'en', pageProps }) => {
+	render: ({ children, metadata, headContent, language = 'en', pageProps, pageModuleUrl }) => {
 		return (
 			<html lang={language}>
 				<Head metadata={metadata}>
 					{headContent}
-					<EcoPropsScript data={pageProps} />
+					<EcoPropsScript data={pageProps} module={pageModuleUrl} />
 				</Head>
 				<body>{children}</body>
 			</html>

--- a/examples/with-react-better-auth/src/includes/html.tsx
+++ b/examples/with-react-better-auth/src/includes/html.tsx
@@ -13,12 +13,12 @@ const HtmlTemplate = eco.html<ReactNode>({
 		scripts: [{ content: themeScript }, { content: announcementScript }],
 	},
 
-	render: ({ children, metadata, headContent, language = 'en', pageProps }) => {
+	render: ({ children, metadata, headContent, language = 'en', pageProps, pageModuleUrl }) => {
 		return (
 			<html lang={language} suppressHydrationWarning>
 				<Head metadata={metadata}>
 					{headContent}
-					<EcoPropsScript data={pageProps} />
+					<EcoPropsScript data={pageProps} module={pageModuleUrl} />
 				</Head>
 				<body>{children}</body>
 			</html>

--- a/examples/with-react-better-auth/src/includes/html.tsx
+++ b/examples/with-react-better-auth/src/includes/html.tsx
@@ -18,7 +18,7 @@ const HtmlTemplate = eco.html<ReactNode>({
 			<html lang={language} suppressHydrationWarning>
 				<Head metadata={metadata}>
 					{headContent}
-					<EcoPropsScript data={pageProps} module={pageModuleUrl} />
+					<EcoPropsScript data={pageProps} moduleUrl={pageModuleUrl} />
 				</Head>
 				<body>{children}</body>
 			</html>

--- a/examples/with-react-better-auth/src/pages/skills.mdx
+++ b/examples/with-react-better-auth/src/pages/skills.mdx
@@ -503,12 +503,12 @@ const HtmlTemplate = eco.html<ReactNode>({
     scripts: [{ content: themeScript }],
   },
 
-  render: ({ children, metadata, headContent, language = 'en', pageProps }) => {
+  render: ({ children, metadata, headContent, language = 'en', pageProps, pageModuleUrl }) => {
     return (
       <html lang={language}>
         <Head metadata={metadata}>
           {headContent}
-          <EcoPropsScript data={pageProps} />
+          <EcoPropsScript data={pageProps} module={pageModuleUrl} />
         </Head>
         <body>{children}</body>
       </html>

--- a/examples/with-react-better-auth/src/pages/skills.mdx
+++ b/examples/with-react-better-auth/src/pages/skills.mdx
@@ -508,7 +508,7 @@ const HtmlTemplate = eco.html<ReactNode>({
       <html lang={language}>
         <Head metadata={metadata}>
           {headContent}
-          <EcoPropsScript data={pageProps} module={pageModuleUrl} />
+          <EcoPropsScript data={pageProps} moduleUrl={pageModuleUrl} />
         </Head>
         <body>{children}</body>
       </html>

--- a/packages/core/src/hmr/client/hmr-runtime.ts
+++ b/packages/core/src/hmr/client/hmr-runtime.ts
@@ -100,7 +100,7 @@ interface HMRPayload {
 
 			await import(url);
 
-			if (await navigationRuntime.reloadCurrentPage({ clearCache: false })) {
+			if (await navigationRuntime.reloadCurrentPage({ clearCache: false, moduleUrl: url })) {
 			}
 		} catch (e) {
 			console.error('[ecopages] Failed to apply HMR update:', e);

--- a/packages/core/src/route-renderer/orchestration/component-render-context.ts
+++ b/packages/core/src/route-renderer/orchestration/component-render-context.ts
@@ -9,9 +9,7 @@ import { addTriggerAttribute, isThenable, wrapWithScriptsInjector } from './rend
  * must not treat arbitrary objects as resolved output.
  */
 export type ForeignChildInterceptionResult =
-	| { kind: 'inline'; props?: Record<string, unknown> }
-	| { kind: 'resolved'; value: string }
-	| undefined;
+	{ kind: 'inline'; props?: Record<string, unknown> } | { kind: 'resolved'; value: string } | undefined;
 
 /**
  * Foreign-child metadata passed into the active renderer-owned runtime.

--- a/packages/core/src/route-renderer/orchestration/component-render-context.ts
+++ b/packages/core/src/route-renderer/orchestration/component-render-context.ts
@@ -5,11 +5,13 @@ import { addTriggerAttribute, isThenable, wrapWithScriptsInjector } from './rend
  * Result returned by a renderer-owned foreign-child runtime.
  *
  * `inline` keeps rendering inside the current integration. `resolved.value` is
- * opaque renderer-owned output, such as final HTML or a transport token for
- * later queue resolution; callers must not coerce arbitrary values to strings.
+ * the queue transport token string allocated by `createQueuedRuntime`; callers
+ * must not treat arbitrary objects as resolved output.
  */
 export type ForeignChildInterceptionResult =
-	{ kind: 'inline'; props?: Record<string, unknown> } | { kind: 'resolved'; value: unknown } | undefined;
+	| { kind: 'inline'; props?: Record<string, unknown> }
+	| { kind: 'resolved'; value: string }
+	| undefined;
 
 /**
  * Foreign-child metadata passed into the active renderer-owned runtime.

--- a/packages/core/src/route-renderer/orchestration/foreign-subtree-execution.service.test.ts
+++ b/packages/core/src/route-renderer/orchestration/foreign-subtree-execution.service.test.ts
@@ -114,6 +114,36 @@ describe('ForeignSubtreeExecutionService queue resolution', () => {
 		);
 	});
 
+	it('rejects opaque foreign children when queuing instead of string-coercing them', () => {
+		const service = new ForeignSubtreeExecutionService();
+		const shell = createComponent('shell', 'shell');
+		const deferredWidget = createComponent('deferred-widget', 'deferred');
+		const renderInput: ComponentRenderInput = {
+			component: shell,
+			props: {},
+			integrationContext: {
+				componentInstanceId: 'host',
+			},
+		};
+
+		const runtime = service.createQueueRuntime({
+			renderInput,
+			rendererCache: new Map(),
+			runtimeContextKey: '__testQueuedForeignSubtreeRuntime',
+			tokenPrefix: '__TEST_QUEUE__',
+			shouldQueueForeignChild: () => true,
+		});
+
+		expect(() =>
+			runtime.interceptForeignChildSync?.({
+				currentIntegration: 'shell',
+				targetIntegration: 'deferred',
+				component: deferredWidget,
+				props: { children: { opaque: true } },
+			}),
+		).toThrow(/refused to coerce opaque foreign children/);
+	});
+
 	it('preserves existing shared integration context fields when queue runtime state is attached', () => {
 		const service = new ForeignSubtreeExecutionService();
 		const shell = createComponent('shell', 'shell');

--- a/packages/core/src/route-renderer/orchestration/foreign-subtree-execution.service.ts
+++ b/packages/core/src/route-renderer/orchestration/foreign-subtree-execution.service.ts
@@ -11,7 +11,7 @@ import {
 	runWithComponentRenderContext,
 	type ForeignChildRuntime,
 } from './component-render-context.ts';
-import { isMarkupNodeLike } from './render-output.utils.ts';
+import { assertForeignChildrenNotOpaque, isMarkupNodeLike } from './render-output.utils.ts';
 
 export type QueuedForeignChildDecisionInput = {
 	currentIntegration: string;
@@ -238,6 +238,10 @@ export class ForeignSubtreeExecutionService {
 				};
 			}
 
+			if ('children' in input.props) {
+				assertForeignChildrenNotOpaque(input.props.children, 'foreign-subtree queue');
+			}
+
 			runtimeContext.nextForeignSubtreeId += 1;
 			const foreignSubtreeId = runtimeContext.nextForeignSubtreeId;
 			const token = this.createForeignSubtreeToken(options.tokenPrefix, runtimeContext, foreignSubtreeId);
@@ -292,11 +296,12 @@ export class ForeignSubtreeExecutionService {
 				}
 
 				if (typeof children !== 'string' && !isMarkupNodeLike(children)) {
+					assertForeignChildrenNotOpaque(children, options.queueLabel);
 					return { assets: [], children };
 				}
 
 				const html = await this.resolveQueuedTokens(
-					typeof children === 'string' ? children : (children.outerHTML ?? String(children ?? '')),
+					typeof children === 'string' ? children : (children.outerHTML ?? ''),
 					queuedResolutionsByToken,
 					resolveToken,
 				);

--- a/packages/core/src/route-renderer/orchestration/render-output.utils.test.ts
+++ b/packages/core/src/route-renderer/orchestration/render-output.utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+	assertForeignChildrenNotOpaque,
+	isOpaqueForeignChildValue,
+} from './render-output.utils.ts';
+
+describe('opaque foreign children', () => {
+	it('treats plain objects as opaque and allows template and markup shapes', () => {
+		expect(isOpaqueForeignChildValue({ opaque: true })).toBe(true);
+		expect(isOpaqueForeignChildValue(Object.create(null))).toBe(true);
+		expect(isOpaqueForeignChildValue({ strings: ['<div>', '</div>'], values: [] })).toBe(false);
+		expect(isOpaqueForeignChildValue({ nodeType: 1, outerHTML: '<div></div>' })).toBe(false);
+		expect(isOpaqueForeignChildValue(['a', 'b'])).toBe(false);
+		expect(isOpaqueForeignChildValue({ $$typeof: Symbol.for('react.element') })).toBe(false);
+		expect(isOpaqueForeignChildValue('already-serialized')).toBe(false);
+	});
+
+	it('throws a typed error for opaque foreign children', () => {
+		expect(() => assertForeignChildrenNotOpaque({ opaque: true }, 'test queue')).toThrow(
+			/test queue refused to coerce opaque foreign children/,
+		);
+		expect(() => assertForeignChildrenNotOpaque('<div></div>', 'test queue')).not.toThrow();
+	});
+});

--- a/packages/core/src/route-renderer/orchestration/render-output.utils.test.ts
+++ b/packages/core/src/route-renderer/orchestration/render-output.utils.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-	assertForeignChildrenNotOpaque,
-	isOpaqueForeignChildValue,
-} from './render-output.utils.ts';
+import { assertForeignChildrenNotOpaque, isOpaqueForeignChildValue } from './render-output.utils.ts';
 
 describe('opaque foreign children', () => {
 	it('treats plain objects as opaque and allows template and markup shapes', () => {

--- a/packages/core/src/route-renderer/orchestration/render-output.utils.ts
+++ b/packages/core/src/route-renderer/orchestration/render-output.utils.ts
@@ -151,6 +151,54 @@ export function isMarkupNodeLike(value: unknown): value is MarkupNodeLikeShape {
 	return isMarkupNodeLikeShape(value);
 }
 
+/**
+ * Returns whether a value is a plain opaque object that string serializers would
+ * coerce via `String(value)` rather than render as markup.
+ *
+ * @remarks
+ * Template results (`strings`/`values`), markup nodes, arrays, and framework
+ * element markers (`$$typeof`) are not opaque. Cross-integration children that
+ * are only plain objects must use EcoEmbed or already-serialized HTML.
+ */
+export function isOpaqueForeignChildValue(children: unknown): boolean {
+	if (children === null || typeof children !== 'object') {
+		return false;
+	}
+
+	if (Array.isArray(children)) {
+		return false;
+	}
+
+	if ('$$typeof' in children) {
+		return false;
+	}
+
+	if ('strings' in children && Array.isArray((children as { strings: unknown }).strings)) {
+		return false;
+	}
+
+	if (isMarkupNodeLikeShape(children)) {
+		return false;
+	}
+
+	const prototype = Object.getPrototypeOf(children);
+	return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Throws when foreign-path children would be coerced from an opaque object.
+ */
+export function assertForeignChildrenNotOpaque(children: unknown, context: string): void {
+	if (!isOpaqueForeignChildValue(children)) {
+		return;
+	}
+
+	const childTag = Object.prototype.toString.call(children);
+	throw new TypeError(
+		`[ecopages] ${context} refused to coerce opaque foreign children (${childTag}). Use EcoEmbed for cross-integration children or pass already-serialized HTML.`,
+	);
+}
+
 function injectTriggerAttributeIntoString(content: string, triggerId: string): string {
 	const str = content;
 	let i = 0;

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -653,6 +653,8 @@ export interface HtmlTemplateProps<T = EcoPagesElement> extends PageHeadProps<T>
 	language?: string;
 	headContent?: T;
 	pageProps: Record<string, unknown>;
+	/** Browser-importable page module URL for router-enabled documents. */
+	pageModuleUrl?: string;
 }
 
 /**

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -428,14 +428,11 @@ export type EcoPagesElement = string | Promise<string>;
  * Serializable child payloads accepted by cross-integration deferred rendering.
  *
  * @remarks
- * This models the broad value shapes that EcoPages already flattens when a
- * foreign component boundary serializes its children for another integration.
- * It is intentionally transport-oriented rather than framework-native, so it
- * can be shared across Kita, Lit, React, and Ecopages JSX authoring surfaces
- * without coupling core types to any one renderer.
- *
- * Do not treat `EcoChildren` as trusted serialized HTML. Opaque objects must be
- * intercepted at composition boundaries before framework serializers coerce them.
+ * Covers primitives, arrays, and Kita/Lit-style template results (`strings` /
+ * optional `values`). Plain opaque objects are intentionally excluded; foreign
+ * composition boundaries reject them before serializers can coerce `String(object)`.
+ * Framework-native trees (React nodes, JSX elements) stay outside this type and
+ * use EcoEmbed or already-serialized HTML at the boundary.
  */
 export type EcoChildren =
 	| string
@@ -449,9 +446,6 @@ export type EcoChildren =
 	| {
 			strings: readonly string[];
 			values?: readonly EcoChildren[];
-	  }
-	| {
-			[key: string]: EcoChildren;
 	  };
 
 /**

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -647,7 +647,14 @@ export interface HtmlTemplateProps<T = EcoPagesElement> extends PageHeadProps<T>
 	language?: string;
 	headContent?: T;
 	pageProps: Record<string, unknown>;
-	/** Browser-importable page module URL for router-enabled documents. */
+	/**
+	 * Browser-importable page module URL for router-enabled documents.
+	 *
+	 * @remarks
+	 * Transport-only: threaded into HTML shells (for example `EcoPropsScript`
+	 * `moduleUrl`) and serialized as the page-data envelope `moduleUrl`. Not page
+	 * component state.
+	 */
 	pageModuleUrl?: string;
 }
 

--- a/packages/integrations/ecopages-jsx/README.md
+++ b/packages/integrations/ecopages-jsx/README.md
@@ -99,7 +99,7 @@ Ecopages JSX can own the outer page shell or just a nested foreign subtree. When
 
 Important:
 
-- Cross-integration JSX children must use `EcoEmbed`. Opaque plain objects fail fast; Ecopages JSX does not coerce them with `String(object)`.
+- Cross-integration JSX children must use `EcoEmbed`. Opaque plain objects fail fast at core foreign-child queue boundaries; they are not coerced with `String(object)`.
 - Components that may render foreign children must declare those children in `config.dependencies.components`.
 - Ecopages validates mixed-renderer ownership from declared dependencies during render preparation. It does not treat rendered HTML alone as the source of truth.
 - Ecopages JSX keeps raw-markup preservation and asset collection inside the JSX renderer.

--- a/packages/integrations/ecopages-jsx/src/ecopages-jsx-radiant-ssr-policy.ts
+++ b/packages/integrations/ecopages-jsx/src/ecopages-jsx-radiant-ssr-policy.ts
@@ -31,13 +31,14 @@ type RadiantServerRuntimeModules = {
  *
  * @remarks
  * Radiant's server bridge and light-DOM shim are loaded lazily because most JSX
- * renders do not need them. Once enabled, the resolved runtime modules are
- * cached statically so repeated page and component renders do not keep paying
- * module-resolution or shim-installation costs.
+ * renders do not need them. Resolved runtime modules are cached on the policy
+ * instance so repeated renders on the same renderer reuse one load without
+ * process-wide mutable class state. Light-DOM constructor installation remains
+ * process-global and idempotent via {@link ensureRadiantLightDomGlobals}.
  */
 export class EcopagesJsxRadiantSsrPolicy {
-	private static runtimeModules: RadiantServerRuntimeModules | undefined;
-	private static runtimeModulesPromise:
+	private runtimeModules: RadiantServerRuntimeModules | undefined;
+	private runtimeModulesPromise:
 		| Promise<{
 				installLightDomShim: () => RadiantLightDomShimWindow;
 				withServerRadiantElementSsrRuntime: <T>(render: () => T) => T;
@@ -48,19 +49,6 @@ export class EcopagesJsxRadiantSsrPolicy {
 
 	constructor(enabled: boolean) {
 		this.enabled = enabled;
-	}
-
-	/**
-	 * Clears process-wide Radiant module caches between isolated tests.
-	 *
-	 * @remarks
-	 * The SSR runtime is process-global by design (shared custom-element
-	 * constructors). Tests that flip import order must reset these caches so
-	 * later cases do not inherit an earlier activation.
-	 */
-	static resetForTests(): void {
-		EcopagesJsxRadiantSsrPolicy.runtimeModules = undefined;
-		EcopagesJsxRadiantSsrPolicy.runtimeModulesPromise = undefined;
 	}
 
 	/**
@@ -82,7 +70,7 @@ export class EcopagesJsxRadiantSsrPolicy {
 			return render();
 		}
 
-		const runtimeModules = await EcopagesJsxRadiantSsrPolicy.runtimeModulesPromise;
+		const runtimeModules = await this.runtimeModulesPromise;
 		if (!runtimeModules) {
 			return render();
 		}
@@ -98,7 +86,7 @@ export class EcopagesJsxRadiantSsrPolicy {
 	 * generated host HTML without escaping it back into plain text.
 	 */
 	renderIntrinsicElementMarkup(instance: unknown): ReturnType<typeof createMarkupNodeLike> | undefined {
-		const renderBridge = EcopagesJsxRadiantSsrPolicy.runtimeModules?.resolveRadiantElementRenderBridge(instance);
+		const renderBridge = this.runtimeModules?.resolveRadiantElementRenderBridge(instance);
 		if (!renderBridge) {
 			return undefined;
 		}
@@ -113,14 +101,14 @@ export class EcopagesJsxRadiantSsrPolicy {
 	}
 
 	private async ensureRuntimeInstalled(): Promise<void> {
-		if (!EcopagesJsxRadiantSsrPolicy.runtimeModulesPromise) {
+		if (!this.runtimeModulesPromise) {
 			const radiantLightDomShimEntry = import.meta.resolve('@ecopages/radiant/server/light-dom-shim');
 			const radiantElementSsrRuntimeModuleUrl = new URL(
 				'./radiant-element-ssr-bridge.js',
 				radiantLightDomShimEntry,
 			).href;
 
-			EcopagesJsxRadiantSsrPolicy.runtimeModulesPromise = (async () => {
+			this.runtimeModulesPromise = (async () => {
 				const lightDomShimModule = await import(radiantLightDomShimEntry);
 				ensureRadiantLightDomGlobals(lightDomShimModule.installLightDomShim);
 
@@ -141,20 +129,28 @@ export class EcopagesJsxRadiantSsrPolicy {
 						radiantElementSsrRuntimeModule.withServerRadiantElementSsrRuntime,
 				};
 
-				EcopagesJsxRadiantSsrPolicy.runtimeModules = modules;
+				this.runtimeModules = modules;
 				return modules;
 			})();
 		}
 
-		await EcopagesJsxRadiantSsrPolicy.runtimeModulesPromise;
+		await this.runtimeModulesPromise;
 
-		const lightDomShimModule = EcopagesJsxRadiantSsrPolicy.runtimeModules;
+		const lightDomShimModule = this.runtimeModules;
 		if (lightDomShimModule) {
 			ensureRadiantLightDomGlobals(lightDomShimModule.installLightDomShim);
 		}
 	}
 }
 
+/**
+ * Installs Radiant light-DOM constructors on `globalThis` once.
+ *
+ * @remarks
+ * Custom-element constructors must be process-global; undoing them between tests
+ * is unsafe. Callers that clear globals for isolation must rely on a fresh policy
+ * instance so {@link EcopagesJsxRadiantSsrPolicy.prepareRuntime} re-runs install.
+ */
 function ensureRadiantLightDomGlobals(installLightDomShim: () => RadiantLightDomShimWindow): void {
 	if (typeof globalThis.HTMLElement !== 'undefined') {
 		return;

--- a/packages/integrations/ecopages-jsx/src/ecopages-jsx-renderer.ts
+++ b/packages/integrations/ecopages-jsx/src/ecopages-jsx-renderer.ts
@@ -48,9 +48,10 @@ export class EcopagesJsxRenderer extends IntegrationRenderer<JsxRenderable> {
 	 * Serializes foreign-child props for string-first boundaries.
 	 *
 	 * @remarks
-	 * Plain objects that are neither DOM nodes nor JSX-renderable values are
-	 * rejected before `renderToString`. Cross-integration children must use
-	 * `EcoEmbed`; silent `String(object)` coercion is not supported.
+	 * DOM nodes become `outerHTML`. JSX trees, arrays, and template results are
+	 * stringified here. Other values are left for core foreign-child interception,
+	 * which rejects opaque plain objects before queueing. Cross-integration
+	 * children must use `EcoEmbed`.
 	 */
 	private normalizeForeignChildProps(props: Record<string, unknown>): Record<string, unknown> {
 		if (!('children' in props)) {
@@ -76,41 +77,34 @@ export class EcopagesJsxRenderer extends IntegrationRenderer<JsxRenderable> {
 			};
 		}
 
-		if (this.isOpaqueForeignChildValue(children)) {
-			const childTag = Object.prototype.toString.call(children);
-			throw new TypeError(
-				`[ecopages] ${this.name} renderer refused to coerce opaque foreign children (${childTag}). Use EcoEmbed for cross-integration JSX children.`,
-			);
+		if (this.isJsxSerializableForeignChild(children)) {
+			return {
+				...props,
+				children: renderToString(children as JsxRenderable),
+			};
 		}
 
-		return {
-			...props,
-			children: renderToString(children as JsxRenderable),
-		};
+		return props;
 	}
 
 	/**
-	 * Returns whether a child value is a plain object that string serializers
-	 * would coerce rather than render.
+	 * Returns whether children are a JSX/template shape this renderer can
+	 * serialize before foreign-child queueing.
 	 */
-	private isOpaqueForeignChildValue(children: unknown): boolean {
+	private isJsxSerializableForeignChild(children: unknown): boolean {
+		if (Array.isArray(children)) {
+			return true;
+		}
+
 		if (children === null || typeof children !== 'object') {
 			return false;
 		}
 
-		if (Array.isArray(children)) {
-			return false;
-		}
-
 		if ('$$typeof' in children) {
-			return false;
+			return true;
 		}
 
-		if ('strings' in children && Array.isArray((children as { strings: unknown }).strings)) {
-			return false;
-		}
-
-		return Object.getPrototypeOf(children) === Object.prototype || Object.getPrototypeOf(children) === null;
+		return 'strings' in children && Array.isArray((children as { strings: unknown }).strings);
 	}
 
 	/**

--- a/packages/integrations/ecopages-jsx/src/test/ecopages-jsx-hydration-scope.test.tsx
+++ b/packages/integrations/ecopages-jsx/src/test/ecopages-jsx-hydration-scope.test.tsx
@@ -126,14 +126,15 @@ describe('EcopagesJsxRenderer hydration scope', () => {
 			withServerRadiantElementSsrRuntime: <T,>(render: () => T) => render(),
 		};
 
+		const radiantSsrPolicy = new EcopagesJsxRadiantSsrPolicy(true);
 		(
-			EcopagesJsxRadiantSsrPolicy as unknown as {
+			radiantSsrPolicy as unknown as {
 				runtimeModules?: typeof runtimeModules;
 				runtimeModulesPromise?: Promise<typeof runtimeModules>;
 			}
 		).runtimeModules = runtimeModules;
 		(
-			EcopagesJsxRadiantSsrPolicy as unknown as {
+			radiantSsrPolicy as unknown as {
 				runtimeModules?: typeof runtimeModules;
 				runtimeModulesPromise?: Promise<typeof runtimeModules>;
 			}
@@ -177,7 +178,7 @@ describe('EcopagesJsxRenderer hydration scope', () => {
 			runtimeOrigin: 'http://localhost:3000',
 			resolvedIntegrationDependencies: [],
 			jsxConfig: {
-				radiantSsrEnabled: true,
+				radiantSsrPolicy,
 			},
 		});
 

--- a/packages/integrations/ecopages-jsx/src/test/ecopages-jsx-renderer.test.ts
+++ b/packages/integrations/ecopages-jsx/src/test/ecopages-jsx-renderer.test.ts
@@ -53,7 +53,6 @@ function createAppConfig(rootDir: string): EcoPagesAppConfig {
 
 async function withClearedLightDomGlobals<T>(run: () => Promise<T>): Promise<T> {
 	const descriptors = new Map<LightDomGlobalKey, PropertyDescriptor | undefined>();
-	EcopagesJsxRadiantSsrPolicy.resetForTests();
 
 	for (const key of lightDomGlobalKeys) {
 		descriptors.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
@@ -63,7 +62,6 @@ async function withClearedLightDomGlobals<T>(run: () => Promise<T>): Promise<T> 
 	try {
 		return await run();
 	} finally {
-		EcopagesJsxRadiantSsrPolicy.resetForTests();
 		for (const key of lightDomGlobalKeys) {
 			Reflect.deleteProperty(globalThis, key);
 			const descriptor = descriptors.get(key);
@@ -206,4 +204,12 @@ test('EcopagesJsxRenderer keeps MDX extension matching instance-owned', () => {
 	assert.equal(rendererA.isMdxFile('/tmp/page.guide.mdx'), false);
 	assert.equal(rendererB.isMdxFile('/tmp/page.docs.mdx'), false);
 	assert.equal(rendererB.isMdxFile('/tmp/page.guide.mdx'), true);
+});
+
+test('EcopagesJsxRadiantSsrPolicy does not expose resetForTests', () => {
+	assert.equal('resetForTests' in EcopagesJsxRadiantSsrPolicy, false);
+	assert.equal(
+		typeof (EcopagesJsxRadiantSsrPolicy as unknown as { resetForTests?: unknown }).resetForTests,
+		'undefined',
+	);
 });

--- a/packages/integrations/ecopages-jsx/src/test/ecopages-jsx-renderer.test.ts
+++ b/packages/integrations/ecopages-jsx/src/test/ecopages-jsx-renderer.test.ts
@@ -205,11 +205,3 @@ test('EcopagesJsxRenderer keeps MDX extension matching instance-owned', () => {
 	assert.equal(rendererB.isMdxFile('/tmp/page.docs.mdx'), false);
 	assert.equal(rendererB.isMdxFile('/tmp/page.guide.mdx'), true);
 });
-
-test('EcopagesJsxRadiantSsrPolicy does not expose resetForTests', () => {
-	assert.equal('resetForTests' in EcopagesJsxRadiantSsrPolicy, false);
-	assert.equal(
-		typeof (EcopagesJsxRadiantSsrPolicy as unknown as { resetForTests?: unknown }).resetForTests,
-		'undefined',
-	);
-});

--- a/packages/integrations/ecopages-jsx/src/test/ecopages-jsx-renderer.test.tsx
+++ b/packages/integrations/ecopages-jsx/src/test/ecopages-jsx-renderer.test.tsx
@@ -544,7 +544,7 @@ describe('EcopagesJsxRenderer', () => {
 					component: ForeignShell,
 					props: { children: { opaque: true } },
 				}),
-			).toThrow(/refused to coerce opaque foreign children/);
+			).toThrow(/foreign-subtree queue refused to coerce opaque foreign children/);
 		});
 
 		it('preserves normalized props when the delegated child stays inline', async () => {

--- a/packages/integrations/lit/src/STATIC_RENDER.md
+++ b/packages/integrations/lit/src/STATIC_RENDER.md
@@ -35,11 +35,11 @@ beforeStaticExport
 
 ## Ownership
 
-| Concern | Owner |
-| ------- | ----- |
-| Session + worker lifecycle | `LitPlugin` (`renderSession`) |
-| Lazy session lookup | `LitRenderer` via `getRenderSession` |
-| Worker identity | First `{ configModulePath, runtimeOrigin }`; same identity is sticky; different identity recreates |
+| Concern                    | Owner                                                                                              |
+| -------------------------- | -------------------------------------------------------------------------------------------------- |
+| Session + worker lifecycle | `LitPlugin` (`renderSession`)                                                                      |
+| Lazy session lookup        | `LitRenderer` via `getRenderSession`                                                               |
+| Worker identity            | First `{ configModulePath, runtimeOrigin }`; same identity is sticky; different identity recreates |
 
 Renderers created before plugin `setup()` still use the worker after setup assigns the session, because `execute` activates the integration runtime then reads the accessor.
 
@@ -58,10 +58,10 @@ When `RouteRendererOptions.locals` is present, `LitRenderer.execute` forces the 
 
 ## Protocol
 
-| Message            | Direction     | Purpose                                                                 |
-| ------------------ | ------------- | ----------------------------------------------------------------------- |
+| Message            | Direction     | Purpose                                                                       |
+| ------------------ | ------------- | ----------------------------------------------------------------------------- |
 | `init`             | main → worker | Load `eco.config.ts`, bootstrap runtime (`configModulePath`, `runtimeOrigin`) |
-| `ready`            | worker → main | Worker initialized                                                      |
-| `render`           | main → worker | Render one Lit page route (`filePath`, `PageParams`, optional `PageQuery`) |
-| `result` / `error` | worker → main | HTML body plus optional `cacheStrategy`, or an error message            |
-| `shutdown`         | main → worker | Exit worker thread                                                      |
+| `ready`            | worker → main | Worker initialized                                                            |
+| `render`           | main → worker | Render one Lit page route (`filePath`, `PageParams`, optional `PageQuery`)    |
+| `result` / `error` | worker → main | HTML body plus optional `cacheStrategy`, or an error message                  |
+| `shutdown`         | main → worker | Exit worker thread                                                            |

--- a/packages/integrations/lit/src/STATIC_RENDER.md
+++ b/packages/integrations/lit/src/STATIC_RENDER.md
@@ -26,7 +26,7 @@ LitRenderer.execute() (main)
                                           (no active session in worker)
 
 beforeStaticExport
-  └─ ensureWorker() (recreate if identity changed)
+  └─ ensureWorker() only when `renderSession` is still null
   └─ preloadStaticRoutes()
        └─ preload SSR lazy scripts for Lit pages
 ```
@@ -35,13 +35,15 @@ beforeStaticExport
 
 ## Ownership
 
-| Concern                    | Owner                                                                                              |
-| -------------------------- | -------------------------------------------------------------------------------------------------- |
-| Session + worker lifecycle | `LitPlugin` (`renderSession`)                                                                      |
-| Lazy session lookup        | `LitRenderer` via `getRenderSession`                                                               |
-| Worker identity            | First `{ configModulePath, runtimeOrigin }`; same identity is sticky; different identity recreates |
+| Concern                    | Owner                                                                                                                                                                  |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Session + worker lifecycle | `LitPlugin` (`renderSession`)                                                                                                                                          |
+| Lazy session lookup        | `LitRenderer` via `getRenderSession`                                                                                                                                   |
+| Worker identity            | First `{ configModulePath, runtimeOrigin }` passed to `ensureWorker`; same identity is sticky; a later `ensureWorker` with a different identity disposes and recreates |
 
 Renderers created before plugin `setup()` still use the worker after setup assigns the session, because `execute` activates the integration runtime then reads the accessor.
+
+`beforeStaticExport` does not re-call `ensureWorker` when setup already created the session, so a different `context.baseUrl` at export time will not recreate an existing worker.
 
 ## Locals policy
 

--- a/packages/integrations/lit/src/STATIC_RENDER.md
+++ b/packages/integrations/lit/src/STATIC_RENDER.md
@@ -14,17 +14,38 @@ LitPlugin.setup()
                                      installBuildRuntime()
                                      RouteRendererFactory
 
+LitPlugin.initializeRenderer()
+  └─ LitRenderer({ getRenderSession })   lazy accessor (not constructor snapshot)
+
 LitRenderer.execute() (main)
-  └─ session.renderPageInWorker()
-       └─ postMessage(render) ─────► RouteRendererFactory.execute()
-                                     (no active session in worker)
+  └─ ensureIntegrationRuntimeActivated()
+  └─ getRenderSession()
+       ├─ locals present ──────────► super.execute() (in-process)
+       └─ session.renderPageInWorker()
+            └─ postMessage(render) ─────► RouteRendererFactory.execute()
+                                          (no active session in worker)
 
 beforeStaticExport
+  └─ ensureWorker() (recreate if identity changed)
   └─ preloadStaticRoutes()
        └─ preload SSR lazy scripts for Lit pages
 ```
 
 `ECOPAGES_LIT_STATIC_RENDER_WORKER=true` in the worker environment prevents nested worker creation during `LitPlugin.setup()` and skips processor `.setup()` inside `setupAppRuntimePlugins` (main thread already prepared artifacts).
+
+## Ownership
+
+| Concern | Owner |
+| ------- | ----- |
+| Session + worker lifecycle | `LitPlugin` (`renderSession`) |
+| Lazy session lookup | `LitRenderer` via `getRenderSession` |
+| Worker identity | First `{ configModulePath, runtimeOrigin }`; same identity is sticky; different identity recreates |
+
+Renderers created before plugin `setup()` still use the worker after setup assigns the session, because `execute` activates the integration runtime then reads the accessor.
+
+## Locals policy
+
+When `RouteRendererOptions.locals` is present, `LitRenderer.execute` forces the in-process path (`super.execute`). Request locals are not sent through the worker protocol (structured-clone risk and request-scoped data). Static export and routes without locals continue through the worker.
 
 ## Files
 
@@ -35,14 +56,12 @@ beforeStaticExport
 | `lit-static-render-worker.ts`        | Worker entry (exported as `@ecopages/lit/static-render-worker`) |
 | `lit-static-render-protocol.ts`      | Request/response message types                                  |
 
-`LitPlugin.initializeRenderer()` injects the session into `LitRenderer`. There is no process-global coordinator.
-
 ## Protocol
 
-| Message            | Direction     | Purpose                                                            |
-| ------------------ | ------------- | ------------------------------------------------------------------ |
-| `init`             | main → worker | Load `eco.config.ts`, bootstrap runtime                            |
-| `ready`            | worker → main | Worker initialized                                                 |
-| `render`           | main → worker | Render one Lit page route (`filePath`, `params`, optional `query`) |
-| `result` / `error` | worker → main | HTML body plus optional `cacheStrategy`, or an error message       |
-| `shutdown`         | main → worker | Exit worker thread                                                 |
+| Message            | Direction     | Purpose                                                                 |
+| ------------------ | ------------- | ----------------------------------------------------------------------- |
+| `init`             | main → worker | Load `eco.config.ts`, bootstrap runtime (`configModulePath`, `runtimeOrigin`) |
+| `ready`            | worker → main | Worker initialized                                                      |
+| `render`           | main → worker | Render one Lit page route (`filePath`, `PageParams`, optional `PageQuery`) |
+| `result` / `error` | worker → main | HTML body plus optional `cacheStrategy`, or an error message            |
+| `shutdown`         | main → worker | Exit worker thread                                                      |

--- a/packages/integrations/lit/src/lit-renderer.ts
+++ b/packages/integrations/lit/src/lit-renderer.ts
@@ -10,6 +10,7 @@ import type {
 	EcoFunctionComponent,
 	EcoPagesElement,
 	IntegrationRendererRenderOptions,
+	PageParams,
 	RouteRenderResult,
 	RouteRendererBody,
 	RouteRendererOptions,
@@ -29,7 +30,15 @@ import {
 } from './utils/lit-html-rendering.ts';
 
 export type LitRendererOptions = ConstructorParameters<typeof IntegrationRenderer>[0] & {
-	renderSession?: LitStaticRenderSession;
+	/**
+	 * Lazy session lookup owned by {@link LitPlugin}.
+	 *
+	 * @remarks
+	 * Must not snapshot the session at construction time. Plugin `setup()` may
+	 * assign the session after the renderer is created; `execute` activates the
+	 * integration runtime then reads this accessor so worker dispatch still works.
+	 */
+	getRenderSession?: () => LitStaticRenderSession | undefined;
 };
 
 /**
@@ -37,19 +46,32 @@ export type LitRendererOptions = ConstructorParameters<typeof IntegrationRendere
  */
 export class LitRenderer extends IntegrationRenderer<EcoPagesElement> {
 	override name = LIT_PLUGIN_NAME;
-	private readonly renderSession?: LitStaticRenderSession;
+	private readonly getRenderSession?: () => LitStaticRenderSession | undefined;
 
 	constructor(options: LitRendererOptions) {
-		const { renderSession, ...rendererOptions } = options;
+		const { getRenderSession, ...rendererOptions } = options;
 		super(rendererOptions);
-		this.renderSession = renderSession;
+		this.getRenderSession = getRenderSession;
 	}
 
+	/**
+	 * Renders a Lit page route, preferring the plugin worker when available.
+	 *
+	 * @remarks
+	 * Activates the integration runtime before reading {@link getRenderSession}
+	 * so a renderer constructed before plugin setup still sees the session.
+	 * When `options.locals` is present, rendering stays in-process: request locals
+	 * are not structured-cloned across the worker boundary.
+	 */
 	public override async execute(options: RouteRendererOptions): Promise<RouteRenderResult> {
-		if (this.renderSession) {
-			const result = await this.renderSession.renderPageInWorker({
+		await this.ensureIntegrationRuntimeActivated();
+		const renderSession = this.getRenderSession?.();
+
+		if (renderSession && options.locals === undefined) {
+			const params: PageParams = options.params ?? {};
+			const result = await renderSession.renderPageInWorker({
 				filePath: options.file,
-				params: (options.params ?? {}) as Record<string, string>,
+				params,
 				query: options.query,
 			});
 
@@ -205,8 +227,9 @@ export class LitRenderer extends IntegrationRenderer<EcoPagesElement> {
 	 * Preloads SSR-eligible lazy scripts to register custom elements before render.
 	 */
 	protected async preloadSsrLazyScripts(components: Array<EcoComponent | undefined>): Promise<void> {
-		if (this.renderSession) {
-			await this.renderSession.preloadSsrLazyScripts(components);
+		const renderSession = this.getRenderSession?.();
+		if (renderSession) {
+			await renderSession.preloadSsrLazyScripts(components);
 			return;
 		}
 

--- a/packages/integrations/lit/src/lit-static-render-protocol.ts
+++ b/packages/integrations/lit/src/lit-static-render-protocol.ts
@@ -1,4 +1,4 @@
-import type { PageQuery, RouteRenderResult } from '@ecopages/core';
+import type { PageParams, PageQuery, RouteRenderResult } from '@ecopages/core';
 
 export type LitStaticRenderCacheStrategy = RouteRenderResult['cacheStrategy'];
 
@@ -12,7 +12,8 @@ export type LitStaticRenderWorkerRenderMessage = {
 	type: 'render';
 	id: string;
 	filePath: string;
-	params: Record<string, string>;
+	/** Route params; multi-value keys stay as `string[]`. */
+	params: PageParams;
 	/** Serializable route query; preserves multi-value keys as `string[]`. */
 	query?: PageQuery;
 };

--- a/packages/integrations/lit/src/lit-static-render-session.ts
+++ b/packages/integrations/lit/src/lit-static-render-session.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type { EcoComponent, EcoPagesAppConfig, PageQuery } from '@ecopages/core';
+import type { EcoComponent, EcoPagesAppConfig, PageParams, PageQuery } from '@ecopages/core';
 import type { StaticExportContext } from '@ecopages/core/plugins/integration-plugin';
 import type { AssetDefinition } from '@ecopages/core/services/asset-processing-service';
 import { LitSsrLazyPreloader } from './lit-ssr-lazy-preloader.ts';
@@ -8,6 +8,11 @@ import { LitStaticRenderWorkerClient } from './lit-static-render-worker-client.t
 import type { LitStaticRenderCacheStrategy } from './lit-static-render-protocol.ts';
 
 type LitStaticRenderWorkerClientContract = Pick<LitStaticRenderWorkerClient, 'start' | 'renderPage' | 'dispose'>;
+
+type LitStaticRenderWorkerIdentity = {
+	configModulePath: string;
+	runtimeOrigin: string;
+};
 
 type LitStaticRenderSessionOptions = {
 	resolveDependencyPath: (componentDir: string, sourcePath: string) => string;
@@ -27,13 +32,18 @@ type LitStaticRenderSessionOptions = {
  *
  * @remarks
  * Owns worker lifecycle and SSR preload for Lit page routes during static export
- * and runtime/dev requests. Injected into `LitRenderer` by `LitPlugin`; there is
- * no process-global coordinator.
+ * and runtime/dev requests. Injected into `LitRenderer` via a lazy accessor from
+ * `LitPlugin`; there is no process-global coordinator.
+ *
+ * Worker init identity is sticky for the first `{ configModulePath, runtimeOrigin }`.
+ * Later `ensureWorker` calls with the same identity are no-ops; a different identity
+ * recreates the worker so stale config/origin is never silently reused.
  */
 export class LitStaticRenderSession {
 	private readonly preloader: LitSsrLazyPreloader;
 	private readonly createWorkerClient: NonNullable<LitStaticRenderSessionOptions['createWorkerClient']>;
 	private workerClient: LitStaticRenderWorkerClientContract | null = null;
+	private workerIdentity: LitStaticRenderWorkerIdentity | null = null;
 
 	constructor(options: LitStaticRenderSessionOptions) {
 		this.preloader = new LitSsrLazyPreloader({
@@ -50,11 +60,31 @@ export class LitStaticRenderSession {
 				}));
 	}
 
+	/**
+	 * Ensures the static render worker is running for the given identity.
+	 *
+	 * @remarks
+	 * First successful start sticks that identity. Matching re-entry is a no-op.
+	 * A different `configModulePath` or `runtimeOrigin` disposes and recreates.
+	 */
 	async ensureWorker(input: { configModulePath: string; runtimeOrigin: string }): Promise<void> {
-		if (this.workerClient) {
+		if (
+			this.workerClient &&
+			this.workerIdentity &&
+			this.workerIdentity.configModulePath === input.configModulePath &&
+			this.workerIdentity.runtimeOrigin === input.runtimeOrigin
+		) {
 			return;
 		}
 
+		if (this.workerClient) {
+			await this.dispose();
+		}
+
+		this.workerIdentity = {
+			configModulePath: input.configModulePath,
+			runtimeOrigin: input.runtimeOrigin,
+		};
 		this.workerClient = this.createWorkerClient({
 			configModulePath: input.configModulePath,
 			runtimeOrigin: input.runtimeOrigin,
@@ -76,7 +106,7 @@ export class LitStaticRenderSession {
 
 	async renderPageInWorker(input: {
 		filePath: string;
-		params: Record<string, string>;
+		params: PageParams;
 		query?: PageQuery;
 	}): Promise<{ html: string; cacheStrategy?: LitStaticRenderCacheStrategy }> {
 		if (!this.workerClient) {
@@ -93,6 +123,7 @@ export class LitStaticRenderSession {
 	async dispose(): Promise<void> {
 		await this.workerClient?.dispose();
 		this.workerClient = null;
+		this.workerIdentity = null;
 	}
 
 	private async preloadLitRoutes(context: StaticExportContext): Promise<void> {

--- a/packages/integrations/lit/src/lit-static-render-worker-client.ts
+++ b/packages/integrations/lit/src/lit-static-render-worker-client.ts
@@ -1,6 +1,6 @@
 import { Worker } from 'node:worker_threads';
 import { fileURLToPath } from 'node:url';
-import type { PageQuery } from '@ecopages/core';
+import type { PageParams, PageQuery } from '@ecopages/core';
 import type {
 	LitStaticRenderCacheStrategy,
 	LitStaticRenderWorkerRequestMessage,
@@ -105,7 +105,7 @@ export class LitStaticRenderWorkerClient {
 
 	async renderPage(input: {
 		filePath: string;
-		params: Record<string, string>;
+		params: PageParams;
 		query?: PageQuery;
 	}): Promise<{ html: string; cacheStrategy?: LitStaticRenderCacheStrategy }> {
 		await this.start();

--- a/packages/integrations/lit/src/lit-static-render-worker.ts
+++ b/packages/integrations/lit/src/lit-static-render-worker.ts
@@ -3,7 +3,7 @@ import { pathToFileURL } from 'node:url';
 import { setupAppRuntimePlugins } from '@ecopages/core/build/build-adapter';
 import { installBuildRuntime } from '@ecopages/core/build/build-runtime';
 import { RouteRendererFactory } from '@ecopages/core/route-renderer/route-renderer';
-import type { EcoPagesAppConfig, PageQuery } from '@ecopages/core';
+import type { EcoPagesAppConfig, PageParams, PageQuery } from '@ecopages/core';
 import type {
 	LitStaticRenderCacheStrategy,
 	LitStaticRenderWorkerRequestMessage,
@@ -40,7 +40,7 @@ async function initializeWorker(configModulePath: string, runtimeOrigin: string)
 
 async function renderPage(
 	filePath: string,
-	params: Record<string, string>,
+	params: PageParams,
 	query?: PageQuery,
 ): Promise<{ html: string; cacheStrategy?: LitStaticRenderCacheStrategy }> {
 	if (!routeRendererFactory) {

--- a/packages/integrations/lit/src/lit.plugin.ts
+++ b/packages/integrations/lit/src/lit.plugin.ts
@@ -25,6 +25,11 @@ export const PLUGIN_NAME = LIT_PLUGIN_NAME;
 /**
  * The Lit plugin class
  * This plugin provides support for Lit components in Ecopages
+ *
+ * @remarks
+ * Owns the {@link LitStaticRenderSession} for worker SSR. Renderers receive a
+ * lazy `getRenderSession` accessor so construction before {@link setup} still
+ * observes the session once setup assigns it.
  */
 export class LitPlugin extends IntegrationPlugin {
 	renderer = LitRenderer;
@@ -80,7 +85,7 @@ export class LitPlugin extends IntegrationPlugin {
 	override initializeRenderer(options?: { rendererModules?: unknown }): LitRenderer {
 		const renderer = new this.renderer({
 			...this.createRendererOptions(options),
-			renderSession: this.renderSession ?? undefined,
+			getRenderSession: () => this.renderSession ?? undefined,
 		});
 		return this.attachRendererRuntimeServices(renderer);
 	}

--- a/packages/integrations/lit/src/test/lit-renderer.test.ts
+++ b/packages/integrations/lit/src/test/lit-renderer.test.ts
@@ -9,10 +9,12 @@ import {
 } from '@ecopages/core';
 import { createDeferredIntegrationPlugin, createTestAppConfig } from '@ecopages/testing';
 import { toForeignSubtreeRenderPayload } from '@ecopages/core/route-renderer/orchestration/foreign-subtree-execution.service';
+import { IntegrationRenderer } from '@ecopages/core/route-renderer/integration-renderer';
 import { LitElement, html as litHtml } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { html as staticHtml } from 'lit/static-html.js';
 import { LitRenderer } from '../lit-renderer.ts';
+import type { LitStaticRenderSession } from '../lit-static-render-session.ts';
 
 let customElementIndex = 0;
 
@@ -958,6 +960,95 @@ describe('LitRenderer', () => {
 			await expect(testRenderer.renderToResponse(View, {}, {})).rejects.toThrow(
 				'Error rendering view: View failed to render',
 			);
+		});
+	});
+
+	describe('lazy worker session', () => {
+		it('uses the worker after plugin setup assigns a session to a pre-created renderer', async () => {
+			const sessionHolder: { current?: Pick<LitStaticRenderSession, 'renderPageInWorker'> } = {};
+			const renderPageInWorker = vi.fn(async () => ({
+				html: '<html>lazy-worker</html>',
+				cacheStrategy: { revalidate: 15 },
+			}));
+
+			const renderer = new LitRenderer({
+				appConfig: Config,
+				assetProcessingService: {} as never,
+				runtimeOrigin: 'http://localhost:3000',
+				resolvedIntegrationDependencies: [],
+				getRenderSession: () => sessionHolder.current as LitStaticRenderSession | undefined,
+			});
+
+			const inProcessSpy = vi.spyOn(IntegrationRenderer.prototype, 'execute').mockResolvedValue({
+				body: '<html>in-process</html>',
+			});
+
+			try {
+				await renderer.execute({ file: '/app/pages/index.lit.tsx', params: {} });
+				expect(renderPageInWorker).not.toHaveBeenCalled();
+				expect(inProcessSpy).toHaveBeenCalledTimes(1);
+
+				sessionHolder.current = { renderPageInWorker };
+				inProcessSpy.mockClear();
+
+				const result = await renderer.execute({
+					file: '/app/pages/index.lit.tsx',
+					params: { slug: ['a', 'b'] },
+					query: { tag: ['x', 'y'] },
+				});
+
+				expect(inProcessSpy).not.toHaveBeenCalled();
+				expect(renderPageInWorker).toHaveBeenCalledWith({
+					filePath: '/app/pages/index.lit.tsx',
+					params: { slug: ['a', 'b'] },
+					query: { tag: ['x', 'y'] },
+				});
+				expect(result).toEqual({
+					body: '<html>lazy-worker</html>',
+					cacheStrategy: { revalidate: 15 },
+				});
+			} finally {
+				inProcessSpy.mockRestore();
+			}
+		});
+
+		it('forces in-process execute when locals are present', async () => {
+			const renderPageInWorker = vi.fn(async () => ({
+				html: '<html>worker</html>',
+			}));
+
+			const renderer = new LitRenderer({
+				appConfig: Config,
+				assetProcessingService: {} as never,
+				runtimeOrigin: 'http://localhost:3000',
+				resolvedIntegrationDependencies: [],
+				getRenderSession: () =>
+					({
+						renderPageInWorker,
+					}) as Pick<LitStaticRenderSession, 'renderPageInWorker'> as LitStaticRenderSession,
+			});
+
+			const inProcessSpy = vi.spyOn(IntegrationRenderer.prototype, 'execute').mockResolvedValue({
+				body: '<html>locals-in-process</html>',
+			});
+
+			try {
+				const result = await renderer.execute({
+					file: '/app/pages/index.lit.tsx',
+					params: { id: '1' },
+					locals: { requestId: 'req-1' },
+				});
+
+				expect(renderPageInWorker).not.toHaveBeenCalled();
+				expect(inProcessSpy).toHaveBeenCalledWith({
+					file: '/app/pages/index.lit.tsx',
+					params: { id: '1' },
+					locals: { requestId: 'req-1' },
+				});
+				expect(result).toEqual({ body: '<html>locals-in-process</html>' });
+			} finally {
+				inProcessSpy.mockRestore();
+			}
 		});
 	});
 });

--- a/packages/integrations/lit/src/test/lit-static-render-session.test.ts
+++ b/packages/integrations/lit/src/test/lit-static-render-session.test.ts
@@ -92,6 +92,72 @@ describe('LitStaticRenderSession', () => {
 		expect(workerDispose).toHaveBeenCalledTimes(1);
 	});
 
+	it('recreates the worker when init identity changes', async () => {
+		workerStart.mockClear();
+		workerDispose.mockClear();
+
+		const createClient = vi.fn(() => createWorkerClient());
+		const session = new LitStaticRenderSession({
+			resolveDependencyPath: (_componentDir, sourcePath) => sourcePath,
+			createWorkerClient: createClient,
+		});
+
+		await session.ensureWorker({
+			configModulePath: '/app/eco.config.ts',
+			runtimeOrigin: 'http://127.0.0.1:3000',
+		});
+		await session.ensureWorker({
+			configModulePath: '/app/eco.config.ts',
+			runtimeOrigin: 'http://127.0.0.1:3000',
+		});
+
+		expect(createClient).toHaveBeenCalledTimes(1);
+		expect(workerStart).toHaveBeenCalledTimes(1);
+
+		await session.ensureWorker({
+			configModulePath: '/app/eco.config.ts',
+			runtimeOrigin: 'http://127.0.0.1:4000',
+		});
+
+		expect(workerDispose).toHaveBeenCalledTimes(1);
+		expect(createClient).toHaveBeenCalledTimes(2);
+		expect(workerStart).toHaveBeenCalledTimes(2);
+		expect(createClient).toHaveBeenLastCalledWith({
+			configModulePath: '/app/eco.config.ts',
+			runtimeOrigin: 'http://127.0.0.1:4000',
+		});
+
+		await session.dispose();
+	});
+
+	it('forwards array PageParams and PageQuery to the worker client', async () => {
+		workerRenderPage.mockClear();
+
+		const session = new LitStaticRenderSession({
+			resolveDependencyPath: (_componentDir, sourcePath) => sourcePath,
+			createWorkerClient,
+		});
+
+		await session.ensureWorker({
+			configModulePath: '/app/eco.config.ts',
+			runtimeOrigin: 'http://127.0.0.1:3000',
+		});
+
+		await session.renderPageInWorker({
+			filePath: '/app/src/pages/catch-all.lit.tsx',
+			params: { slug: ['docs', 'intro'] },
+			query: { tag: ['a', 'b'], preview: '1' },
+		});
+
+		expect(workerRenderPage).toHaveBeenCalledWith({
+			filePath: '/app/src/pages/catch-all.lit.tsx',
+			params: { slug: ['docs', 'intro'] },
+			query: { tag: ['a', 'b'], preview: '1' },
+		});
+
+		await session.dispose();
+	});
+
 	it('preloads SSR scripts only for Lit template routes', async () => {
 		const litComponent = {
 			config: {

--- a/packages/integrations/react/package.json
+++ b/packages/integrations/react/package.json
@@ -31,7 +31,8 @@
 		"./runtime/use-sync-external-store-with-selector": "./src/runtime/use-sync-external-store-with-selector.ts",
 		"./router-adapter": "./src/router-adapter.ts",
 		"./layout-compose": "./src/layout-compose.ts",
-		"./serialize-page-data-script": "./src/serialize-page-data-script.ts"
+		"./serialize-page-data-script": "./src/serialize-page-data-script.ts",
+		"./page-data-reader": "./src/page-data-reader.ts"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/integrations/react/src/layout-compose.test.ts
+++ b/packages/integrations/react/src/layout-compose.test.ts
@@ -97,9 +97,13 @@ describe('layout-compose', () => {
 			render: () => 'page',
 		});
 
-		const tree = composeLayoutPageTree(pageComponent(Page), {}, {
-			resolvePersistedTier: () => ({ layout: CachedLayout, key: 'layout-key' }),
-		});
+		const tree = composeLayoutPageTree(
+			pageComponent(Page),
+			{},
+			{
+				resolvePersistedTier: () => ({ layout: CachedLayout, key: 'layout-key' }),
+			},
+		);
 
 		expect(tree.type).toBe(CachedLayout);
 		expect(tree.key).toBe('layout-key');

--- a/packages/integrations/react/src/layout-compose.test.ts
+++ b/packages/integrations/react/src/layout-compose.test.ts
@@ -89,6 +89,22 @@ describe('layout-compose', () => {
 		expect(tree.type).toBe(Outer);
 	});
 
+	it('should apply persisted layout tiers when a resolver is provided', () => {
+		const Layout = ({ children }: { children?: string }) => createElement('section', null, children);
+		const CachedLayout = ({ children }: { children?: string }) => createElement('cached', null, children);
+		const Page = eco.page({
+			layout: Layout,
+			render: () => 'page',
+		});
+
+		const tree = composeLayoutPageTree(pageComponent(Page), {}, {
+			resolvePersistedTier: () => ({ layout: CachedLayout, key: 'layout-key' }),
+		});
+
+		expect(tree.type).toBe(CachedLayout);
+		expect(tree.key).toBe('layout-key');
+	});
+
 	it('should derive layout locals from shell props instead of pageProps.locals', () => {
 		const Layout = ({ locals, children }: { locals?: { role: string }; children?: string }) =>
 			createElement('section', null, locals?.role, children);

--- a/packages/integrations/react/src/layout-compose.ts
+++ b/packages/integrations/react/src/layout-compose.ts
@@ -154,15 +154,13 @@ export function composeLayoutPageTree<P extends Record<string, unknown>>(
 	const layouts = Page.config?.layouts;
 	if (layouts && layouts.length > 0) {
 		const layoutProps = context.locals ? { locals: context.locals } : {};
-		return [...layouts]
-			.reverse()
-			.reduce<ReactElement>((children, Layout, reverseIndex) => {
-				const index = layouts.length - 1 - reverseIndex;
-				const tier = resolvePersistedTier?.(Layout, index);
-				const ResolvedLayout = toReactComponent(tier?.layout ?? Layout);
-				const elementProps = tier?.key ? { key: tier.key, ...layoutProps } : layoutProps;
-				return createElement(ResolvedLayout, elementProps, children);
-			}, pageElement);
+		return [...layouts].reverse().reduce<ReactElement>((children, Layout, reverseIndex) => {
+			const index = layouts.length - 1 - reverseIndex;
+			const tier = resolvePersistedTier?.(Layout, index);
+			const ResolvedLayout = toReactComponent(tier?.layout ?? Layout);
+			const elementProps = tier?.key ? { key: tier.key, ...layoutProps } : layoutProps;
+			return createElement(ResolvedLayout, elementProps, children);
+		}, pageElement);
 	}
 
 	return pageElement;

--- a/packages/integrations/react/src/layout-compose.ts
+++ b/packages/integrations/react/src/layout-compose.ts
@@ -17,6 +17,11 @@ export type LayoutComposeOptions = {
 	context?: LayoutComposeContext;
 	/** @remarks Pass the app-resolved React runtime during SSR so composition matches `renderToString`. */
 	react?: ReactRuntime;
+	/**
+	 * Optional resolver that substitutes cached layout instances and React keys
+	 * for SPA layout persistence.
+	 */
+	resolvePersistedTier?: (layout: EcoComponent, index: number) => { layout: EcoComponent; key?: string };
 };
 
 function resolveReact(options?: LayoutComposeOptions): ReactRuntime {
@@ -133,11 +138,16 @@ export function composeLayoutPageTree<P extends Record<string, unknown>>(
 	const context = options?.context ?? resolveLayoutContext(pageProps);
 	const pageElement = createElement(Page, pageProps);
 	const layoutEntries = Page.config?.layoutEntries;
+	const resolvePersistedTier = options?.resolvePersistedTier;
 
 	if (layoutEntries && layoutEntries.length > 0) {
-		return [...layoutEntries].reverse().reduce<ReactElement>((children, entry) => {
+		return [...layoutEntries].reverse().reduce<ReactElement>((children, entry, reverseIndex) => {
+			const index = layoutEntries.length - 1 - reverseIndex;
 			const layoutProps = resolveLayoutEntryProps(entry, context);
-			return createElement(toReactComponent(entry.component), layoutProps, children);
+			const tier = resolvePersistedTier?.(entry.component, index);
+			const Layout = toReactComponent(tier?.layout ?? entry.component);
+			const elementProps = tier?.key ? { key: tier.key, ...layoutProps } : layoutProps;
+			return createElement(Layout, elementProps, children);
 		}, pageElement);
 	}
 
@@ -146,10 +156,13 @@ export function composeLayoutPageTree<P extends Record<string, unknown>>(
 		const layoutProps = context.locals ? { locals: context.locals } : {};
 		return [...layouts]
 			.reverse()
-			.reduce<ReactElement>(
-				(children, Layout) => createElement(toReactComponent(Layout), layoutProps, children),
-				pageElement,
-			);
+			.reduce<ReactElement>((children, Layout, reverseIndex) => {
+				const index = layouts.length - 1 - reverseIndex;
+				const tier = resolvePersistedTier?.(Layout, index);
+				const ResolvedLayout = toReactComponent(tier?.layout ?? Layout);
+				const elementProps = tier?.key ? { key: tier.key, ...layoutProps } : layoutProps;
+				return createElement(ResolvedLayout, elementProps, children);
+			}, pageElement);
 	}
 
 	return pageElement;

--- a/packages/integrations/react/src/page-data-manifest.ts
+++ b/packages/integrations/react/src/page-data-manifest.ts
@@ -8,13 +8,12 @@
  *
  * Compatibility matrix:
  * - new client / new document: prefer `schemaVersion:1` envelope (`moduleUrl` + `props`)
- * - new client / old document: accept legacy flat props; module falls back to
- *   hydration markers/regex for one compatibility release
+ * - new client / old document: accept legacy flat props; module discovery uses
+ *   `window.__ECO_PAGES__.page.module` or `script[data-eco-page-bootstrap="react-router"]`
  * - old client / new document: old clients that only read flat props should be
  *   upgraded; envelope consumers must unwrap `props` before hydration
- * - malformed / unknown schema (numeric `schemaVersion` present but envelope invalid): empty
- *   props and no module URL from the manifest; navigation may still discover a
- *   module via bootstrap markers or the temporary regex fallback
+ * - malformed / unknown schema (numeric `schemaVersion` present but envelope invalid):
+ *   empty props and no module URL from the manifest
  * - HMR: `moduleUrlOverride` still bypasses document discovery
  * - legacy flat props may include a string `schemaVersion` field without being treated as an envelope
  */

--- a/packages/integrations/react/src/page-data-manifest.ts
+++ b/packages/integrations/react/src/page-data-manifest.ts
@@ -107,6 +107,8 @@ export function createEcoPageDataManifestV1(input: {
  *
  * @remarks
  * Shared by server serializers and `EcoPropsScript` so envelope rules stay in one place.
+ * A valid v1 envelope is returned as-is; `options.moduleUrl` is ignored in that case.
+ * Flat props wrap into a v1 envelope only when `options.moduleUrl` is provided.
  */
 export function resolvePageDataDocumentPayload(
 	data: EcoPageDataDocumentPayload,

--- a/packages/integrations/react/src/page-data-manifest.ts
+++ b/packages/integrations/react/src/page-data-manifest.ts
@@ -7,25 +7,25 @@
  * documents may still contain a flat props object; consumers must detect both.
  *
  * Compatibility matrix:
- * - new client / new document: prefer `v:1` envelope (`module` + `props`)
+ * - new client / new document: prefer `schemaVersion:1` envelope (`moduleUrl` + `props`)
  * - new client / old document: accept legacy flat props; module falls back to
  *   hydration markers/regex for one compatibility release
  * - old client / new document: old clients that only read flat props should be
  *   upgraded; envelope consumers must unwrap `props` before hydration
- * - malformed / unknown schema (numeric `v` present but envelope invalid): empty
+ * - malformed / unknown schema (numeric `schemaVersion` present but envelope invalid): empty
  *   props and no module URL from the manifest; navigation may still discover a
  *   module via bootstrap markers or the temporary regex fallback
  * - HMR: `moduleUrlOverride` still bypasses document discovery
- * - legacy flat props may include a string `v` field without being treated as an envelope
+ * - legacy flat props may include a string `schemaVersion` field without being treated as an envelope
  */
 export const ECO_PAGE_DATA_SCHEMA_VERSION = 1 as const;
 
 export type EcoPageDataProps = Record<string, unknown>;
 
 export type EcoPageDataManifestV1 = {
-	v: typeof ECO_PAGE_DATA_SCHEMA_VERSION;
+	schemaVersion: typeof ECO_PAGE_DATA_SCHEMA_VERSION;
 	navigationOwner: 'react-router';
-	module: string;
+	moduleUrl: string;
 	props: EcoPageDataProps;
 };
 
@@ -41,9 +41,9 @@ export function isEcoPageDataManifestV1(value: unknown): value is EcoPageDataMan
 
 	const candidate = value as Partial<EcoPageDataManifestV1>;
 	return (
-		candidate.v === ECO_PAGE_DATA_SCHEMA_VERSION &&
+		candidate.schemaVersion === ECO_PAGE_DATA_SCHEMA_VERSION &&
 		candidate.navigationOwner === 'react-router' &&
-		typeof candidate.module === 'string' &&
+		typeof candidate.moduleUrl === 'string' &&
 		typeof candidate.props === 'object' &&
 		candidate.props !== null &&
 		!Array.isArray(candidate.props)
@@ -54,12 +54,14 @@ export function isEcoPageDataManifestV1(value: unknown): value is EcoPageDataMan
  * Returns whether a payload claims a numeric schema version without being a valid v1 envelope.
  *
  * @remarks
- * Only numeric `v` values are treated as envelope attempts. Legacy flat props may
- * legitimately include a string `v` field (e.g. a version string) and must not be
+ * Only numeric `schemaVersion` values are treated as envelope attempts. Legacy flat props may
+ * legitimately include a string `schemaVersion` field (e.g. a version string) and must not be
  * wiped. Near-miss numeric envelopes must not fall through to the flat-props path.
  */
 function isMalformedPageDataEnvelope(payload: object): boolean {
-	return 'v' in payload && typeof (payload as { v: unknown }).v === 'number';
+	return (
+		'schemaVersion' in payload && typeof (payload as { schemaVersion: unknown }).schemaVersion === 'number'
+	);
 }
 
 /**
@@ -85,17 +87,44 @@ export function resolveEcoPageDataProps(payload: unknown): EcoPageDataProps {
  * Extracts the page module URL from a v1 envelope when present.
  */
 export function resolveEcoPageDataModuleUrl(payload: unknown): string | null {
-	return isEcoPageDataManifestV1(payload) ? payload.module : null;
+	return isEcoPageDataManifestV1(payload) ? payload.moduleUrl : null;
 }
 
 /**
  * Builds the canonical v1 page-data envelope for React documents.
  */
-export function createEcoPageDataManifestV1(input: { module: string; props: EcoPageDataProps }): EcoPageDataManifestV1 {
+export function createEcoPageDataManifestV1(input: {
+	moduleUrl: string;
+	props: EcoPageDataProps;
+}): EcoPageDataManifestV1 {
 	return {
-		v: ECO_PAGE_DATA_SCHEMA_VERSION,
+		schemaVersion: ECO_PAGE_DATA_SCHEMA_VERSION,
 		navigationOwner: 'react-router',
-		module: input.module,
+		moduleUrl: input.moduleUrl,
 		props: input.props,
 	};
+}
+
+/**
+ * Normalizes flat page props or an existing envelope into the document payload shape.
+ *
+ * @remarks
+ * Shared by server serializers and `EcoPropsScript` so envelope rules stay in one place.
+ */
+export function resolvePageDataDocumentPayload(
+	data: EcoPageDataDocumentPayload,
+	options?: { moduleUrl?: string },
+): EcoPageDataDocumentPayload {
+	if (isEcoPageDataManifestV1(data)) {
+		return data;
+	}
+
+	const props = { ...(data as EcoPageDataProps) };
+	const moduleUrl = options?.moduleUrl;
+
+	if (!moduleUrl) {
+		return props;
+	}
+
+	return createEcoPageDataManifestV1({ moduleUrl, props });
 }

--- a/packages/integrations/react/src/page-data-manifest.ts
+++ b/packages/integrations/react/src/page-data-manifest.ts
@@ -58,9 +58,7 @@ export function isEcoPageDataManifestV1(value: unknown): value is EcoPageDataMan
  * wiped. Near-miss numeric envelopes must not fall through to the flat-props path.
  */
 function isMalformedPageDataEnvelope(payload: object): boolean {
-	return (
-		'schemaVersion' in payload && typeof (payload as { schemaVersion: unknown }).schemaVersion === 'number'
-	);
+	return 'schemaVersion' in payload && typeof (payload as { schemaVersion: unknown }).schemaVersion === 'number';
 }
 
 /**

--- a/packages/integrations/react/src/page-data-reader.test.ts
+++ b/packages/integrations/react/src/page-data-reader.test.ts
@@ -1,12 +1,63 @@
 import { describe, expect, it, afterEach } from 'vitest';
-import { readPageDataDocument } from './page-data-reader.ts';
+import {
+	getDevPageDataReaderBootstrapSource,
+	getProdPageDataReaderBootstrapSource,
+	readPageDataDocument,
+	type ReadPageDataDocumentResult,
+} from './page-data-reader.ts';
 
-function installPageDataScript(content: string): void {
-	const script = { id: '__ECO_PAGE_DATA__', textContent: content };
-	(globalThis as { document?: { getElementById: (id: string) => typeof script | null } }).document = {
+function installPageDataScript(content: string | null): void {
+	const script = content === null ? null : { id: '__ECO_PAGE_DATA__', textContent: content };
+	(globalThis as { document?: { getElementById: (id: string) => typeof script } }).document = {
 		getElementById: (id: string) => (id === '__ECO_PAGE_DATA__' ? script : null),
 	};
 }
+
+function readViaBootstrap(source: string, readerName: 'readPageDataDocument' | 'rd'): ReadPageDataDocumentResult {
+	const reader = new Function(`${source}; return ${readerName};`)() as () => ReadPageDataDocumentResult;
+	return reader();
+}
+
+const fixtures: Array<{ name: string; content: string | null; expected: ReadPageDataDocumentResult }> = [
+	{
+		name: 'v1 envelope',
+		content: JSON.stringify({
+			schemaVersion: 1,
+			navigationOwner: 'react-router',
+			moduleUrl: '/assets/page.js',
+			props: { slug: 'intro' },
+		}),
+		expected: {
+			moduleUrl: '/assets/page.js',
+			props: { slug: 'intro' },
+		},
+	},
+	{
+		name: 'legacy flat props',
+		content: JSON.stringify({ slug: 'legacy' }),
+		expected: { props: { slug: 'legacy' } },
+	},
+	{
+		name: 'malformed numeric envelope',
+		content: JSON.stringify({ schemaVersion: 1, moduleUrl: '/x.js', props: null }),
+		expected: { props: {} },
+	},
+	{
+		name: 'legacy string schemaVersion field',
+		content: JSON.stringify({ schemaVersion: '1.2.3', slug: 'x' }),
+		expected: { props: { schemaVersion: '1.2.3', slug: 'x' } },
+	},
+	{
+		name: 'missing script',
+		content: null,
+		expected: { props: {} },
+	},
+	{
+		name: 'invalid JSON',
+		content: 'not-json',
+		expected: { props: {} },
+	},
+];
 
 describe('page-data-reader', () => {
 	afterEach(() => {
@@ -33,5 +84,19 @@ describe('page-data-reader', () => {
 		installPageDataScript(JSON.stringify({ slug: 'legacy' }));
 
 		expect(readPageDataDocument()).toEqual({ props: { slug: 'legacy' } });
+	});
+
+	it('keeps inlined bootstrap readers aligned with readPageDataDocument', () => {
+		const devSource = getDevPageDataReaderBootstrapSource();
+		const prodSource = getProdPageDataReaderBootstrapSource();
+
+		for (const fixture of fixtures) {
+			installPageDataScript(fixture.content);
+			expect(readPageDataDocument(), fixture.name).toEqual(fixture.expected);
+			expect(readViaBootstrap(devSource, 'readPageDataDocument'), `dev:${fixture.name}`).toEqual(
+				fixture.expected,
+			);
+			expect(readViaBootstrap(prodSource, 'rd'), `prod:${fixture.name}`).toEqual(fixture.expected);
+		}
 	});
 });

--- a/packages/integrations/react/src/page-data-reader.test.ts
+++ b/packages/integrations/react/src/page-data-reader.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { readPageDataDocument } from './page-data-reader.ts';
+
+function installPageDataScript(content: string): void {
+	const script = { id: '__ECO_PAGE_DATA__', textContent: content };
+	(globalThis as { document?: { getElementById: (id: string) => typeof script | null } }).document = {
+		getElementById: (id: string) => (id === '__ECO_PAGE_DATA__' ? script : null),
+	};
+}
+
+describe('page-data-reader', () => {
+	afterEach(() => {
+		delete (globalThis as { document?: unknown }).document;
+	});
+
+	it('should read v1 envelopes from __ECO_PAGE_DATA__', () => {
+		installPageDataScript(
+			JSON.stringify({
+				schemaVersion: 1,
+				navigationOwner: 'react-router',
+				moduleUrl: '/assets/page.js',
+				props: { slug: 'intro' },
+			}),
+		);
+
+		expect(readPageDataDocument()).toEqual({
+			moduleUrl: '/assets/page.js',
+			props: { slug: 'intro' },
+		});
+	});
+
+	it('should fall back to legacy flat props', () => {
+		installPageDataScript(JSON.stringify({ slug: 'legacy' }));
+
+		expect(readPageDataDocument()).toEqual({ props: { slug: 'legacy' } });
+	});
+});

--- a/packages/integrations/react/src/page-data-reader.ts
+++ b/packages/integrations/react/src/page-data-reader.ts
@@ -7,6 +7,10 @@ export type ReadPageDataDocumentResult = {
 
 /**
  * Reads `__ECO_PAGE_DATA__`, supporting both v1 envelopes and legacy flat props.
+ *
+ * @remarks
+ * Always returns unwrapped `props`. `moduleUrl` is set only when the document
+ * carries a valid v1 envelope.
  */
 export function readPageDataDocument(): ReadPageDataDocumentResult {
 	const element = document.getElementById('__ECO_PAGE_DATA__');

--- a/packages/integrations/react/src/page-data-reader.ts
+++ b/packages/integrations/react/src/page-data-reader.ts
@@ -1,8 +1,4 @@
-import {
-	resolveEcoPageDataModuleUrl,
-	resolveEcoPageDataProps,
-	type EcoPageDataProps,
-} from './page-data-manifest.ts';
+import { resolveEcoPageDataModuleUrl, resolveEcoPageDataProps, type EcoPageDataProps } from './page-data-manifest.ts';
 
 export type ReadPageDataDocumentResult = {
 	moduleUrl?: string;

--- a/packages/integrations/react/src/page-data-reader.ts
+++ b/packages/integrations/react/src/page-data-reader.ts
@@ -1,0 +1,38 @@
+import {
+	resolveEcoPageDataModuleUrl,
+	resolveEcoPageDataProps,
+	type EcoPageDataProps,
+} from './page-data-manifest.ts';
+
+export type ReadPageDataDocumentResult = {
+	moduleUrl?: string;
+	props: EcoPageDataProps;
+};
+
+/**
+ * Reads `__ECO_PAGE_DATA__`, supporting both v1 envelopes and legacy flat props.
+ */
+export function readPageDataDocument(): ReadPageDataDocumentResult {
+	const element = document.getElementById('__ECO_PAGE_DATA__');
+	if (!element?.textContent) {
+		return { props: {} };
+	}
+
+	try {
+		const parsed: unknown = JSON.parse(element.textContent);
+		const moduleUrl = resolveEcoPageDataModuleUrl(parsed) ?? undefined;
+		return {
+			...(moduleUrl && { moduleUrl }),
+			props: resolveEcoPageDataProps(parsed),
+		};
+	} catch {
+		return { props: {} };
+	}
+}
+
+/**
+ * Returns page props from `__ECO_PAGE_DATA__` for hydration and HMR handlers.
+ */
+export function getPageDataFromDocument(): EcoPageDataProps {
+	return readPageDataDocument().props;
+}

--- a/packages/integrations/react/src/page-data-reader.ts
+++ b/packages/integrations/react/src/page-data-reader.ts
@@ -1,4 +1,9 @@
-import { resolveEcoPageDataModuleUrl, resolveEcoPageDataProps, type EcoPageDataProps } from './page-data-manifest.ts';
+import {
+	ECO_PAGE_DATA_SCHEMA_VERSION,
+	resolveEcoPageDataModuleUrl,
+	resolveEcoPageDataProps,
+	type EcoPageDataProps,
+} from './page-data-manifest.ts';
 
 export type ReadPageDataDocumentResult = {
 	moduleUrl?: string;
@@ -35,4 +40,52 @@ export function readPageDataDocument(): ReadPageDataDocumentResult {
  */
 export function getPageDataFromDocument(): EcoPageDataProps {
 	return readPageDataDocument().props;
+}
+
+/**
+ * Inlined browser bootstrap for generated hydration scripts.
+ *
+ * @remarks
+ * Hydration and HMR entry modules are evaluated as native browser ESM. Bare
+ * package imports such as `@ecopages/react/page-data-reader` are not resolvable
+ * there, so the reader algorithm is embedded. Keep this string aligned with
+ * {@link readPageDataDocument} / {@link getPageDataFromDocument}.
+ */
+export function getDevPageDataReaderBootstrapSource(): string {
+	return `const readPageDataDocument = () => {
+  const el = document.getElementById("__ECO_PAGE_DATA__");
+  if (!el?.textContent) {
+    return { props: {} };
+  }
+  try {
+    const parsed = JSON.parse(el.textContent);
+    if (
+      parsed &&
+      parsed.schemaVersion === ${ECO_PAGE_DATA_SCHEMA_VERSION} &&
+      parsed.navigationOwner === "react-router" &&
+      typeof parsed.moduleUrl === "string" &&
+      parsed.props &&
+      typeof parsed.props === "object" &&
+      !Array.isArray(parsed.props)
+    ) {
+      return { moduleUrl: parsed.moduleUrl, props: parsed.props };
+    }
+    if (parsed && typeof parsed === "object" && typeof parsed.schemaVersion === "number") {
+      return { props: {} };
+    }
+    return {
+      props: parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {},
+    };
+  } catch {
+    return { props: {} };
+  }
+};
+const getPageData = () => readPageDataDocument().props;`;
+}
+
+/**
+ * Minified equivalent of {@link getDevPageDataReaderBootstrapSource}.
+ */
+export function getProdPageDataReaderBootstrapSource(): string {
+	return `const rd=()=>{const e=document.getElementById("__ECO_PAGE_DATA__");if(!e?.textContent)return{props:{}};try{const p=JSON.parse(e.textContent);if(p&&p.schemaVersion===${ECO_PAGE_DATA_SCHEMA_VERSION}&&p.navigationOwner==="react-router"&&typeof p.moduleUrl==="string"&&p.props&&typeof p.props==="object"&&!Array.isArray(p.props))return{moduleUrl:p.moduleUrl,props:p.props};if(p&&typeof p==="object"&&typeof p.schemaVersion==="number")return{props:{}};return{props:p&&typeof p==="object"&&!Array.isArray(p)?p:{}}}catch{return{props:{}}}};const gd=()=>rd().props;`;
 }

--- a/packages/integrations/react/src/react-renderer.ts
+++ b/packages/integrations/react/src/react-renderer.ts
@@ -484,25 +484,6 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 		return hydrationProps;
 	}
 
-	private resolvePageModuleUrl(
-		pagePackage: IntegrationRendererRenderOptions<ReactNode>['pagePackage'] | undefined,
-	): string | undefined {
-		if (!this.routerAdapter) {
-			return undefined;
-		}
-
-		const entryScripts =
-			pagePackage?.pageBrowserGraph?.entryAssets.filter(
-				(asset): asset is ProcessedAsset & { srcUrl: string } =>
-					asset.kind === 'script' && typeof asset.srcUrl === 'string',
-			) ?? [];
-		const bootstrapScript = entryScripts.find(
-			(asset) => asset.attributes?.['data-eco-page-bootstrap'] === 'react-router',
-		);
-
-		return bootstrapScript?.srcUrl ?? entryScripts[0]?.srcUrl;
-	}
-
 	/**
 	 * Builds shared document html contributions for router-backed React pages rendered
 	 * through a non-React HTML shell.
@@ -887,14 +868,15 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 		pagePackage,
 	}: IntegrationRendererRenderOptions<ReactNode>): Promise<RouteRendererBody> {
 		try {
-			const pageModuleUrl = this.resolvePageModuleUrl(pagePackage);
+			const pageModuleUrl = this.pagePayloadService.resolvePageModuleUrl(pagePackage, {
+				routerEnabled: Boolean(this.routerAdapter),
+			});
 			const safeLocals = this.pagePayloadService.getSerializableLocals(locals, this.getComponentRequires(Page));
 			const allPageProps = this.pagePayloadService.buildSerializedPageProps({
 				pageProps,
 				params,
 				query,
 				safeLocals,
-				pageModuleUrl,
 			});
 
 			return await this.renderPageWithDocumentShell({
@@ -911,6 +893,7 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 				htmlTemplate: HtmlTemplate,
 				metadata,
 				pageProps: allPageProps,
+				documentProps: pageModuleUrl ? { pageModuleUrl } : undefined,
 			});
 		} catch (error) {
 			throw this.createRenderError('Failed to render component', error);
@@ -928,13 +911,14 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 			options.renderOptions.locals,
 			this.getComponentRequires(options.renderOptions.Page),
 		);
-		const pageModuleUrl = this.resolvePageModuleUrl(options.renderOptions.pagePackage);
+		const pageModuleUrl = this.pagePayloadService.resolvePageModuleUrl(options.renderOptions.pagePackage, {
+			routerEnabled: Boolean(this.routerAdapter),
+		});
 		const allPageProps = this.pagePayloadService.buildSerializedPageProps({
 			pageProps: options.renderOptions.pageProps,
 			params: options.renderOptions.params,
 			query: options.renderOptions.query,
 			safeLocals,
-			pageModuleUrl,
 		});
 
 		return this.buildNonReactDocumentContributions(options.renderOptions.HtmlTemplate, allPageProps, pageModuleUrl);
@@ -969,13 +953,14 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 
 		const HtmlTemplate = await this.getHtmlTemplate();
 		const metadata = await this.resolveViewMetadata(input.view, input.props);
-		const pageModuleUrl = this.resolvePageModuleUrl(this.htmlTransformer.getPagePackage());
+		const pageModuleUrl = this.pagePayloadService.resolvePageModuleUrl(this.htmlTransformer.getPagePackage(), {
+			routerEnabled: Boolean(this.routerAdapter),
+		});
 		const serializedPageProps = this.pagePayloadService.buildSerializedPageProps({
 			pageProps: normalizedProps,
 			params: {},
 			query: {},
 			safeLocals: this.pagePayloadService.getSerializableLocals(undefined, this.getComponentRequires(input.view)),
-			pageModuleUrl,
 		});
 		const shellLayouts: DocumentShellLayoutInput[] = input.layout ? [{ component: input.layout, props: {} }] : [];
 		const composeChildren = this.resolveComposeChildren(
@@ -1004,6 +989,7 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 				documentProps: {
 					metadata,
 					pageProps: serializedPageProps,
+					...(pageModuleUrl && { pageModuleUrl }),
 				},
 			},
 		);

--- a/packages/integrations/react/src/serialize-page-data-script.test.ts
+++ b/packages/integrations/react/src/serialize-page-data-script.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
-	ECO_PAGE_MODULE_PROP,
 	escapePageDataJson,
 	resolveEcoPageDataModuleUrl,
 	resolveEcoPageDataProps,
+	resolvePageDataDocumentPayload,
 	serializePageDataManifestScript,
 	serializePageDataScript,
 } from './serialize-page-data-script.ts';
@@ -24,34 +24,47 @@ describe('serialize-page-data-script', () => {
 	it('should emit a versioned manifest with module identity and props', () => {
 		expect(
 			serializePageDataManifestScript({
-				module: '/assets/pages/docs.js',
+				moduleUrl: '/assets/pages/docs.js',
 				props: { slug: 'intro' },
 			}),
 		).toBe(
-			'<script id="__ECO_PAGE_DATA__" type="application/json">{"v":1,"navigationOwner":"react-router","module":"/assets/pages/docs.js","props":{"slug":"intro"}}</script>',
+			'<script id="__ECO_PAGE_DATA__" type="application/json">{"schemaVersion":1,"navigationOwner":"react-router","moduleUrl":"/assets/pages/docs.js","props":{"slug":"intro"}}</script>',
 		);
-		expect(ECO_PAGE_MODULE_PROP).toBe('__ecoPageModule');
 	});
 
 	it('should reject malformed envelopes instead of treating them as flat props', () => {
-		const malformed = { v: 1, module: '/x.js', props: null };
+		const malformed = { schemaVersion: 1, moduleUrl: '/x.js', props: null };
 		expect(resolveEcoPageDataProps(malformed)).toEqual({});
 		expect(resolveEcoPageDataModuleUrl(malformed)).toBeNull();
 	});
 
-	it('should keep legacy flat props that include a string v field', () => {
-		expect(resolveEcoPageDataProps({ v: '1.2.3', slug: 'x' })).toEqual({ v: '1.2.3', slug: 'x' });
+	it('should keep legacy flat props that include a string schemaVersion field', () => {
+		expect(resolveEcoPageDataProps({ schemaVersion: '1.2.3', slug: 'x' })).toEqual({
+			schemaVersion: '1.2.3',
+			slug: 'x',
+		});
 	});
 
 	it('should unwrap valid v1 envelopes and keep legacy flat props', () => {
 		expect(
 			resolveEcoPageDataProps({
-				v: 1,
+				schemaVersion: 1,
 				navigationOwner: 'react-router',
-				module: '/assets/page.js',
+				moduleUrl: '/assets/page.js',
 				props: { slug: 'intro' },
 			}),
 		).toEqual({ slug: 'intro' });
 		expect(resolveEcoPageDataProps({ slug: 'legacy' })).toEqual({ slug: 'legacy' });
+	});
+
+	it('should build envelopes from flat props and an explicit module URL', () => {
+		expect(
+			resolvePageDataDocumentPayload({ slug: 'intro' }, { moduleUrl: '/assets/page.js' }),
+		).toEqual({
+			schemaVersion: 1,
+			navigationOwner: 'react-router',
+			moduleUrl: '/assets/page.js',
+			props: { slug: 'intro' },
+		});
 	});
 });

--- a/packages/integrations/react/src/serialize-page-data-script.test.ts
+++ b/packages/integrations/react/src/serialize-page-data-script.test.ts
@@ -58,9 +58,7 @@ describe('serialize-page-data-script', () => {
 	});
 
 	it('should build envelopes from flat props and an explicit module URL', () => {
-		expect(
-			resolvePageDataDocumentPayload({ slug: 'intro' }, { moduleUrl: '/assets/page.js' }),
-		).toEqual({
+		expect(resolvePageDataDocumentPayload({ slug: 'intro' }, { moduleUrl: '/assets/page.js' })).toEqual({
 			schemaVersion: 1,
 			navigationOwner: 'react-router',
 			moduleUrl: '/assets/page.js',

--- a/packages/integrations/react/src/serialize-page-data-script.ts
+++ b/packages/integrations/react/src/serialize-page-data-script.ts
@@ -2,7 +2,6 @@ import {
 	type EcoPageDataDocumentPayload,
 	type EcoPageDataProps,
 	createEcoPageDataManifestV1,
-	resolvePageDataDocumentPayload,
 } from './page-data-manifest.ts';
 
 export {

--- a/packages/integrations/react/src/serialize-page-data-script.ts
+++ b/packages/integrations/react/src/serialize-page-data-script.ts
@@ -2,6 +2,7 @@ import {
 	type EcoPageDataDocumentPayload,
 	type EcoPageDataProps,
 	createEcoPageDataManifestV1,
+	resolvePageDataDocumentPayload,
 } from './page-data-manifest.ts';
 
 export {
@@ -10,21 +11,11 @@ export {
 	isEcoPageDataManifestV1,
 	resolveEcoPageDataModuleUrl,
 	resolveEcoPageDataProps,
+	resolvePageDataDocumentPayload,
 	type EcoPageDataDocumentPayload,
 	type EcoPageDataManifestV1,
 	type EcoPageDataProps,
 } from './page-data-manifest.ts';
-
-/**
- * Reserved page-props key that carries the browser page module into HTML templates.
- *
- * @remarks
- * React-managed shells use `<EcoPropsScript data={pageProps} />` without a separate
- * `module` prop. The renderer may set this reserved key on serialized page props so
- * `EcoPropsScript` can emit the v1 envelope. The key is stripped before props reach
- * hydration; it is transport-only and must not be authored as application state.
- */
-export const ECO_PAGE_MODULE_PROP = '__ecoPageModule';
 
 /**
  * Escapes page data JSON for safe embedding in HTML script bodies.
@@ -48,6 +39,6 @@ export function serializePageDataScript(pageProps: EcoPageDataDocumentPayload | 
 /**
  * Emits a versioned page-data envelope for React router documents.
  */
-export function serializePageDataManifestScript(input: { module: string; props: EcoPageDataProps }): string {
+export function serializePageDataManifestScript(input: { moduleUrl: string; props: EcoPageDataProps }): string {
 	return serializePageDataScript(createEcoPageDataManifestV1(input));
 }

--- a/packages/integrations/react/src/serialize-page-data-script.ts
+++ b/packages/integrations/react/src/serialize-page-data-script.ts
@@ -27,9 +27,9 @@ export function escapePageDataJson(pageProps: EcoPageDataDocumentPayload | undef
  * Emits the canonical `__ECO_PAGE_DATA__` bootstrap script tag.
  *
  * @remarks
- * Prefer {@link serializePageDataManifestScript} for router-enabled documents so
- * clients can discover the page module without parsing hydration JavaScript.
- * Legacy callers may still pass a flat props object.
+ * Accepts a v1 envelope or legacy flat props. Router-enabled documents should
+ * use {@link serializePageDataManifestScript} so clients can discover the page
+ * module without parsing hydration JavaScript.
  */
 export function serializePageDataScript(pageProps: EcoPageDataDocumentPayload | undefined): string {
 	return `<script id="__ECO_PAGE_DATA__" type="application/json">${escapePageDataJson(pageProps)}</script>`;
@@ -37,6 +37,11 @@ export function serializePageDataScript(pageProps: EcoPageDataDocumentPayload | 
 
 /**
  * Emits a versioned page-data envelope for React router documents.
+ *
+ * @remarks
+ * Canonical HTML serializer for router-enabled pages. SPA commit paths that
+ * build a React element instead of an HTML string use
+ * {@link resolvePageDataDocumentPayload} with the same envelope shape.
  */
 export function serializePageDataManifestScript(input: { moduleUrl: string; props: EcoPageDataProps }): string {
 	return serializePageDataScript(createEcoPageDataManifestV1(input));

--- a/packages/integrations/react/src/services/react-page-payload.service.test.ts
+++ b/packages/integrations/react/src/services/react-page-payload.service.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { ReactPagePayloadService } from './react-page-payload.service.ts';
+
+describe('ReactPagePayloadService', () => {
+	it('emits a v1 envelope with flat page props when moduleUrl is provided', () => {
+		const service = new ReactPagePayloadService();
+		const html = service.buildRouterPageDataScript({ slug: 'intro', params: {} }, '/assets/page.js');
+
+		expect(html).toBe(
+			'<script id="__ECO_PAGE_DATA__" type="application/json">{"schemaVersion":1,"navigationOwner":"react-router","moduleUrl":"/assets/page.js","props":{"slug":"intro","params":{}}}</script>',
+		);
+	});
+
+	it('emits legacy flat props when moduleUrl is absent', () => {
+		const service = new ReactPagePayloadService();
+		expect(service.buildRouterPageDataScript({ slug: 'legacy' })).toBe(
+			'<script id="__ECO_PAGE_DATA__" type="application/json">{"slug":"legacy"}</script>',
+		);
+	});
+});

--- a/packages/integrations/react/src/services/react-page-payload.service.ts
+++ b/packages/integrations/react/src/services/react-page-payload.service.ts
@@ -1,7 +1,6 @@
 import { LocalsAccessError } from '@ecopages/core/errors';
 import {
 	resolvePageDataDocumentPayload,
-	serializePageDataManifestScript,
 	serializePageDataScript,
 	type EcoPageDataProps,
 } from '../serialize-page-data-script.ts';
@@ -58,15 +57,7 @@ export class ReactPagePayloadService {
 	 */
 	buildRouterPageDataScript(pageProps: HtmlTemplateProps['pageProps'] | undefined, moduleUrl?: string): string {
 		const props = { ...((pageProps ?? {}) as EcoPageDataProps) };
-
-		if (!moduleUrl) {
-			return serializePageDataScript(resolvePageDataDocumentPayload(props));
-		}
-
-		return serializePageDataManifestScript({
-			moduleUrl,
-			props: resolvePageDataDocumentPayload(props).props as EcoPageDataProps,
-		});
+		return serializePageDataScript(resolvePageDataDocumentPayload(props, { moduleUrl }));
 	}
 
 	/**

--- a/packages/integrations/react/src/services/react-page-payload.service.ts
+++ b/packages/integrations/react/src/services/react-page-payload.service.ts
@@ -1,6 +1,6 @@
 import { LocalsAccessError } from '@ecopages/core/errors';
 import {
-	resolvePageDataDocumentPayload,
+	serializePageDataManifestScript,
 	serializePageDataScript,
 	type EcoPageDataProps,
 } from '../serialize-page-data-script.ts';
@@ -52,12 +52,16 @@ export class ReactPagePayloadService {
 	 * Creates the `__ECO_PAGE_DATA__` script for router hydration.
 	 *
 	 * @remarks
-	 * When `moduleUrl` is present, emits the v1 envelope. Otherwise emits legacy flat props
+	 * When `moduleUrl` is present, emits the v1 envelope via
+	 * {@link serializePageDataManifestScript}. Otherwise emits legacy flat props
 	 * for non-router shells.
 	 */
 	buildRouterPageDataScript(pageProps: HtmlTemplateProps['pageProps'] | undefined, moduleUrl?: string): string {
 		const props = { ...((pageProps ?? {}) as EcoPageDataProps) };
-		return serializePageDataScript(resolvePageDataDocumentPayload(props, { moduleUrl }));
+		if (moduleUrl) {
+			return serializePageDataManifestScript({ moduleUrl, props });
+		}
+		return serializePageDataScript(props);
 	}
 
 	/**

--- a/packages/integrations/react/src/services/react-page-payload.service.ts
+++ b/packages/integrations/react/src/services/react-page-payload.service.ts
@@ -1,11 +1,12 @@
 import { LocalsAccessError } from '@ecopages/core/errors';
 import {
-	ECO_PAGE_MODULE_PROP,
+	resolvePageDataDocumentPayload,
 	serializePageDataManifestScript,
 	serializePageDataScript,
 	type EcoPageDataProps,
 } from '../serialize-page-data-script.ts';
 import type { HtmlTemplateProps, IntegrationRendererRenderOptions, RequestLocals } from '@ecopages/core';
+import type { ProcessedAsset } from '@ecopages/core/services/asset-processing-service';
 import type { ReactNode } from 'react';
 
 type PagePayloadOptions = {
@@ -13,8 +14,9 @@ type PagePayloadOptions = {
 	params: IntegrationRendererRenderOptions<ReactNode>['params'];
 	query: IntegrationRendererRenderOptions<ReactNode>['query'];
 	safeLocals?: RequestLocals;
-	pageModuleUrl?: string;
 };
+
+type PagePackage = IntegrationRendererRenderOptions<ReactNode>['pagePackage'];
 
 /**
  * Builds the serialized page payload React exposes to document shells and the browser.
@@ -25,26 +27,45 @@ type PagePayloadOptions = {
  */
 export class ReactPagePayloadService {
 	/**
+	 * Resolves the browser-importable page module URL from processed page entry assets.
+	 */
+	resolvePageModuleUrl(
+		pagePackage: PagePackage | undefined,
+		options: { routerEnabled: boolean },
+	): string | undefined {
+		if (!options.routerEnabled) {
+			return undefined;
+		}
+
+		const entryScripts =
+			pagePackage?.pageBrowserGraph?.entryAssets.filter(
+				(asset): asset is ProcessedAsset & { srcUrl: string } =>
+					asset.kind === 'script' && typeof asset.srcUrl === 'string',
+			) ?? [];
+		const bootstrapScript = entryScripts.find(
+			(asset) => asset.attributes?.['data-eco-page-bootstrap'] === 'react-router',
+		);
+
+		return bootstrapScript?.srcUrl ?? entryScripts[0]?.srcUrl;
+	}
+
+	/**
 	 * Creates the `__ECO_PAGE_DATA__` script for router hydration.
 	 *
 	 * @remarks
-	 * When `moduleUrl` (or {@link ECO_PAGE_MODULE_PROP} on `pageProps`) is present,
-	 * emits the v1 envelope. Otherwise emits legacy flat props for non-router shells.
-	 * The reserved module key is always stripped from the props object.
+	 * When `moduleUrl` is present, emits the v1 envelope. Otherwise emits legacy flat props
+	 * for non-router shells.
 	 */
 	buildRouterPageDataScript(pageProps: HtmlTemplateProps['pageProps'] | undefined, moduleUrl?: string): string {
 		const props = { ...((pageProps ?? {}) as EcoPageDataProps) };
-		const resolvedModuleUrl =
-			moduleUrl ?? (typeof props[ECO_PAGE_MODULE_PROP] === 'string' ? props[ECO_PAGE_MODULE_PROP] : undefined);
-		delete props[ECO_PAGE_MODULE_PROP];
 
-		if (!resolvedModuleUrl) {
-			return serializePageDataScript(props);
+		if (!moduleUrl) {
+			return serializePageDataScript(resolvePageDataDocumentPayload(props));
 		}
 
 		return serializePageDataManifestScript({
-			module: resolvedModuleUrl,
-			props,
+			moduleUrl,
+			props: resolvePageDataDocumentPayload(props).props as EcoPageDataProps,
 		});
 	}
 
@@ -53,7 +74,8 @@ export class ReactPagePayloadService {
 	 *
 	 * @remarks
 	 * Narrower than the full server render input: only routing data, public page
-	 * props, explicitly allowed locals, and the reserved module transport key.
+	 * props, and explicitly allowed locals. Page module identity is threaded via
+	 * `HtmlTemplateProps.pageModuleUrl`, not serialized page props.
 	 */
 	buildSerializedPageProps(options: PagePayloadOptions): HtmlTemplateProps['pageProps'] {
 		return {
@@ -61,7 +83,6 @@ export class ReactPagePayloadService {
 			params: options.params,
 			query: options.query,
 			...(options.safeLocals && { locals: options.safeLocals }),
-			...(options.pageModuleUrl && { [ECO_PAGE_MODULE_PROP]: options.pageModuleUrl }),
 		};
 	}
 

--- a/packages/integrations/react/src/utils/hydration-scripts.test.browser.ts
+++ b/packages/integrations/react/src/utils/hydration-scripts.test.browser.ts
@@ -167,6 +167,7 @@ describe('createHydrationScript browser execution', () => {
 			isDevelopment: true,
 			isMdx: false,
 			router: routerAdapter,
+			pageDataReaderImportPath: new URL('../page-data-reader.ts', import.meta.url).href,
 		});
 
 		const moduleUrl = createModuleUrl(script);
@@ -247,6 +248,7 @@ describe('createHydrationScript browser execution', () => {
 			isDevelopment: true,
 			isMdx: false,
 			router: routerAdapter,
+			pageDataReaderImportPath: new URL('../page-data-reader.ts', import.meta.url).href,
 		});
 
 		const moduleUrl = createModuleUrl(script);

--- a/packages/integrations/react/src/utils/hydration-scripts.test.ts
+++ b/packages/integrations/react/src/utils/hydration-scripts.test.ts
@@ -92,16 +92,17 @@ describe('createHydrationScript', () => {
 		expect(script).toContain('const currentPageLayoutStack = (Component) =>');
 		expect(script).toContain("layout?.config?.__eco?.file ?? '').join('|')");
 		expect(script).toContain('clearCache: currentPageLayoutStackKey !== nextPageLayoutStackKey');
-		expect(script).toContain('moduleUrl: "/assets/page.js"');
+		expect(script).toContain('moduleUrl: newUrl');
 		expect(script).toContain('const initialPageData = readPageDataDocument();');
 		expect(script).toContain('const props = initialPageData.props;');
 		expect(script).toContain('window.__ECO_PAGES__.page = {');
 		expect(script).toContain('const nextProps = getPageData();');
 		expect(script).toContain('root.render(createTree(NewPage, nextProps));');
 		expect(script).toContain('console.log("[ecopages] React component updated via router");');
-		expect(script).toContain(
-			'import { readPageDataDocument, getPageDataFromDocument as getPageData } from "@ecopages/react/page-data-reader"',
-		);
+		expect(script).toContain('const readPageDataDocument = () => {');
+		expect(script).toContain('parsed.schemaVersion === 1');
+		expect(script).toContain('moduleUrl: parsed.moduleUrl');
+		expect(script).not.toContain('@ecopages/react/page-data-reader');
 		expect(script).toContain('module: initialPageData.moduleUrl || pageModuleUrl');
 		expect(script).not.toContain('__ECO_PAGE_DATA_FALLBACK__');
 	});

--- a/packages/integrations/react/src/utils/hydration-scripts.test.ts
+++ b/packages/integrations/react/src/utils/hydration-scripts.test.ts
@@ -99,7 +99,9 @@ describe('createHydrationScript', () => {
 		expect(script).toContain('const nextProps = getPageData();');
 		expect(script).toContain('root.render(createTree(NewPage, nextProps));');
 		expect(script).toContain('console.log("[ecopages] React component updated via router");');
-		expect(script).toContain('import { readPageDataDocument, getPageDataFromDocument as getPageData } from "@ecopages/react/page-data-reader"');
+		expect(script).toContain(
+			'import { readPageDataDocument, getPageDataFromDocument as getPageData } from "@ecopages/react/page-data-reader"',
+		);
 		expect(script).toContain('module: initialPageData.moduleUrl || pageModuleUrl');
 		expect(script).not.toContain('__ECO_PAGE_DATA_FALLBACK__');
 	});

--- a/packages/integrations/react/src/utils/hydration-scripts.test.ts
+++ b/packages/integrations/react/src/utils/hydration-scripts.test.ts
@@ -57,7 +57,7 @@ describe('createHydrationScript', () => {
 		expect(script).toContain('a.unmount()');
 		expect(script).toContain('window.__ECO_PAGES__?.navigation?.releaseOwnership?.("react-router")');
 		expect(script).toContain(
-			'const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.module||u,props:pr};',
+			'const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};',
 		);
 		expect(script).toContain(
 			'if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}',
@@ -99,8 +99,8 @@ describe('createHydrationScript', () => {
 		expect(script).toContain('const nextProps = getPageData();');
 		expect(script).toContain('root.render(createTree(NewPage, nextProps));');
 		expect(script).toContain('console.log("[ecopages] React component updated via router");');
-		expect(script).toContain('document.getElementById("__ECO_PAGE_DATA__")');
-		expect(script).toContain('module: initialPageData.module || pageModuleUrl');
+		expect(script).toContain('import { readPageDataDocument, getPageDataFromDocument as getPageData } from "@ecopages/react/page-data-reader"');
+		expect(script).toContain('module: initialPageData.moduleUrl || pageModuleUrl');
 		expect(script).not.toContain('__ECO_PAGE_DATA_FALLBACK__');
 	});
 
@@ -130,7 +130,7 @@ describe('createHydrationScript', () => {
 
 		expect(script).toContain('const sr=()=>{');
 		expect(script).toContain(
-			'const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.module||u,props:pr};',
+			'const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};',
 		);
 		expect(script).toContain('if(sr()){root=window.__ECO_PAGES__.react.pageRoot;return}');
 	});
@@ -150,7 +150,7 @@ describe('createHydrationScript', () => {
 		});
 
 		expect(script).toContain('const u="/src/pages/react-notes.react.tsx";');
-		expect(script).toContain('window.__ECO_PAGES__.page={module:pd.module||u,props:pr};');
+		expect(script).toContain('window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};');
 	});
 });
 

--- a/packages/integrations/react/src/utils/hydration-scripts.ts
+++ b/packages/integrations/react/src/utils/hydration-scripts.ts
@@ -8,57 +8,19 @@ import type { ReactRouterAdapter } from '../router-adapter.ts';
 
 const DEFAULT_LAYOUT_COMPOSE_IMPORT_PATH = '@ecopages/react/layout-compose';
 const PAGE_LAYOUT_NORMALIZATION_IMPORT = '@ecopages/core/eco/page-layout-normalization';
+const PAGE_DATA_READER_IMPORT = '@ecopages/react/page-data-reader';
+
+function getDevPageDataReaderImport(): string {
+	return `import { readPageDataDocument, getPageDataFromDocument as getPageData } from "${PAGE_DATA_READER_IMPORT}";`;
+}
+
+function getProdPageDataReaderImport(): string {
+	return `import{readPageDataDocument as rd,getPageDataFromDocument as gd}from"${PAGE_DATA_READER_IMPORT}";`;
+}
 
 function resolveLayoutComposeImportPath(options: HydrationScriptOptions): string {
 	return options.layoutComposeImportPath ?? DEFAULT_LAYOUT_COMPOSE_IMPORT_PATH;
 }
-
-/**
- * Reads `__ECO_PAGE_DATA__`, supporting both v1 envelopes and legacy flat props.
- *
- * @remarks
- * Detection mirrors `isEcoPageDataManifestV1`: require `v === 1`,
- * `navigationOwner === "react-router"`, string `module`, and a non-array object
- * `props`. Near-miss envelopes with a `v` field fall closed to empty props.
- */
-function getDevPageDataReaderScript(): string {
-	return `const readPageDataDocument = () => {
-  const el = document.getElementById("__ECO_PAGE_DATA__");
-  if (el?.textContent) {
-    try {
-      const parsed = JSON.parse(el.textContent);
-      if (
-        parsed &&
-        parsed.v === 1 &&
-        parsed.navigationOwner === "react-router" &&
-        typeof parsed.module === "string" &&
-        parsed.props &&
-        typeof parsed.props === "object" &&
-        !Array.isArray(parsed.props)
-      ) {
-        return { module: parsed.module, props: parsed.props };
-      }
-      if (parsed && typeof parsed === "object" && typeof parsed.v === "number") {
-        return { props: {} };
-      }
-      return { props: parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {} };
-    } catch {}
-  }
-  return { props: {} };
-};
-const getPageData = () => readPageDataDocument().props;`;
-}
-
-/**
- * Minified equivalent of {@link getDevPageDataReaderScript}.
- */
-function getProdPageDataReaderScript(): string {
-	return `const rd=()=>{const e=document.getElementById("__ECO_PAGE_DATA__");if(e?.textContent){try{const p=JSON.parse(e.textContent);if(p&&p.v===1&&p.navigationOwner==="react-router"&&typeof p.module==="string"&&p.props&&typeof p.props==="object"&&!Array.isArray(p.props))return{module:p.module,props:p.props};if(p&&typeof p==="object"&&typeof p.v==="number")return{props:{}};return{props:p&&typeof p==="object"&&!Array.isArray(p)?p:{}}}catch{}}return{props:{}}};const gd=()=>rd().props;`;
-}
-
-/**
- * Options for generating a hydration script.
- */
 export type HydrationScriptOptions = {
 	/** The module path imported by the page entry module. */
 	importPath: string;
@@ -251,6 +213,7 @@ function createDevScriptWithRouter(options: HydrationScriptOptions): string {
 import { hydrateRoot } from "${reactDomClientImportPath}";
 import { createElement } from "${reactImportPath}";
 import { ${components.router}, ${components.pageContent} } from "${routerImportPath}";
+${getDevPageDataReaderImport()}
 ${getImportStatement(importPath, isMdx)}
 const pageModuleUrl = ${pageModuleUrlExpression};
 export default Page;
@@ -268,13 +231,11 @@ ${getDevPageRootCleanupScript()}
 ${getDevRouterBootstrapRegistrationScript()}
 ${getDevReuseExistingRouterRootScript()}
 
-${getDevPageDataReaderScript()}
-
 const initialPageData = readPageDataDocument();
 const props = initialPageData.props;
 
 window.__ECO_PAGES__.page = {
-  module: initialPageData.module || pageModuleUrl,
+  module: initialPageData.moduleUrl || pageModuleUrl,
   props
 };
 
@@ -287,7 +248,7 @@ const mount = () => {
   const pageData = readPageDataDocument();
   const props = pageData.props;
   window.__ECO_PAGES__.page = {
-    module: pageData.module || pageModuleUrl,
+    module: pageData.moduleUrl || pageModuleUrl,
     props
   };
 
@@ -327,7 +288,7 @@ const mount = () => {
 
       const nextPageData = readPageDataDocument();
       window.__ECO_PAGES__.page = {
-        module: nextPageData.module || pageModuleUrl,
+        module: nextPageData.moduleUrl || pageModuleUrl,
         props: nextProps
       };
       root.render(createTree(NewPage, nextProps));
@@ -372,6 +333,7 @@ function createDevScriptWithoutRouter(options: HydrationScriptOptions): string {
 import { hydrateRoot } from "${reactDomClientImportPath}";
 import { createElement } from "${reactImportPath}";
 import { composeLayoutPageTree } from "${layoutComposeImportPath}";
+${getDevPageDataReaderImport()}
 ${getImportStatement(importPath, isMdx)}
 const pageModuleUrl = ${pageModuleUrlExpression};
 export default Page;
@@ -387,13 +349,11 @@ window.__ECO_PAGES__.react.pageRoot = window.__ECO_PAGES__.react.pageRoot || nul
 let root = window.__ECO_PAGES__.react.pageRoot;
 ${getDevPageRootCleanupScript()}
 
-${getDevPageDataReaderScript()}
-
 const initialPageData = readPageDataDocument();
 const props = initialPageData.props;
 
 window.__ECO_PAGES__.page = {
-  module: initialPageData.module || pageModuleUrl,
+  module: initialPageData.moduleUrl || pageModuleUrl,
   props
 };
 
@@ -403,7 +363,7 @@ const mount = () => {
   const pageData = readPageDataDocument();
   const props = pageData.props;
   window.__ECO_PAGES__.page = {
-    module: pageData.module || pageModuleUrl,
+    module: pageData.moduleUrl || pageModuleUrl,
     props
   };
 
@@ -456,10 +416,10 @@ function createProdScriptWithRouter(options: HydrationScriptOptions): string {
 	}
 
 	if (isMdx) {
-		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{${components.router} as R,${components.pageContent} as PC}from"${routerImportPath}";import{ensurePageConfigLayouts as epl}from"${PAGE_LAYOUT_NORMALIZATION_IMPORT}";import*as M from"${importPath}";const P=M.default;if(M.config){P.config=M.config;epl(P.config);}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdRouterBootstrapRegistrationScript()}${getProdReuseExistingRouterRootScript()}${getProdPageDataReaderScript()}const ct=(C,p)=>ce(R,${getRouterProps('C', 'p')},ce(PC));const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.module||u,props:pr};if(sr()){root=window.__ECO_PAGES__.react.pageRoot;return}if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{${components.router} as R,${components.pageContent} as PC}from"${routerImportPath}";import{ensurePageConfigLayouts as epl}from"${PAGE_LAYOUT_NORMALIZATION_IMPORT}";import*as M from"${importPath}";${getProdPageDataReaderImport()}const P=M.default;if(M.config){P.config=M.config;epl(P.config);}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdRouterBootstrapRegistrationScript()}${getProdReuseExistingRouterRootScript()}const ct=(C,p)=>ce(R,${getRouterProps('C', 'p')},ce(PC));const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(sr()){root=window.__ECO_PAGES__.react.pageRoot;return}if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 	}
 
-	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{${components.router} as R,${components.pageContent} as PC}from"${routerImportPath}";import P from"${importPath}";const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdRouterBootstrapRegistrationScript()}${getProdReuseExistingRouterRootScript()}${getProdPageDataReaderScript()}const ct=(C,p)=>ce(R,${getRouterProps('C', 'p')},ce(PC));const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.module||u,props:pr};if(sr()){root=window.__ECO_PAGES__.react.pageRoot;return}if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{${components.router} as R,${components.pageContent} as PC}from"${routerImportPath}";import P from"${importPath}";${getProdPageDataReaderImport()}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdRouterBootstrapRegistrationScript()}${getProdReuseExistingRouterRootScript()}const ct=(C,p)=>ce(R,${getRouterProps('C', 'p')},ce(PC));const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(sr()){root=window.__ECO_PAGES__.react.pageRoot;return}if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 }
 
 /**
@@ -477,10 +437,10 @@ function createProdScriptWithoutRouter(options: HydrationScriptOptions): string 
 	const layoutComposeImportPath = resolveLayoutComposeImportPath(options);
 
 	if (isMdx) {
-		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import{ensurePageConfigLayouts as epl}from"${PAGE_LAYOUT_NORMALIZATION_IMPORT}";import*as M from"${importPath}";const P=M.default;if(M.config){P.config=M.config;epl(P.config);}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdPageDataReaderScript()}const ct=(C,p)=>clp(C,p);const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.module||u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import{ensurePageConfigLayouts as epl}from"${PAGE_LAYOUT_NORMALIZATION_IMPORT}";import*as M from"${importPath}";${getProdPageDataReaderImport()}const P=M.default;if(M.config){P.config=M.config;epl(P.config);}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const ct=(C,p)=>clp(C,p);const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 	}
 
-	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import P from"${importPath}";const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdPageDataReaderScript()}const ct=(C,p)=>clp(C,p);const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.module||u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import P from"${importPath}";${getProdPageDataReaderImport()}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const ct=(C,p)=>clp(C,p);const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 }
 
 /**

--- a/packages/integrations/react/src/utils/hydration-scripts.ts
+++ b/packages/integrations/react/src/utils/hydration-scripts.ts
@@ -5,23 +5,23 @@
  */
 
 import type { ReactRouterAdapter } from '../router-adapter.ts';
+import { getDevPageDataReaderBootstrapSource, getProdPageDataReaderBootstrapSource } from '../page-data-reader.ts';
 
 const DEFAULT_LAYOUT_COMPOSE_IMPORT_PATH = '@ecopages/react/layout-compose';
 const PAGE_LAYOUT_NORMALIZATION_IMPORT = '@ecopages/core/eco/page-layout-normalization';
-const DEFAULT_PAGE_DATA_READER_IMPORT = '@ecopages/react/page-data-reader';
 
-function resolvePageDataReaderImportPath(options: HydrationScriptOptions): string {
-	return options.pageDataReaderImportPath ?? DEFAULT_PAGE_DATA_READER_IMPORT;
+function getDevPageDataReaderSource(options: HydrationScriptOptions): string {
+	if (options.pageDataReaderImportPath) {
+		return `import { readPageDataDocument, getPageDataFromDocument as getPageData } from "${options.pageDataReaderImportPath}";`;
+	}
+	return getDevPageDataReaderBootstrapSource();
 }
 
-function getDevPageDataReaderImport(options: HydrationScriptOptions): string {
-	const importPath = resolvePageDataReaderImportPath(options);
-	return `import { readPageDataDocument, getPageDataFromDocument as getPageData } from "${importPath}";`;
-}
-
-function getProdPageDataReaderImport(options: HydrationScriptOptions): string {
-	const importPath = resolvePageDataReaderImportPath(options);
-	return `import{readPageDataDocument as rd,getPageDataFromDocument as gd}from"${importPath}";`;
+function getProdPageDataReaderSource(options: HydrationScriptOptions): string {
+	if (options.pageDataReaderImportPath) {
+		return `import{readPageDataDocument as rd,getPageDataFromDocument as gd}from"${options.pageDataReaderImportPath}";`;
+	}
+	return getProdPageDataReaderBootstrapSource();
 }
 
 function resolveLayoutComposeImportPath(options: HydrationScriptOptions): string {
@@ -49,11 +49,12 @@ export type HydrationScriptOptions = {
 	/** Import path for shared layout composition helper */
 	layoutComposeImportPath?: string;
 	/**
-	 * Import path for the shared page-data reader.
+	 * Optional import path for the page-data reader.
 	 *
 	 * @remarks
-	 * Defaults to `@ecopages/react/page-data-reader`. Browser unit tests that
-	 * execute generated scripts from `data:` URLs must pass a resolvable URL.
+	 * When omitted, hydration scripts inline the reader so native browser ESM /
+	 * HMR entry evaluation does not depend on bare `@ecopages/react/*` imports.
+	 * Browser unit tests that execute `data:` scripts may still pass a resolvable URL.
 	 */
 	pageDataReaderImportPath?: string;
 };
@@ -227,7 +228,7 @@ function createDevScriptWithRouter(options: HydrationScriptOptions): string {
 import { hydrateRoot } from "${reactDomClientImportPath}";
 import { createElement } from "${reactImportPath}";
 import { ${components.router}, ${components.pageContent} } from "${routerImportPath}";
-${getDevPageDataReaderImport(options)}
+${getDevPageDataReaderSource(options)}
 ${getImportStatement(importPath, isMdx)}
 const pageModuleUrl = ${pageModuleUrlExpression};
 export default Page;
@@ -293,7 +294,7 @@ const mount = () => {
       if (window.__ECO_PAGES__?.navigation?.getOwnerState().owner === "react-router") {
         await window.__ECO_PAGES__?.navigation?.reloadCurrentPage?.({
           clearCache: currentPageLayoutStackKey !== nextPageLayoutStackKey,
-          moduleUrl: "${importPath}",
+          moduleUrl: newUrl,
           source: "react-router"
         });
         console.log("[ecopages] ${getComponentType(isMdx)} component updated via router");
@@ -347,7 +348,7 @@ function createDevScriptWithoutRouter(options: HydrationScriptOptions): string {
 import { hydrateRoot } from "${reactDomClientImportPath}";
 import { createElement } from "${reactImportPath}";
 import { composeLayoutPageTree } from "${layoutComposeImportPath}";
-${getDevPageDataReaderImport(options)}
+${getDevPageDataReaderSource(options)}
 ${getImportStatement(importPath, isMdx)}
 const pageModuleUrl = ${pageModuleUrlExpression};
 export default Page;
@@ -430,10 +431,10 @@ function createProdScriptWithRouter(options: HydrationScriptOptions): string {
 	}
 
 	if (isMdx) {
-		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{${components.router} as R,${components.pageContent} as PC}from"${routerImportPath}";import{ensurePageConfigLayouts as epl}from"${PAGE_LAYOUT_NORMALIZATION_IMPORT}";import*as M from"${importPath}";${getProdPageDataReaderImport(options)}const P=M.default;if(M.config){P.config=M.config;epl(P.config);}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdRouterBootstrapRegistrationScript()}${getProdReuseExistingRouterRootScript()}const ct=(C,p)=>ce(R,${getRouterProps('C', 'p')},ce(PC));const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(sr()){root=window.__ECO_PAGES__.react.pageRoot;return}if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{${components.router} as R,${components.pageContent} as PC}from"${routerImportPath}";import{ensurePageConfigLayouts as epl}from"${PAGE_LAYOUT_NORMALIZATION_IMPORT}";import*as M from"${importPath}";${getProdPageDataReaderSource(options)}const P=M.default;if(M.config){P.config=M.config;epl(P.config);}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdRouterBootstrapRegistrationScript()}${getProdReuseExistingRouterRootScript()}const ct=(C,p)=>ce(R,${getRouterProps('C', 'p')},ce(PC));const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(sr()){root=window.__ECO_PAGES__.react.pageRoot;return}if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 	}
 
-	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{${components.router} as R,${components.pageContent} as PC}from"${routerImportPath}";import P from"${importPath}";${getProdPageDataReaderImport(options)}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdRouterBootstrapRegistrationScript()}${getProdReuseExistingRouterRootScript()}const ct=(C,p)=>ce(R,${getRouterProps('C', 'p')},ce(PC));const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(sr()){root=window.__ECO_PAGES__.react.pageRoot;return}if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{${components.router} as R,${components.pageContent} as PC}from"${routerImportPath}";import P from"${importPath}";${getProdPageDataReaderSource(options)}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdRouterBootstrapRegistrationScript()}${getProdReuseExistingRouterRootScript()}const ct=(C,p)=>ce(R,${getRouterProps('C', 'p')},ce(PC));const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(sr()){root=window.__ECO_PAGES__.react.pageRoot;return}if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 }
 
 /**
@@ -451,10 +452,10 @@ function createProdScriptWithoutRouter(options: HydrationScriptOptions): string 
 	const layoutComposeImportPath = resolveLayoutComposeImportPath(options);
 
 	if (isMdx) {
-		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import{ensurePageConfigLayouts as epl}from"${PAGE_LAYOUT_NORMALIZATION_IMPORT}";import*as M from"${importPath}";${getProdPageDataReaderImport(options)}const P=M.default;if(M.config){P.config=M.config;epl(P.config);}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const ct=(C,p)=>clp(C,p);const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import{ensurePageConfigLayouts as epl}from"${PAGE_LAYOUT_NORMALIZATION_IMPORT}";import*as M from"${importPath}";${getProdPageDataReaderSource(options)}const P=M.default;if(M.config){P.config=M.config;epl(P.config);}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const ct=(C,p)=>clp(C,p);const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 	}
 
-	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import P from"${importPath}";${getProdPageDataReaderImport(options)}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const ct=(C,p)=>clp(C,p);const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import P from"${importPath}";${getProdPageDataReaderSource(options)}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const ct=(C,p)=>clp(C,p);const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 }
 
 /**

--- a/packages/integrations/react/src/utils/hydration-scripts.ts
+++ b/packages/integrations/react/src/utils/hydration-scripts.ts
@@ -8,14 +8,20 @@ import type { ReactRouterAdapter } from '../router-adapter.ts';
 
 const DEFAULT_LAYOUT_COMPOSE_IMPORT_PATH = '@ecopages/react/layout-compose';
 const PAGE_LAYOUT_NORMALIZATION_IMPORT = '@ecopages/core/eco/page-layout-normalization';
-const PAGE_DATA_READER_IMPORT = '@ecopages/react/page-data-reader';
+const DEFAULT_PAGE_DATA_READER_IMPORT = '@ecopages/react/page-data-reader';
 
-function getDevPageDataReaderImport(): string {
-	return `import { readPageDataDocument, getPageDataFromDocument as getPageData } from "${PAGE_DATA_READER_IMPORT}";`;
+function resolvePageDataReaderImportPath(options: HydrationScriptOptions): string {
+	return options.pageDataReaderImportPath ?? DEFAULT_PAGE_DATA_READER_IMPORT;
 }
 
-function getProdPageDataReaderImport(): string {
-	return `import{readPageDataDocument as rd,getPageDataFromDocument as gd}from"${PAGE_DATA_READER_IMPORT}";`;
+function getDevPageDataReaderImport(options: HydrationScriptOptions): string {
+	const importPath = resolvePageDataReaderImportPath(options);
+	return `import { readPageDataDocument, getPageDataFromDocument as getPageData } from "${importPath}";`;
+}
+
+function getProdPageDataReaderImport(options: HydrationScriptOptions): string {
+	const importPath = resolvePageDataReaderImportPath(options);
+	return `import{readPageDataDocument as rd,getPageDataFromDocument as gd}from"${importPath}";`;
 }
 
 function resolveLayoutComposeImportPath(options: HydrationScriptOptions): string {
@@ -42,6 +48,14 @@ export type HydrationScriptOptions = {
 	router?: ReactRouterAdapter;
 	/** Import path for shared layout composition helper */
 	layoutComposeImportPath?: string;
+	/**
+	 * Import path for the shared page-data reader.
+	 *
+	 * @remarks
+	 * Defaults to `@ecopages/react/page-data-reader`. Browser unit tests that
+	 * execute generated scripts from `data:` URLs must pass a resolvable URL.
+	 */
+	pageDataReaderImportPath?: string;
 };
 
 export type IslandHydrationScriptOptions = {
@@ -213,7 +227,7 @@ function createDevScriptWithRouter(options: HydrationScriptOptions): string {
 import { hydrateRoot } from "${reactDomClientImportPath}";
 import { createElement } from "${reactImportPath}";
 import { ${components.router}, ${components.pageContent} } from "${routerImportPath}";
-${getDevPageDataReaderImport()}
+${getDevPageDataReaderImport(options)}
 ${getImportStatement(importPath, isMdx)}
 const pageModuleUrl = ${pageModuleUrlExpression};
 export default Page;
@@ -333,7 +347,7 @@ function createDevScriptWithoutRouter(options: HydrationScriptOptions): string {
 import { hydrateRoot } from "${reactDomClientImportPath}";
 import { createElement } from "${reactImportPath}";
 import { composeLayoutPageTree } from "${layoutComposeImportPath}";
-${getDevPageDataReaderImport()}
+${getDevPageDataReaderImport(options)}
 ${getImportStatement(importPath, isMdx)}
 const pageModuleUrl = ${pageModuleUrlExpression};
 export default Page;
@@ -416,10 +430,10 @@ function createProdScriptWithRouter(options: HydrationScriptOptions): string {
 	}
 
 	if (isMdx) {
-		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{${components.router} as R,${components.pageContent} as PC}from"${routerImportPath}";import{ensurePageConfigLayouts as epl}from"${PAGE_LAYOUT_NORMALIZATION_IMPORT}";import*as M from"${importPath}";${getProdPageDataReaderImport()}const P=M.default;if(M.config){P.config=M.config;epl(P.config);}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdRouterBootstrapRegistrationScript()}${getProdReuseExistingRouterRootScript()}const ct=(C,p)=>ce(R,${getRouterProps('C', 'p')},ce(PC));const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(sr()){root=window.__ECO_PAGES__.react.pageRoot;return}if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{${components.router} as R,${components.pageContent} as PC}from"${routerImportPath}";import{ensurePageConfigLayouts as epl}from"${PAGE_LAYOUT_NORMALIZATION_IMPORT}";import*as M from"${importPath}";${getProdPageDataReaderImport(options)}const P=M.default;if(M.config){P.config=M.config;epl(P.config);}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdRouterBootstrapRegistrationScript()}${getProdReuseExistingRouterRootScript()}const ct=(C,p)=>ce(R,${getRouterProps('C', 'p')},ce(PC));const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(sr()){root=window.__ECO_PAGES__.react.pageRoot;return}if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 	}
 
-	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{${components.router} as R,${components.pageContent} as PC}from"${routerImportPath}";import P from"${importPath}";${getProdPageDataReaderImport()}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdRouterBootstrapRegistrationScript()}${getProdReuseExistingRouterRootScript()}const ct=(C,p)=>ce(R,${getRouterProps('C', 'p')},ce(PC));const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(sr()){root=window.__ECO_PAGES__.react.pageRoot;return}if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{${components.router} as R,${components.pageContent} as PC}from"${routerImportPath}";import P from"${importPath}";${getProdPageDataReaderImport(options)}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}${getProdRouterBootstrapRegistrationScript()}${getProdReuseExistingRouterRootScript()}const ct=(C,p)=>ce(R,${getRouterProps('C', 'p')},ce(PC));const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(sr()){root=window.__ECO_PAGES__.react.pageRoot;return}if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 }
 
 /**
@@ -437,10 +451,10 @@ function createProdScriptWithoutRouter(options: HydrationScriptOptions): string 
 	const layoutComposeImportPath = resolveLayoutComposeImportPath(options);
 
 	if (isMdx) {
-		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import{ensurePageConfigLayouts as epl}from"${PAGE_LAYOUT_NORMALIZATION_IMPORT}";import*as M from"${importPath}";${getProdPageDataReaderImport()}const P=M.default;if(M.config){P.config=M.config;epl(P.config);}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const ct=(C,p)=>clp(C,p);const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+		return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import{ensurePageConfigLayouts as epl}from"${PAGE_LAYOUT_NORMALIZATION_IMPORT}";import*as M from"${importPath}";${getProdPageDataReaderImport(options)}const P=M.default;if(M.config){P.config=M.config;epl(P.config);}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const ct=(C,p)=>clp(C,p);const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 	}
 
-	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import P from"${importPath}";${getProdPageDataReaderImport()}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const ct=(C,p)=>clp(C,p);const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
+	return `import{hydrateRoot as hr}from"${reactDomClientImportPath}";import{createElement as ce}from"${reactImportPath}";import{composeLayoutPageTree as clp}from"${layoutComposeImportPath}";import P from"${importPath}";${getProdPageDataReaderImport(options)}const u=${pageModuleUrlExpression};export default P;export const config=P.config;const a=!!document.querySelector('script[data-eco-script-id="${scriptId}"]');if(a){window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.react=window.__ECO_PAGES__.react||{};window.__ECO_PAGES__.react.pageRoot=window.__ECO_PAGES__.react.pageRoot||null;let root=window.__ECO_PAGES__.react.pageRoot;${getProdPageRootCleanupScript()}const ct=(C,p)=>clp(C,p);const m=()=>{const pd=rd();const pr=pd.props;window.__ECO_PAGES__.page={module:pd.moduleUrl||u,props:pr};if(window.__ECO_PAGES__.react?.pageRoot){root=window.__ECO_PAGES__.react.pageRoot;root.render(ct(P,pr));return}root=hr(document.body,ct(P,pr),{onRecoverableError:(e)=>console.warn("[ecopages] Hydration error:",e)});window.__ECO_PAGES__.react.pageRoot=root};${getProdRerunRegistrationScript(scriptId)}document.readyState==="loading"?document.addEventListener("DOMContentLoaded",m):m()}`;
 }
 
 /**

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -199,9 +199,11 @@ The router relies on **HTML-First** navigation to sync perfectly with SSR:
 
 1. **SSR**: Initial page arrives completely rendered.
 2. **Hydration**: Client hydrates and the router attaches.
-3. **Navigation**: On click, the router:
+3. **Navigation**: On click, the router resolves an explicit outcome (`spa`, `handoff`, `hard-navigation`, or `stale`), then:
     - Fetches the raw HTML of the next route.
     - Extracts page-level serialized props and metadata from `#__ECO_PAGE_DATA__`.
     - Preloads the next page component via dynamic import of `moduleUrl`.
+    - Commits head/history/React state for SPA outcomes, or hands off to browser-router.
+    - Clears `isNavigating` on every non-stale terminal, including handoff and hard fallback.
     - Updates React state, syncs `<head>`, and triggers `startViewTransition`.
     - The React graph reconciles and the animation plays.

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -179,7 +179,7 @@ render: ({ children, metadata, headContent, language = 'en', pageProps, pageModu
 	<html lang={language}>
 		<head>
 			{/* … */}
-			<EcoPropsScript data={pageProps} module={pageModuleUrl} />
+			<EcoPropsScript data={pageProps} moduleUrl={pageModuleUrl} />
 		</head>
 		<body>{children}</body>
 	</html>
@@ -188,9 +188,10 @@ render: ({ children, metadata, headContent, language = 'en', pageProps, pageModu
 
 Important:
 
-- Hydration uses `props` only. `moduleUrl` is for navigation module discovery.
-- `pageModuleUrl` on `HtmlTemplateProps` is transport-only; it is not page component state.
-- When the envelope is absent, the router may still use `window.__ECO_PAGES__.page.module` or `script[data-eco-page-bootstrap="react-router"]` `src`.
+- Hydration uses envelope `props` only. Envelope `moduleUrl` is for navigation module discovery.
+- Pass `HtmlTemplateProps.pageModuleUrl` into `<EcoPropsScript moduleUrl={...} />`.
+- `pageModuleUrl` is transport-only; it is not page component state.
+- When `#__ECO_PAGE_DATA__` yields no valid envelope `moduleUrl`, discovery falls back to `window.__ECO_PAGES__.page.module`, then `script[data-eco-page-bootstrap="react-router"]` `src`.
 - HMR reloads can pass an explicit `moduleUrlOverride` and bypass document discovery.
 
 ## How It Works
@@ -199,11 +200,9 @@ The router relies on **HTML-First** navigation to sync perfectly with SSR:
 
 1. **SSR**: Initial page arrives completely rendered.
 2. **Hydration**: Client hydrates and the router attaches.
-3. **Navigation**: On click, the router resolves an explicit outcome (`spa`, `handoff`, `hard-navigation`, or `stale`), then:
-    - Fetches the raw HTML of the next route.
-    - Extracts page-level serialized props and metadata from `#__ECO_PAGE_DATA__`.
-    - Preloads the next page component via dynamic import of `moduleUrl`.
-    - Commits head/history/React state for SPA outcomes, or hands off to browser-router.
-    - Clears `isNavigating` on every non-stale terminal, including handoff and hard fallback.
-    - Updates React state, syncs `<head>`, and triggers `startViewTransition`.
-    - The React graph reconciles and the animation plays.
+3. **Navigation**: On click, `resolveReactNavigation` returns an explicit outcome:
+    - `spa`: fetch HTML → read `#__ECO_PAGE_DATA__` → dynamic-import `moduleUrl` → morph `<head>`, update history, commit React state (optional `startViewTransition`).
+    - `handoff`: fetched document has no React page module → coordinator hands off to browser-router (hard `assign` if handoff fails).
+    - `hard-navigation`: static-asset URL or failed fetch → `location.assign` / `location.href`.
+    - `stale`: a newer navigation superseded this attempt.
+    - `isNavigating` clears on every non-stale terminal (including handoff and hard fallback); stale attempts leave it for the newer owner.

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -155,6 +155,44 @@ By default, we impose a "clean morph", disabling default cross-fade ghosting. To
 </div>
 ```
 
+## Page data protocol
+
+Router-enabled documents emit a JSON script that SPA navigation reads without parsing hydration JavaScript:
+
+```html
+<script id="__ECO_PAGE_DATA__" type="application/json">
+	{
+		"schemaVersion": 1,
+		"navigationOwner": "react-router",
+		"moduleUrl": "/assets/pages/about.js",
+		"props": { "params": {}, "query": {} }
+	}
+</script>
+```
+
+In a React HTML shell, pass the transport field explicitly:
+
+```tsx
+import { EcoPropsScript } from '@ecopages/react-router';
+
+render: ({ children, metadata, headContent, language = 'en', pageProps, pageModuleUrl }) => (
+	<html lang={language}>
+		<head>
+			{/* … */}
+			<EcoPropsScript data={pageProps} module={pageModuleUrl} />
+		</head>
+		<body>{children}</body>
+	</html>
+);
+```
+
+Important:
+
+- Hydration uses `props` only. `moduleUrl` is for navigation module discovery.
+- `pageModuleUrl` on `HtmlTemplateProps` is transport-only; it is not page component state.
+- When the envelope is absent, the router may still use `window.__ECO_PAGES__.page.module` or `script[data-eco-page-bootstrap="react-router"]` `src`.
+- HMR reloads can pass an explicit `moduleUrlOverride` and bypass document discovery.
+
 ## How It Works
 
 The router relies on **HTML-First** navigation to sync perfectly with SSR:
@@ -163,7 +201,7 @@ The router relies on **HTML-First** navigation to sync perfectly with SSR:
 2. **Hydration**: Client hydrates and the router attaches.
 3. **Navigation**: On click, the router:
     - Fetches the raw HTML of the next route.
-    - Extracts page-level serialized props and metadata.
-    - Preloads the next page component via dynamic import.
+    - Extracts page-level serialized props and metadata from `#__ECO_PAGE_DATA__`.
+    - Preloads the next page component via dynamic import of `moduleUrl`.
     - Updates React state, syncs `<head>`, and triggers `startViewTransition`.
     - The React graph reconciles and the animation plays.

--- a/packages/react-router/src/hydration-assets.ts
+++ b/packages/react-router/src/hydration-assets.ts
@@ -8,17 +8,3 @@ function isReactPageAssetName(src: string): boolean {
 export function isReactRouterPageBootstrapAssetSrc(src: string): boolean {
 	return isReactPageAssetName(src) && !src.includes('ecopages-react-island-');
 }
-
-/**
- * Returns whether a script URL follows the legacy React hydration asset naming pattern.
- */
-export function isReactHydrationAssetSrc(src: string): boolean {
-	return isReactPageAssetName(src) && src.includes('hydration.js');
-}
-
-/**
- * Returns whether a script URL should be treated as the page module source during router navigation.
- */
-export function isReactPageHydrationAssetSrc(src: string): boolean {
-	return isReactRouterPageBootstrapAssetSrc(src);
-}

--- a/packages/react-router/src/navigation-orchestrator.test.ts
+++ b/packages/react-router/src/navigation-orchestrator.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { decideQueuedNavigationReplay } from '../src/navigation-orchestrator.ts';
+
+describe('decideQueuedNavigationReplay', () => {
+	it('skips when there is no queued href', () => {
+		expect(
+			decideQueuedNavigationReplay({
+				queuedHref: null,
+				committedPath: '/a',
+				runtimeActive: true,
+			}),
+		).toEqual({ kind: 'none' });
+	});
+
+	it('skips when the queued path already matches the committed path', () => {
+		expect(
+			decideQueuedNavigationReplay({
+				queuedHref: '/a?x=1',
+				committedPath: '/a?x=1',
+				runtimeActive: true,
+			}),
+		).toEqual({ kind: 'none' });
+	});
+
+	it('replays locally while React still owns the runtime', () => {
+		expect(
+			decideQueuedNavigationReplay({
+				queuedHref: '/b',
+				committedPath: '/a',
+				runtimeActive: true,
+			}),
+		).toEqual({ kind: 'local-navigate', href: '/b' });
+	});
+
+	it('replays through the coordinator after cleanup-before-handoff', () => {
+		expect(
+			decideQueuedNavigationReplay({
+				queuedHref: '/b',
+				committedPath: '/a',
+				runtimeActive: false,
+			}),
+		).toEqual({ kind: 'coordinator-navigate', href: '/b' });
+	});
+});

--- a/packages/react-router/src/navigation-orchestrator.ts
+++ b/packages/react-router/src/navigation-orchestrator.ts
@@ -1,0 +1,276 @@
+/**
+ * Explicit React-router navigation outcomes and commit ordering.
+ *
+ * @remarks
+ * Resolution (fetch → module load → spa | handoff | hard) is pure relative to
+ * DOM/React side effects. The EcoRouter bridge supplies those effects and keeps
+ * `isNavigating` consistent from the returned outcome terminals.
+ *
+ * @module
+ */
+
+import { isStaticAssetHref } from '@ecopages/core/router/link-intent';
+import {
+	type FetchedPageDocument,
+	type LoadedPageModule,
+	fetchPageDocument,
+	loadPageModuleFromDocument,
+} from './navigation.ts';
+
+export type NavigationDirection = 'back' | 'forward' | 'replace';
+
+/**
+ * Terminal decision for one navigate() attempt before React/DOM commit.
+ */
+export type ReactNavigationOutcome =
+	| { kind: 'stale' }
+	| { kind: 'hard-navigation'; href: string; mode: 'assign' | 'location' }
+	| {
+			kind: 'spa';
+			page: LoadedPageModule;
+			direction: NavigationDirection;
+			refreshPersistedLayout: boolean;
+			requestedUrl: string;
+	  }
+	| {
+			kind: 'handoff';
+			href: string;
+			fetched: FetchedPageDocument;
+			direction: NavigationDirection;
+	  };
+
+export type ResolveReactNavigationInput = {
+	url: string;
+	signal: AbortSignal;
+	isStale: () => boolean;
+	isPopState: boolean;
+	pushHistory: boolean;
+	moduleUrlOverride?: string;
+};
+
+export type SpaCommitEffects = {
+	isStale: () => boolean;
+	morphHead: (doc: Document) => Promise<{ cleanup: () => void; flushRerunScripts: () => void }>;
+	applyViewTransitionNames: () => void;
+	saveScrollPositions: () => void;
+	restoreScrollPositions: (finalPath: string, isPopState: boolean) => void;
+	updateHistory: (finalPath: string, requestedUrl: string, direction: NavigationDirection) => void;
+	commitPageData: (moduleUrl: string, props: Record<string, unknown>) => void;
+	setCurrentPage: (page: { Component: LoadedPageModule['Component']; props: Record<string, unknown>; refreshPersistedLayout: boolean }) => void;
+	waitForRender: (page: {
+		Component: LoadedPageModule['Component'];
+		props: Record<string, unknown>;
+		refreshPersistedLayout: boolean;
+	}) => Promise<void>;
+	runInReactTransition: (update: () => void) => void;
+	startViewTransition?: (update: () => Promise<void>) => Promise<void>;
+	onCommittedPath: (finalPath: string) => void;
+};
+
+export type SpaCommitResult = 'committed' | 'stale';
+
+export type HandoffEffects = {
+	isStale: () => boolean;
+	requestHandoff: (request: {
+		href: string;
+		finalHref: string;
+		direction: NavigationDirection;
+		document: Document;
+		html: string;
+		isStaleSourceNavigation: () => boolean;
+	}) => Promise<boolean>;
+	hardAssign: (href: string) => void;
+};
+
+export type HandoffResult = 'handed-off' | 'hard-fallback' | 'stale';
+
+export type QueueReplayDecision =
+	| { kind: 'none' }
+	| { kind: 'local-navigate'; href: string }
+	| { kind: 'coordinator-navigate'; href: string };
+
+function resolveDirection(isPopState: boolean, pushHistory: boolean): NavigationDirection {
+	if (isPopState) {
+		return 'back';
+	}
+	return pushHistory ? 'forward' : 'replace';
+}
+
+/**
+ * Resolves fetch + module discovery into an explicit navigation outcome.
+ */
+export async function resolveReactNavigation(
+	input: ResolveReactNavigationInput,
+): Promise<ReactNavigationOutcome> {
+	if (isStaticAssetHref(input.url)) {
+		return {
+			kind: 'hard-navigation',
+			href: new URL(input.url, window.location.origin).href,
+			mode: 'assign',
+		};
+	}
+
+	const fetchedPage = await fetchPageDocument(input.url, { signal: input.signal });
+	if (input.isStale()) {
+		return { kind: 'stale' };
+	}
+
+	if (!fetchedPage) {
+		return { kind: 'hard-navigation', href: input.url, mode: 'location' };
+	}
+
+	const page = await loadPageModuleFromDocument(fetchedPage.doc, fetchedPage.finalPath, {
+		moduleUrlOverride: input.moduleUrlOverride,
+	});
+	if (input.isStale()) {
+		return { kind: 'stale' };
+	}
+
+	const direction = resolveDirection(input.isPopState, input.pushHistory);
+
+	if (page) {
+		return {
+			kind: 'spa',
+			page,
+			direction,
+			refreshPersistedLayout: Boolean(input.moduleUrlOverride),
+			requestedUrl: input.url,
+		};
+	}
+
+	return {
+		kind: 'handoff',
+		href: input.url,
+		fetched: fetchedPage,
+		direction,
+	};
+}
+
+/**
+ * Applies SPA commit ordering: head morph → history → React commit → finalize.
+ *
+ * @remarks
+ * View transitions wrap the React commit when `startViewTransition` is provided.
+ * Stale checks after async boundaries abort without leaving head morph half-applied.
+ */
+export async function applySpaNavigation(
+	outcome: Extract<ReactNavigationOutcome, { kind: 'spa' }>,
+	effects: SpaCommitEffects,
+	options: { skipViewTransition: boolean; isPopState: boolean },
+): Promise<SpaCommitResult> {
+	const { page, requestedUrl, refreshPersistedLayout } = outcome;
+	const nextPage = {
+		Component: page.Component,
+		props: page.props,
+		refreshPersistedLayout,
+	};
+	const { cleanup: cleanupHead, flushRerunScripts } = await effects.morphHead(page.doc);
+
+	const finalizeCommittedNavigation = () => {
+		effects.onCommittedPath(page.finalPath);
+		flushRerunScripts();
+		cleanupHead();
+		effects.applyViewTransitionNames();
+		effects.restoreScrollPositions(page.finalPath, options.isPopState);
+	};
+
+	const commitNextPage = () => {
+		effects.commitPageData(page.moduleUrl, page.props);
+		effects.setCurrentPage(nextPage);
+	};
+
+	if (effects.isStale()) {
+		cleanupHead();
+		return 'stale';
+	}
+
+	effects.applyViewTransitionNames();
+	effects.saveScrollPositions();
+	effects.updateHistory(page.finalPath, requestedUrl, outcome.direction);
+
+	if (!options.skipViewTransition && effects.startViewTransition) {
+		await effects.startViewTransition(async () => {
+			if (effects.isStale()) {
+				cleanupHead();
+				return;
+			}
+			const renderPromise = effects.waitForRender(nextPage);
+			effects.runInReactTransition(() => {
+				commitNextPage();
+			});
+			await renderPromise;
+			if (effects.isStale()) {
+				return;
+			}
+			finalizeCommittedNavigation();
+		});
+		return effects.isStale() ? 'stale' : 'committed';
+	}
+
+	const renderPromise = effects.waitForRender(nextPage);
+	commitNextPage();
+	await renderPromise;
+	if (effects.isStale()) {
+		cleanupHead();
+		return 'stale';
+	}
+	finalizeCommittedNavigation();
+	return 'committed';
+}
+
+/**
+ * Hands a non-React document to the shared coordinator, or hard-navigates.
+ */
+export async function applyHandoffNavigation(
+	outcome: Extract<ReactNavigationOutcome, { kind: 'handoff' }>,
+	effects: HandoffEffects,
+): Promise<HandoffResult> {
+	if (effects.isStale()) {
+		return 'stale';
+	}
+
+	const handled = await effects.requestHandoff({
+		href: outcome.href,
+		finalHref: outcome.fetched.finalPath,
+		direction: outcome.direction,
+		document: outcome.fetched.doc,
+		html: outcome.fetched.html,
+		isStaleSourceNavigation: effects.isStale,
+	});
+
+	if (!handled) {
+		effects.hardAssign(outcome.fetched.finalPath);
+		return 'hard-fallback';
+	}
+
+	return 'handed-off';
+}
+
+/**
+ * Decides whether a queued click should replay after the active navigation ends.
+ *
+ * @remarks
+ * When React still owns the runtime, replay through local `navigate`. After a
+ * cleanup-before-handoff, replay through the shared coordinator so the newest
+ * owner receives the intent.
+ */
+export function decideQueuedNavigationReplay(input: {
+	queuedHref: string | null;
+	committedPath: string;
+	runtimeActive: boolean;
+}): QueueReplayDecision {
+	if (!input.queuedHref) {
+		return { kind: 'none' };
+	}
+
+	const queuedUrl = new URL(input.queuedHref, 'http://ecopages.local');
+	const queuedPath = queuedUrl.pathname + queuedUrl.search;
+
+	if (queuedPath === input.committedPath) {
+		return { kind: 'none' };
+	}
+
+	return input.runtimeActive
+		? { kind: 'local-navigate', href: input.queuedHref }
+		: { kind: 'coordinator-navigate', href: input.queuedHref };
+}

--- a/packages/react-router/src/navigation-orchestrator.ts
+++ b/packages/react-router/src/navigation-orchestrator.ts
@@ -56,7 +56,11 @@ export type SpaCommitEffects = {
 	restoreScrollPositions: (finalPath: string, isPopState: boolean) => void;
 	updateHistory: (finalPath: string, requestedUrl: string, direction: NavigationDirection) => void;
 	commitPageData: (moduleUrl: string, props: Record<string, unknown>) => void;
-	setCurrentPage: (page: { Component: LoadedPageModule['Component']; props: Record<string, unknown>; refreshPersistedLayout: boolean }) => void;
+	setCurrentPage: (page: {
+		Component: LoadedPageModule['Component'];
+		props: Record<string, unknown>;
+		refreshPersistedLayout: boolean;
+	}) => void;
 	waitForRender: (page: {
 		Component: LoadedPageModule['Component'];
 		props: Record<string, unknown>;
@@ -85,9 +89,7 @@ export type HandoffEffects = {
 export type HandoffResult = 'handed-off' | 'hard-fallback' | 'stale';
 
 export type QueueReplayDecision =
-	| { kind: 'none' }
-	| { kind: 'local-navigate'; href: string }
-	| { kind: 'coordinator-navigate'; href: string };
+	{ kind: 'none' } | { kind: 'local-navigate'; href: string } | { kind: 'coordinator-navigate'; href: string };
 
 function resolveDirection(isPopState: boolean, pushHistory: boolean): NavigationDirection {
 	if (isPopState) {
@@ -99,9 +101,7 @@ function resolveDirection(isPopState: boolean, pushHistory: boolean): Navigation
 /**
  * Resolves fetch + module discovery into an explicit navigation outcome.
  */
-export async function resolveReactNavigation(
-	input: ResolveReactNavigationInput,
-): Promise<ReactNavigationOutcome> {
+export async function resolveReactNavigation(input: ResolveReactNavigationInput): Promise<ReactNavigationOutcome> {
 	if (isStaticAssetHref(input.url)) {
 		return {
 			kind: 'hard-navigation',
@@ -200,6 +200,7 @@ export async function applySpaNavigation(
 			});
 			await renderPromise;
 			if (effects.isStale()) {
+				cleanupHead();
 				return;
 			}
 			finalizeCommittedNavigation();

--- a/packages/react-router/src/navigation.ts
+++ b/packages/react-router/src/navigation.ts
@@ -11,9 +11,10 @@ import { ensurePageConfigLayouts } from '@ecopages/core/eco/page-layout-normaliz
 import type { EcoComponentConfig } from '@ecopages/core';
 import { resolveEcoPageDataModuleUrl, resolveEcoPageDataProps } from '@ecopages/react/serialize-page-data-script';
 import { type ComponentType } from 'react';
-import { isReactPageHydrationAssetSrc } from './hydration-assets.ts';
 
 const ROUTER_PROPS_SCRIPT_ID = '__ECO_PAGE_DATA__';
+const PAGE_BOOTSTRAP_SELECTOR = 'script[data-eco-page-bootstrap="react-router"]';
+
 type PageProps = Record<string, unknown>;
 type NavigablePageComponent = ComponentType<PageProps> & { config?: EcoComponentConfig };
 
@@ -43,7 +44,7 @@ type LoadPageModuleOptions = {
 type LoadPageModuleFromDocumentOptions = {
 	/**
 	 * Explicit page module URL to import instead of extracting one from the
-	 * document's hydration assets.
+	 * document page-data payload.
 	 *
 	 * React Router uses this during HMR-driven reloads so the active hot module
 	 * entry wins over any static bootstrap asset references embedded in the HTML.
@@ -52,9 +53,7 @@ type LoadPageModuleFromDocumentOptions = {
 };
 
 /**
- * Extracts component module URL from window.__ECO_PAGES__.page.
- * For current document, returns the module path set by hydration script.
- * For fetched documents, parses the hydration script to extract the module path.
+ * Reads the runtime page-module marker set by hydration for the current document.
  */
 function extractComponentUrlFromMarker(doc: Document): string | null {
 	if (doc === document && window.__ECO_PAGES__?.page?.module) {
@@ -77,55 +76,12 @@ function parsePageDataPayload(doc: Document): unknown {
 	}
 }
 
-const PAGE_BOOTSTRAP_SELECTOR = 'script[data-eco-page-bootstrap="react-router"]';
-
-/**
- * @deprecated
- * Regex-based hydration script discovery for one compatibility release. Prefer the
- * v1 `__ECO_PAGE_DATA__` envelope (`schemaVersion` + `moduleUrl`). Remove once all
- * producers emit the manifest.
- */
-function deprecatedExtractModuleUrlFromHydrationScriptCode(code: string, fallbackUrl?: string): string | null {
-	/** Matches default import: `import Content from './Content'` */
-	const defaultImportRegex = /import\s+(\w+)\s+from\s*['"]([^'"]+)['"]/;
-	/** Matches namespace import: `import * as Content from './Content'` */
-	const namespaceImportRegex = /import\s*\*\s*as\s*(\w+)\s*from\s*['"]([^'"]+)['"]/;
-	const pageModuleMarkerRegex = /__ECO_PAGES__\.page\s*=\s*\{\s*module\s*:\s*['"]([^'"]+)['"]/;
-	const pageModuleIdentifierRegex = /__ECO_PAGES__\.page\s*=\s*\{\s*module\s*:\s*([A-Za-z_$][\w$]*)\s*,/;
-
-	const markerMatch = code.match(pageModuleMarkerRegex);
-	if (markerMatch) {
-		return markerMatch[1] ?? null;
-	}
-
-	const moduleIdentifier = code.match(pageModuleIdentifierRegex)?.[1];
-	if (moduleIdentifier) {
-		const assignmentRegex = new RegExp(
-			`(?:const|let|var)[^;]*\\b${moduleIdentifier}\\s*=\\s*(?:['"]([^'"]+)['"]|(import\\.meta\\.url))`,
-		);
-		const assignmentMatch = code.match(assignmentRegex);
-		if (assignmentMatch?.[1]) {
-			return assignmentMatch[1];
-		}
-
-		if (fallbackUrl && assignmentMatch?.[2]) {
-			return fallbackUrl;
-		}
-	}
-
-	if (fallbackUrl && code.includes('module:import.meta.url')) {
-		return fallbackUrl;
-	}
-
-	const defaultMatch = code.match(defaultImportRegex);
-	const namespaceMatch = code.match(namespaceImportRegex);
-	return (defaultMatch || namespaceMatch)?.[2] ?? null;
-}
-
 /**
  * Extracts serialized page props from window.__ECO_PAGES__.page or fetched document.
- * For current document, returns props set by hydration script.
- * For fetched documents, parses the JSON script tag directly.
+ *
+ * @remarks
+ * For the current document, returns props set by the hydration script.
+ * For fetched documents, parses `#__ECO_PAGE_DATA__` directly.
  */
 export function extractProps(doc: Document): PageProps {
 	if (doc === document && window.__ECO_PAGES__?.page?.props) {
@@ -142,6 +98,7 @@ function isReactRouteDocument(doc: Document): boolean {
 /**
  * Adds cache-busting timestamp for HMR in development.
  *
+ * @remarks
  * Prevents loading stale cached modules when navigating to previously visited pages.
  * Disabled in production where filenames have content hashes.
  */
@@ -154,51 +111,30 @@ function addCacheBuster(url: string): string {
 }
 
 /**
- * Extracts component module URL using multi-tier strategy.
- *
- * 1. Read the v1 page-data envelope (`schemaVersion` + `moduleUrl`)
- * 2. Read bootstrap/page markers on the current document
- * 3. Fall back to {@link deprecatedExtractModuleUrlFromHydrationScriptCode} for one release
+ * Extracts the browser-importable page module URL from a document.
  *
  * @remarks
- * EcoRouter transition-state extraction remains a separate follow-up. This
- * module only owns document → module/props discovery for React navigation.
+ * Discovery order:
+ * 1. `#__ECO_PAGE_DATA__` envelope (`schemaVersion` + `moduleUrl`)
+ * 2. `window.__ECO_PAGES__.page.module` on the current document
+ * 3. `script[data-eco-page-bootstrap="react-router"]` `src` (the page entry asset)
+ *
+ * Hydration JavaScript is never parsed. Documents without an explicit module
+ * source return `null`.
  */
 export async function extractComponentUrl(doc: Document): Promise<string | null> {
 	const manifestUrl = resolveEcoPageDataModuleUrl(parsePageDataPayload(doc));
-	if (manifestUrl) return manifestUrl;
+	if (manifestUrl) {
+		return manifestUrl;
+	}
 
 	const markerUrl = extractComponentUrlFromMarker(doc);
-	if (markerUrl) return markerUrl;
-
-	const scripts = Array.from(doc.querySelectorAll('script'));
-
-	const inlineHydrationScript = scripts.find(
-		(s) =>
-			!s.src &&
-			!!s.textContent &&
-			s.textContent.includes('__ECO_PAGES__') &&
-			s.textContent.includes('hydrateRoot') &&
-			s.textContent.includes('import'),
-	);
-
-	if (inlineHydrationScript?.textContent) {
-		return deprecatedExtractModuleUrlFromHydrationScriptCode(inlineHydrationScript.textContent);
+	if (markerUrl) {
+		return markerUrl;
 	}
 
-	const hydrationScript =
-		doc.querySelector<HTMLScriptElement>(PAGE_BOOTSTRAP_SELECTOR) ??
-		scripts.find((s) => isReactPageHydrationAssetSrc(s.src ?? ''));
-	if (!hydrationScript?.src) return null;
-
-	try {
-		const scriptUrl = addCacheBuster(hydrationScript.src);
-		const res = await fetch(scriptUrl);
-		const code = await res.text();
-		return deprecatedExtractModuleUrlFromHydrationScriptCode(code, hydrationScript.src);
-	} catch {
-		return null;
-	}
+	const bootstrapScript = doc.querySelector<HTMLScriptElement>(PAGE_BOOTSTRAP_SELECTOR);
+	return bootstrapScript?.src || null;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -239,13 +175,9 @@ function adaptPageModule(moduleNamespace: unknown): NavigablePageComponent | nul
 /**
  * Fetches and parses a page, returning its component, props, and document.
  *
- * Flow: Fetch HTML → Parse → Extract props → Extract component URL → Import module
- *
- * Handles multiple export patterns (Content, default.Content, default) for different
- * integration setups. Does NOT update DOM - caller applies changes.
- *
- * @param url - The URL to load
- * @returns Object with Component, props, doc, and finalPath, or null on error
+ * @remarks
+ * Flow: fetch HTML → parse → extract props → extract module URL → import module.
+ * Does not update the DOM; the caller applies changes.
  */
 export async function loadPageModule(
 	url: string,
@@ -293,16 +225,11 @@ export async function fetchPageDocument(
 /**
  * Loads the page module for a fetched or current document.
  *
- * The router normally extracts the page module URL from the document's
- * hydration assets. Callers can provide `options.moduleUrlOverride` when the
+ * @remarks
+ * The router extracts the page module URL from the document page-data payload or
+ * bootstrap marker. Callers can provide `options.moduleUrlOverride` when the
  * document is stale with respect to the active runtime module identity, such as
  * during HMR-driven current-page reloads.
- *
- * @param doc - Parsed destination document.
- * @param finalPath - Final route path after redirects.
- * @param options - Module loading overrides.
- * @returns Loaded page module payload or `null` when the document is not a
- * React-router page or no page component can be resolved.
  */
 export async function loadPageModuleFromDocument(
 	doc: Document,

--- a/packages/react-router/src/navigation.ts
+++ b/packages/react-router/src/navigation.ts
@@ -131,7 +131,7 @@ function addCacheBuster(url: string): string {
  * Hydration JavaScript is never parsed. Documents without an explicit module
  * source return `null`.
  */
-export async function extractComponentUrl(doc: Document): Promise<string | null> {
+export function extractComponentUrl(doc: Document): string | null {
 	const manifestUrl = resolveEcoPageDataModuleUrl(parsePageDataPayload(doc));
 	if (manifestUrl) {
 		return manifestUrl;
@@ -256,7 +256,7 @@ export async function loadPageModuleFromDocument(
 	options: LoadPageModuleFromDocumentOptions = {},
 ): Promise<LoadedPageModule | null> {
 	const props = extractProps(doc);
-	const componentUrl = options.moduleUrlOverride ?? (await extractComponentUrl(doc));
+	const componentUrl = options.moduleUrlOverride ?? extractComponentUrl(doc);
 
 	if (!componentUrl) {
 		if (isReactRouteDocument(doc)) {

--- a/packages/react-router/src/navigation.ts
+++ b/packages/react-router/src/navigation.ts
@@ -10,7 +10,7 @@ import { isHtmlPageResponse } from '@ecopages/core/router/link-navigation-policy
 import { ensurePageConfigLayouts } from '@ecopages/core/eco/page-layout-normalization';
 import type { EcoComponentConfig } from '@ecopages/core';
 import { resolveEcoPageDataModuleUrl, resolveEcoPageDataProps } from '@ecopages/react/serialize-page-data-script';
-import { type ComponentType } from 'react';
+import { createElement, type ComponentType } from 'react';
 
 const ROUTER_PROPS_SCRIPT_ID = '__ECO_PAGE_DATA__';
 const PAGE_BOOTSTRAP_SELECTOR = 'script[data-eco-page-bootstrap="react-router"]';
@@ -23,8 +23,17 @@ export type PageState = {
 	props: PageProps;
 };
 
+/**
+ * Fully resolved page module ready for SPA commit.
+ *
+ * @remarks
+ * `config` is carried explicitly so layout composition does not depend on
+ * mutating the imported module namespace. `Component` may be a thin wrapper
+ * that exposes the resolved config for {@link PageContent}.
+ */
 export type LoadedPageModule = {
 	Component: NavigablePageComponent;
+	config?: EcoComponentConfig;
 	props: PageProps;
 	doc: Document;
 	finalPath: string;
@@ -147,10 +156,13 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
  * Adapts supported module export shapes to the router's page-component contract.
  *
  * @remarks
- * Config attachment is isolated here because imported component functions may
- * need module-level layout metadata copied onto them before normalization.
+ * Never mutates the imported component function. When module-level config is
+ * present but missing on the export, a thin wrapper carries `config` for layout
+ * composition while rendering the original component.
  */
-function adaptPageModule(moduleNamespace: unknown): NavigablePageComponent | null {
+function adaptPageModule(
+	moduleNamespace: unknown,
+): { Component: NavigablePageComponent; config?: EcoComponentConfig } | null {
 	const module = asRecord(moduleNamespace);
 	if (!module) {
 		return null;
@@ -163,13 +175,20 @@ function adaptPageModule(moduleNamespace: unknown): NavigablePageComponent | nul
 		return null;
 	}
 
-	const Component = rawComponent as NavigablePageComponent;
-	const config = (module.config ?? defaultRecord?.config ?? Component.config) as EcoComponentConfig | undefined;
-	if (config && !Component.config) {
-		Component.config = config;
+	const Imported = rawComponent as NavigablePageComponent;
+	const config = (module.config ?? defaultRecord?.config ?? Imported.config) as EcoComponentConfig | undefined;
+	if (config) {
+		ensurePageConfigLayouts(config);
 	}
-	ensurePageConfigLayouts(Component.config);
-	return Component;
+
+	if (!config || Imported.config === config) {
+		return { Component: Imported, config: Imported.config ?? config };
+	}
+
+	const Page = ((props: PageProps) => createElement(Imported, props)) as NavigablePageComponent;
+	Page.config = config;
+	Page.displayName = Imported.displayName ?? Imported.name ?? 'EcoRouterPage';
+	return { Component: Page, config };
 }
 
 /**
@@ -248,11 +267,18 @@ export async function loadPageModuleFromDocument(
 
 	const moduleUrl = addCacheBuster(componentUrl);
 	const module = (await import(/* @vite-ignore */ moduleUrl)) as unknown;
-	const Component = adaptPageModule(module);
-	if (!Component) {
+	const adapted = adaptPageModule(module);
+	if (!adapted) {
 		console.error('[EcoRouter] No component found in module');
 		return null;
 	}
 
-	return { Component, props, doc, finalPath, moduleUrl: componentUrl };
+	return {
+		Component: adapted.Component,
+		config: adapted.config,
+		props,
+		doc,
+		finalPath,
+		moduleUrl: componentUrl,
+	};
 }

--- a/packages/react-router/src/navigation.ts
+++ b/packages/react-router/src/navigation.ts
@@ -77,41 +77,28 @@ function parsePageDataPayload(doc: Document): unknown {
 	}
 }
 
-/**
- * Matches default import: `import Content from './Content'`
- * Used to extract module path from hydration script for fetched documents.
- */
-const DEFAULT_IMPORT_REGEX = /import\s+(\w+)\s+from\s*['"]([^'"]+)['"]/;
-
-/**
- * Matches namespace import: `import * as Content from './Content'`
- * Used for MDX components. Also handles minified: `import*as Content from'./Content'`
- */
-const NAMESPACE_IMPORT_REGEX = /import\s*\*\s*as\s*(\w+)\s*from\s*['"]([^'"]+)['"]/;
-
-/**
- * Matches explicit page-module markers written by hydration scripts.
- */
-const PAGE_MODULE_MARKER_REGEX = /__ECO_PAGES__\.page\s*=\s*\{\s*module\s*:\s*['"]([^'"]+)['"]/;
-const PAGE_MODULE_IDENTIFIER_REGEX = /__ECO_PAGES__\.page\s*=\s*\{\s*module\s*:\s*([A-Za-z_$][\w$]*)\s*,/;
 const PAGE_BOOTSTRAP_SELECTOR = 'script[data-eco-page-bootstrap="react-router"]';
 
 /**
- * Extracts import path from hydration script code using regex.
- *
- * @remarks
- * Compatibility fallback only. Prefer the v1 `__ECO_PAGE_DATA__` envelope.
- * Remove this path in a later compatibility release once all producers emit
- * `module` in the page-data manifest. Regex discovery is less reliable under
- * minification.
+ * @deprecated
+ * Regex-based hydration script discovery for one compatibility release. Prefer the
+ * v1 `__ECO_PAGE_DATA__` envelope (`schemaVersion` + `moduleUrl`). Remove once all
+ * producers emit the manifest.
  */
-function extractModulePathFromCode(code: string, fallbackUrl?: string): string | null {
-	const markerMatch = code.match(PAGE_MODULE_MARKER_REGEX);
+function deprecatedExtractModuleUrlFromHydrationScriptCode(code: string, fallbackUrl?: string): string | null {
+	/** Matches default import: `import Content from './Content'` */
+	const defaultImportRegex = /import\s+(\w+)\s+from\s*['"]([^'"]+)['"]/;
+	/** Matches namespace import: `import * as Content from './Content'` */
+	const namespaceImportRegex = /import\s*\*\s*as\s*(\w+)\s*from\s*['"]([^'"]+)['"]/;
+	const pageModuleMarkerRegex = /__ECO_PAGES__\.page\s*=\s*\{\s*module\s*:\s*['"]([^'"]+)['"]/;
+	const pageModuleIdentifierRegex = /__ECO_PAGES__\.page\s*=\s*\{\s*module\s*:\s*([A-Za-z_$][\w$]*)\s*,/;
+
+	const markerMatch = code.match(pageModuleMarkerRegex);
 	if (markerMatch) {
 		return markerMatch[1] ?? null;
 	}
 
-	const moduleIdentifier = code.match(PAGE_MODULE_IDENTIFIER_REGEX)?.[1];
+	const moduleIdentifier = code.match(pageModuleIdentifierRegex)?.[1];
 	if (moduleIdentifier) {
 		const assignmentRegex = new RegExp(
 			`(?:const|let|var)[^;]*\\b${moduleIdentifier}\\s*=\\s*(?:['"]([^'"]+)['"]|(import\\.meta\\.url))`,
@@ -130,8 +117,8 @@ function extractModulePathFromCode(code: string, fallbackUrl?: string): string |
 		return fallbackUrl;
 	}
 
-	const defaultMatch = code.match(DEFAULT_IMPORT_REGEX);
-	const namespaceMatch = code.match(NAMESPACE_IMPORT_REGEX);
+	const defaultMatch = code.match(defaultImportRegex);
+	const namespaceMatch = code.match(namespaceImportRegex);
 	return (defaultMatch || namespaceMatch)?.[2] ?? null;
 }
 
@@ -169,9 +156,9 @@ function addCacheBuster(url: string): string {
 /**
  * Extracts component module URL using multi-tier strategy.
  *
- * 1. Read the v1 page-data envelope
+ * 1. Read the v1 page-data envelope (`schemaVersion` + `moduleUrl`)
  * 2. Read bootstrap/page markers on the current document
- * 3. Parse hydration scripts with the documented regex fallback for one release
+ * 3. Fall back to {@link deprecatedExtractModuleUrlFromHydrationScriptCode} for one release
  *
  * @remarks
  * EcoRouter transition-state extraction remains a separate follow-up. This
@@ -196,7 +183,7 @@ export async function extractComponentUrl(doc: Document): Promise<string | null>
 	);
 
 	if (inlineHydrationScript?.textContent) {
-		return extractModulePathFromCode(inlineHydrationScript.textContent);
+		return deprecatedExtractModuleUrlFromHydrationScriptCode(inlineHydrationScript.textContent);
 	}
 
 	const hydrationScript =
@@ -208,7 +195,7 @@ export async function extractComponentUrl(doc: Document): Promise<string | null>
 		const scriptUrl = addCacheBuster(hydrationScript.src);
 		const res = await fetch(scriptUrl);
 		const code = await res.text();
-		return extractModulePathFromCode(code, hydrationScript.src);
+		return deprecatedExtractModuleUrlFromHydrationScriptCode(code, hydrationScript.src);
 	} catch {
 		return null;
 	}

--- a/packages/react-router/src/props-script.ts
+++ b/packages/react-router/src/props-script.ts
@@ -10,24 +10,24 @@ export interface EcoPropsScriptProps {
 	 * Page props or a versioned page-data envelope.
 	 *
 	 * @remarks
-	 * When `module` is passed, the script emits the v1 envelope so SPA navigation can
-	 * discover the page module without parsing hydration JavaScript. Legacy flat props
-	 * remain supported for older documents.
+	 * When `moduleUrl` is passed and `data` is not already a v1 envelope, the script
+	 * emits `schemaVersion:1` with that field. Passing `moduleUrl` alongside an
+	 * existing envelope does not rewrite the envelope's `moduleUrl`.
 	 */
 	data: EcoPageDataDocumentPayload;
-	/** Browser-importable page module URL for router-enabled documents. */
-	module?: string;
+	/** Browser-importable page module URL; serialized as envelope field `moduleUrl`. */
+	moduleUrl?: string;
 }
 
 /**
  * Serializes page props as JSON for SPA navigation.
  *
  * @remarks
- * The hydration script reads this and sets `window.__ECO_PAGES__.page`.
- * Clients parse `#__ECO_PAGE_DATA__` as JSON; module discovery uses the v1
- * envelope `moduleUrl`, the runtime page marker, or the page bootstrap script `src`.
+ * Emits `#__ECO_PAGE_DATA__`. Hydration scripts and SPA commit write
+ * `window.__ECO_PAGES__.page` from that payload. Module discovery uses envelope
+ * `moduleUrl`, then the runtime page marker, then the page bootstrap script `src`.
  */
-export const EcoPropsScript: FC<EcoPropsScriptProps> = ({ data, module: moduleUrl }) => {
+export const EcoPropsScript: FC<EcoPropsScriptProps> = ({ data, moduleUrl }) => {
 	const payload = resolvePageDataDocumentPayload(data, { moduleUrl });
 
 	return createElement('script', {

--- a/packages/react-router/src/props-script.ts
+++ b/packages/react-router/src/props-script.ts
@@ -24,7 +24,8 @@ export interface EcoPropsScriptProps {
  *
  * @remarks
  * The hydration script reads this and sets `window.__ECO_PAGES__.page`.
- * Using `application/json` allows direct parsing without regex.
+ * Clients parse `#__ECO_PAGE_DATA__` as JSON; module discovery uses the v1
+ * envelope `moduleUrl`, the runtime page marker, or the page bootstrap script `src`.
  */
 export const EcoPropsScript: FC<EcoPropsScriptProps> = ({ data, module: moduleUrl }) => {
 	const payload = resolvePageDataDocumentPayload(data, { moduleUrl });

--- a/packages/react-router/src/props-script.ts
+++ b/packages/react-router/src/props-script.ts
@@ -1,24 +1,18 @@
 import { createElement, type FC } from 'react';
 import {
-	createEcoPageDataManifestV1,
-	ECO_PAGE_MODULE_PROP,
 	escapePageDataJson,
-	isEcoPageDataManifestV1,
+	resolvePageDataDocumentPayload,
 	type EcoPageDataDocumentPayload,
-	type EcoPageDataProps,
 } from '@ecopages/react/serialize-page-data-script';
-
-export { ECO_PAGE_MODULE_PROP } from '@ecopages/react/serialize-page-data-script';
 
 export interface EcoPropsScriptProps {
 	/**
 	 * Page props or a versioned page-data envelope.
 	 *
 	 * @remarks
-	 * Flat props may include the reserved {@link ECO_PAGE_MODULE_PROP} key. When
-	 * present (or when `module` is passed explicitly), the script emits the v1
-	 * envelope so SPA navigation can discover the page module without parsing
-	 * hydration JavaScript. Legacy flat props remain supported for older documents.
+	 * When `module` is passed, the script emits the v1 envelope so SPA navigation can
+	 * discover the page module without parsing hydration JavaScript. Legacy flat props
+	 * remain supported for older documents.
 	 */
 	data: EcoPageDataDocumentPayload;
 	/** Browser-importable page module URL for router-enabled documents. */
@@ -32,21 +26,8 @@ export interface EcoPropsScriptProps {
  * The hydration script reads this and sets `window.__ECO_PAGES__.page`.
  * Using `application/json` allows direct parsing without regex.
  */
-export const EcoPropsScript: FC<EcoPropsScriptProps> = ({ data, module }) => {
-	let payload: EcoPageDataDocumentPayload = data;
-
-	if (!isEcoPageDataManifestV1(data)) {
-		const propsRecord = { ...(data as EcoPageDataProps) };
-		const inferredModule =
-			module ??
-			(typeof propsRecord[ECO_PAGE_MODULE_PROP] === 'string' ? propsRecord[ECO_PAGE_MODULE_PROP] : undefined);
-		if (typeof propsRecord[ECO_PAGE_MODULE_PROP] !== 'undefined') {
-			delete propsRecord[ECO_PAGE_MODULE_PROP];
-		}
-		payload = inferredModule
-			? createEcoPageDataManifestV1({ module: inferredModule, props: propsRecord })
-			: propsRecord;
-	}
+export const EcoPropsScript: FC<EcoPropsScriptProps> = ({ data, module: moduleUrl }) => {
+	const payload = resolvePageDataDocumentPayload(data, { moduleUrl });
 
 	return createElement('script', {
 		id: '__ECO_PAGE_DATA__',

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -487,30 +487,27 @@ export const EcoRouter: FC<EcoRouterProps> = ({ page, pageProps, options: userOp
 					activeNavigationRef.current = null;
 				}
 
-				if (replay.kind === 'none') {
-					return;
+				if (replay.kind !== 'none') {
+					queuedNavigationHrefRef.current = null;
+
+					if (replay.kind === 'local-navigate') {
+						void navigate(replay.href, { pushHistory: true });
+					} else {
+						// React finished after cleanup-before-handoff released ownership.
+						// Replay through the coordinator so the active owner receives the intent.
+						void navigationRuntime
+							.requestNavigation({
+								href: replay.href,
+								direction: 'forward',
+								source: 'react-router',
+							})
+							.then((handled) => {
+								if (!handled) {
+									window.location.assign(replay.href);
+								}
+							});
+					}
 				}
-
-				queuedNavigationHrefRef.current = null;
-
-				if (replay.kind === 'local-navigate') {
-					void navigate(replay.href, { pushHistory: true });
-					return;
-				}
-
-				// React finished after cleanup-before-handoff released ownership.
-				// Replay through the coordinator so the active owner receives the intent.
-				void navigationRuntime
-					.requestNavigation({
-						href: replay.href,
-						direction: 'forward',
-						source: 'react-router',
-					})
-					.then((handled) => {
-						if (!handled) {
-							window.location.assign(replay.href);
-						}
-					});
 			}
 		},
 		[options.viewTransitions],

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -488,10 +488,11 @@ export const EcoRouter: FC<EcoRouterProps> = ({ page, pageProps, options: userOp
 						window.location.assign(fetchedPage.finalPath);
 					}
 				}
+			} finally {
 				if (!isStale()) {
 					setIsNavigating(false);
 				}
-			} finally {
+
 				const shouldReplayQueuedNavigation = activeNavigationRef.current?.id === navigationId;
 				const queuedNavigationHref = shouldReplayQueuedNavigation ? queuedNavigationHrefRef.current : null;
 				const queuedNavigationPath = queuedNavigationHref

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -203,7 +203,10 @@ function useNavigationCoordinator(
 		}
 
 		const currentUrl = window.location.pathname + window.location.search;
-		await navigate(currentUrl, { moduleUrlOverride: request?.moduleUrl });
+		await navigate(currentUrl, {
+			moduleUrlOverride: request?.moduleUrl,
+			skipViewTransition: true,
+		});
 		return true;
 	});
 
@@ -376,6 +379,7 @@ export const EcoRouter: FC<EcoRouterProps> = ({ page, pageProps, options: userOp
 			};
 
 			try {
+				isNavigatingRef.current = true;
 				setIsNavigating(true);
 
 				const outcome = await resolveReactNavigation({
@@ -471,6 +475,7 @@ export const EcoRouter: FC<EcoRouterProps> = ({ page, pageProps, options: userOp
 				});
 			} finally {
 				if (!isStale()) {
+					isNavigatingRef.current = false;
 					setIsNavigating(false);
 				}
 

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -42,10 +42,9 @@ import {
 	composeLayoutPageTree,
 	assertComposablePage,
 	normalizePageLayoutComponents,
-	resolveLayoutContext,
-	resolveLayoutEntryProps,
 	type ComposablePage,
 } from '@ecopages/react/layout-compose';
+import type { EcoComponent } from '@ecopages/core';
 import {
 	getAnchorFromNavigationEvent,
 	isStaticAssetHref,
@@ -137,29 +136,19 @@ export const PageContent: FC = () => {
 	const composablePage = assertComposablePage(Page);
 	const layoutComponents = resolvePageLayoutStack(composablePage.config);
 	const shouldRefreshPersistedLayout = Boolean(refreshPersistedLayout);
+	const persistedTiers =
+		persistLayouts && layoutComponents.length > 0
+			? resolvePersistedLayoutStack(layoutComponents, shouldRefreshPersistedLayout)
+			: undefined;
 
-	if (persistLayouts && layoutComponents.length > 0) {
-		const pageElement = createElement(Page, props);
-		const layoutContext = resolveLayoutContext(props);
-		const layoutEntries = composablePage.config?.layoutEntries;
-		const fallbackLayoutProps = layoutContext.locals ? { locals: layoutContext.locals } : {};
-		const persistedTiers = resolvePersistedLayoutStack(layoutComponents, shouldRefreshPersistedLayout);
-
-		const tree = persistedTiers.reduceRight<ReactNode>(
-			(children, { layout: CachedLayout, key: layoutKey }, index) => {
-				const layoutEntry = layoutEntries?.[index];
-				const layoutProps = layoutEntry
-					? resolveLayoutEntryProps(layoutEntry, layoutContext)
-					: fallbackLayoutProps;
-				return createElement(CachedLayout, { key: layoutKey, ...layoutProps }, children);
-			},
-			pageElement,
-		);
-
-		return tree;
-	}
-
-	return composeLayoutPageTree(composablePage, props);
+	return composeLayoutPageTree(composablePage, props, {
+		resolvePersistedTier: persistedTiers
+			? (_layout, index) => ({
+					layout: persistedTiers[index]!.layout as EcoComponent,
+					key: persistedTiers[index]!.key,
+				})
+			: undefined,
+	});
 };
 
 function createDeferred<T>() {

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -26,7 +26,13 @@ import {
 import { type EcoRouterOptions, DEFAULT_OPTIONS } from './types.ts';
 import { RouterContext } from './context.ts';
 import { getLinkNavigationDecision, isSamePageHashNavigationHref } from '@ecopages/core/router/link-navigation-policy';
-import { type PageState, fetchPageDocument, loadPageModuleFromDocument } from './navigation.ts';
+import { type PageState } from './navigation.ts';
+import {
+	applyHandoffNavigation,
+	applySpaNavigation,
+	decideQueuedNavigationReplay,
+	resolveReactNavigation,
+} from './navigation-orchestrator.ts';
 import { morphHead } from './head-morpher.ts';
 import { applyViewTransitionNames } from '@ecopages/core/client/view-transitions';
 import { manageWindowScroll } from '@ecopages/core/client/scroll';
@@ -47,7 +53,6 @@ import {
 import type { EcoComponent } from '@ecopages/core';
 import {
 	getAnchorFromNavigationEvent,
-	isStaticAssetHref,
 	recoverPendingNavigationHref,
 	type EcoPendingNavigationIntent,
 } from '@ecopages/core/router/link-intent';
@@ -359,14 +364,7 @@ export const EcoRouter: FC<EcoRouterProps> = ({ page, pageProps, options: userOp
 			activeNavigationRef.current = navigation;
 			const navigationId = navigation.id;
 			const isStale = () => !navigation.isCurrent();
-			const commitPageData = (moduleUrl: string, props: Record<string, unknown>) => {
-				window.__ECO_PAGES__ = window.__ECO_PAGES__ || {};
-				window.__ECO_PAGES__.page = {
-					module: moduleUrl,
-					props,
-				};
-			};
-			const preparePendingRender = (nextPage: RouterPageState) => {
+			const waitForRender = (nextPage: RouterPageState) => {
 				pendingRenderRef.current?.resolve();
 				const renderDfd = createDeferred<void>();
 				pendingRenderRef.current = {
@@ -376,118 +374,101 @@ export const EcoRouter: FC<EcoRouterProps> = ({ page, pageProps, options: userOp
 				};
 				return renderDfd.promise;
 			};
-			let navigationCommitPromise: Promise<void> | null = null;
 
 			try {
 				setIsNavigating(true);
 
-				if (isStaticAssetHref(url)) {
-					window.location.assign(new URL(url, window.location.origin).href);
-					return;
-				}
-
-				const fetchedPage = await fetchPageDocument(url, { signal: navigation.signal });
-
-				if (isStale()) return;
-
-				if (!fetchedPage) {
-					window.location.href = url;
-					return;
-				}
-
-				const result = await loadPageModuleFromDocument(fetchedPage.doc, fetchedPage.finalPath, {
+				const outcome = await resolveReactNavigation({
+					url,
+					signal: navigation.signal,
+					isStale,
+					isPopState,
+					pushHistory,
 					moduleUrlOverride,
 				});
 
-				if (isStale()) return;
-
-				if (result) {
-					const { Component, props, doc, finalPath, moduleUrl } = result;
-					const nextPage = { Component, props, refreshPersistedLayout: Boolean(moduleUrlOverride) };
-					const { cleanup: cleanupHead, flushRerunScripts } = await morphHead(doc);
-					const finalizeCommittedNavigation = () => {
-						committedPathRef.current = finalPath;
-						flushRerunScripts();
-						cleanupHead();
-						applyViewTransitionNames();
-						restoreScrollPositions(finalPath, isPopState);
-					};
-					const commitNextPage = () => {
-						commitPageData(moduleUrl, props);
-						setCurrentPage(nextPage);
-					};
-
-					if (isStale()) {
-						cleanupHead();
-						return;
-					}
-
-					applyViewTransitionNames();
-
-					saveScrollPositions();
-
-					if (pushHistory) {
-						window.history.pushState(null, '', finalPath);
-					} else if (finalPath !== url) {
-						window.history.replaceState(null, '', finalPath);
-					}
-
-					if (!skipViewTransition && options.viewTransitions && document.startViewTransition) {
-						const renderPromise = preparePendingRender(nextPage);
-
-						navigationCommitPromise = new Promise<void>((resolve) => {
-							document.startViewTransition(async () => {
-								try {
-									if (isStale()) {
-										if (pendingRenderRef.current?.navigationId === navigationId) {
-											pendingRenderRef.current.resolve();
-											pendingRenderRef.current = null;
-										}
-										cleanupHead();
-										return;
-									}
-									startTransition(() => {
-										commitNextPage();
-									});
-									await renderPromise;
-									if (isStale()) {
-										return;
-									}
-									finalizeCommittedNavigation();
-								} finally {
-									resolve();
-								}
-							});
-						});
-						await navigationCommitPromise;
-					} else {
-						const renderPromise = preparePendingRender(nextPage);
-						commitNextPage();
-						await renderPromise;
-						if (isStale()) {
-							cleanupHead();
-							return;
-						}
-						finalizeCommittedNavigation();
-					}
-				} else {
-					if (isStale()) return;
-
-					const handled = await navigationRuntime.requestHandoff({
-						href: url,
-						finalHref: fetchedPage.finalPath,
-						direction: isPopState ? 'back' : pushHistory ? 'forward' : 'replace',
-						source: 'react-router',
-						targetOwner: 'browser-router',
-						document: fetchedPage.doc,
-						html: fetchedPage.html,
-						isStaleSourceNavigation: isStale,
-					});
-
-					if (!handled) {
-						window.location.assign(fetchedPage.finalPath);
-					}
+				if (outcome.kind === 'stale') {
+					return;
 				}
+
+				if (outcome.kind === 'hard-navigation') {
+					if (outcome.mode === 'assign') {
+						window.location.assign(outcome.href);
+					} else {
+						window.location.href = outcome.href;
+					}
+					return;
+				}
+
+				if (outcome.kind === 'spa') {
+					await applySpaNavigation(
+						outcome,
+						{
+							isStale,
+							morphHead,
+							applyViewTransitionNames,
+							saveScrollPositions,
+							restoreScrollPositions,
+							updateHistory: (finalPath, requestedUrl, direction) => {
+								if (direction === 'forward') {
+									window.history.pushState(null, '', finalPath);
+								} else if (finalPath !== requestedUrl) {
+									window.history.replaceState(null, '', finalPath);
+								}
+							},
+							commitPageData: (moduleUrl, props) => {
+								window.__ECO_PAGES__ = window.__ECO_PAGES__ || {};
+								window.__ECO_PAGES__.page = {
+									module: moduleUrl,
+									props,
+								};
+							},
+							setCurrentPage,
+							waitForRender,
+							runInReactTransition: (update) => {
+								startTransition(update);
+							},
+							startViewTransition:
+								!skipViewTransition && options.viewTransitions && document.startViewTransition
+									? (update) =>
+											new Promise<void>((resolve) => {
+												document.startViewTransition(async () => {
+													try {
+														await update();
+													} finally {
+														if (
+															isStale() &&
+															pendingRenderRef.current?.navigationId === navigationId
+														) {
+															pendingRenderRef.current.resolve();
+															pendingRenderRef.current = null;
+														}
+														resolve();
+													}
+												});
+											})
+									: undefined,
+							onCommittedPath: (finalPath) => {
+								committedPathRef.current = finalPath;
+							},
+						},
+						{ skipViewTransition, isPopState },
+					);
+					return;
+				}
+
+				await applyHandoffNavigation(outcome, {
+					isStale,
+					requestHandoff: (request) =>
+						navigationRuntime.requestHandoff({
+							...request,
+							source: 'react-router',
+							targetOwner: 'browser-router',
+						}),
+					hardAssign: (href) => {
+						window.location.assign(href);
+					},
+				});
 			} finally {
 				if (!isStale()) {
 					setIsNavigating(false);
@@ -495,37 +476,41 @@ export const EcoRouter: FC<EcoRouterProps> = ({ page, pageProps, options: userOp
 
 				const shouldReplayQueuedNavigation = activeNavigationRef.current?.id === navigationId;
 				const queuedNavigationHref = shouldReplayQueuedNavigation ? queuedNavigationHrefRef.current : null;
-				const queuedNavigationPath = queuedNavigationHref
-					? new URL(queuedNavigationHref, window.location.origin).pathname +
-						new URL(queuedNavigationHref, window.location.origin).search
-					: null;
+				const replay = decideQueuedNavigationReplay({
+					queuedHref: queuedNavigationHref,
+					committedPath: committedPathRef.current,
+					runtimeActive: runtimeActiveRef.current,
+				});
+
 				navigation.complete();
 				if (activeNavigationRef.current?.id === navigationId) {
 					activeNavigationRef.current = null;
 				}
 
-				if (queuedNavigationHref && queuedNavigationPath !== committedPathRef.current) {
-					queuedNavigationHrefRef.current = null;
-
-					if (runtimeActiveRef.current) {
-						void navigate(queuedNavigationHref, { pushHistory: true });
-					} else {
-						// React may finish after control has already moved to another runtime.
-						// In that case replay the queued click through the shared coordinator
-						// so the newest navigation still lands on its intended owner.
-						void navigationRuntime
-							.requestNavigation({
-								href: queuedNavigationHref,
-								direction: 'forward',
-								source: 'react-router',
-							})
-							.then((handled) => {
-								if (!handled) {
-									window.location.assign(queuedNavigationHref);
-								}
-							});
-					}
+				if (replay.kind === 'none') {
+					return;
 				}
+
+				queuedNavigationHrefRef.current = null;
+
+				if (replay.kind === 'local-navigate') {
+					void navigate(replay.href, { pushHistory: true });
+					return;
+				}
+
+				// React finished after cleanup-before-handoff released ownership.
+				// Replay through the coordinator so the active owner receives the intent.
+				void navigationRuntime
+					.requestNavigation({
+						href: replay.href,
+						direction: 'forward',
+						source: 'react-router',
+					})
+					.then((handled) => {
+						if (!handled) {
+							window.location.assign(replay.href);
+						}
+					});
 			}
 		},
 		[options.viewTransitions],

--- a/packages/react-router/test/hmr-reload.test.browser.ts
+++ b/packages/react-router/test/hmr-reload.test.browser.ts
@@ -1024,12 +1024,7 @@ describe('EcoRouter HMR Integration', () => {
 					pageProps: {},
 					options: { viewTransitions: false },
 					// oxlint-disable-next-line no-children-prop
-					children: createElement(
-						'div',
-						null,
-						createElement(PageContent),
-						createElement(NavigatingProbe),
-					),
+					children: createElement('div', null, createElement(PageContent), createElement(NavigatingProbe)),
 				}),
 			);
 

--- a/packages/react-router/test/hmr-reload.test.browser.ts
+++ b/packages/react-router/test/hmr-reload.test.browser.ts
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { createElement, type ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { getEcoNavigationRuntime } from '@ecopages/core/router/navigation-coordinator';
+import { useRouter } from '../src/context.ts';
 import { EcoRouter, PageContent, clearLayoutCache } from '../src/router.ts';
 
 function htmlPageResponse(body: string, init: ResponseInit = {}): Response {
@@ -141,6 +142,17 @@ function createMultiLinkPage(name: string, links: Array<{ href: string; label: s
 	return Component;
 }
 
+function createNavigablePageHtml(moduleUrl: string, props: Record<string, unknown> = {}) {
+	return `<html data-eco-document-owner="react-router"><body>
+		<script id="__ECO_PAGE_DATA__" type="application/json">${JSON.stringify({
+			schemaVersion: 1,
+			navigationOwner: 'react-router',
+			moduleUrl,
+			props,
+		})}</script>
+	</body></html>`;
+}
+
 function createDeferred(): { promise: Promise<void>; resolve: () => void } {
 	let resolve!: () => void;
 	const promise = new Promise<void>((innerResolve) => {
@@ -245,10 +257,14 @@ describe('EcoRouter HMR Integration', () => {
 			const PageA = createMockPageComponent('PageA');
 			const moduleUrl = new URL('./fixtures/reloaded-page.tsx', import.meta.url).toString();
 			const mockHtml = `
-				<html>
+				<html data-eco-document-owner="react-router">
 					<body>
-						<script id="__ECO_PAGE_DATA__" type="application/json">{}</script>
-						<script type="module">window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.page={module:'${moduleUrl}',props:{}};import Page from '${moduleUrl}'; hydrateRoot(document, Page);</script>
+						<script id="__ECO_PAGE_DATA__" type="application/json">${JSON.stringify({
+							schemaVersion: 1,
+							navigationOwner: 'react-router',
+							moduleUrl,
+							props: {},
+						})}</script>
 					</body>
 				</html>
 			`;
@@ -271,10 +287,14 @@ describe('EcoRouter HMR Integration', () => {
 
 			expect(result).toBeInstanceOf(Promise);
 			await expect(result).resolves.toBe(true);
+			await vi.waitFor(() => {
+				expect(container.textContent).toContain('Reloaded page');
+			});
 		});
 
 		it('ignores coordinator reloads while a navigation is still in flight', async () => {
 			const Page = createMultiLinkPage('BusyPage', [{ href: '/next', label: 'next-link' }]);
+			const moduleUrl = new URL('./fixtures/page-from-props.tsx', import.meta.url).toString();
 			let resolveFetch!: (response: Response) => void;
 			const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
 				() =>
@@ -305,8 +325,22 @@ describe('EcoRouter HMR Integration', () => {
 			expect(reloadResult).toBe(false);
 			expect(fetchSpy).toHaveBeenCalledTimes(1);
 
-			resolveFetch(htmlPageResponse('<html><body><main>Done</main></body></html>', { status: 200 }));
-			await new Promise((resolve) => setTimeout(resolve, 0));
+			resolveFetch(
+				htmlPageResponse(
+					`<html data-eco-document-owner="react-router"><body>
+						<script id="__ECO_PAGE_DATA__" type="application/json">${JSON.stringify({
+							schemaVersion: 1,
+							navigationOwner: 'react-router',
+							moduleUrl,
+							props: { label: 'done' },
+						})}</script>
+					</body></html>`,
+					{ status: 200 },
+				),
+			);
+			await vi.waitFor(() => {
+				expect(window.__ECO_PAGES__?.page?.props).toEqual({ label: 'done' });
+			});
 		});
 
 		it('passes locals to layouts when persistLayouts is disabled', async () => {
@@ -660,14 +694,7 @@ describe('EcoRouter HMR Integration', () => {
 		it('intercepts clicks that originate from a text node inside the anchor', async () => {
 			const Page = createMultiLinkPage('TextNodeClick', [{ href: '/fast', label: 'fast-link' }]);
 			const moduleUrl = new URL('./fixtures/page-from-props.tsx', import.meta.url).toString();
-			const createHtml = (label: string) => `
-				<html>
-					<body>
-						<script id="__ECO_PAGE_DATA__" type="application/json">${JSON.stringify({ label })}</script>
-						<script type="module">window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.page={module:'${moduleUrl}',props:${JSON.stringify({ label })}};import Page from '${moduleUrl}'; hydrateRoot(document, Page);</script>
-					</body>
-				</html>
-			`;
+			const createHtml = (label: string) => createNavigablePageHtml(moduleUrl, { label });
 
 			vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(htmlPageResponse(createHtml('fast'), { status: 200 }));
 
@@ -707,14 +734,7 @@ describe('EcoRouter HMR Integration', () => {
 				{ href: '/fast', label: 'fast-link' },
 			]);
 			const moduleUrl = new URL('./fixtures/page-from-props.tsx', import.meta.url).toString();
-			const createHtml = (label: string) => `
-				<html>
-					<body>
-						<script id="__ECO_PAGE_DATA__" type="application/json">${JSON.stringify({ label })}</script>
-						<script type="module">window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.page={module:'${moduleUrl}',props:${JSON.stringify({ label })}};import Page from '${moduleUrl}'; hydrateRoot(document, Page);</script>
-					</body>
-				</html>
-			`;
+			const createHtml = (label: string) => createNavigablePageHtml(moduleUrl, { label });
 			const slowFetch = createDeferred();
 			const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
 				const url = input.toString();
@@ -785,14 +805,7 @@ describe('EcoRouter HMR Integration', () => {
 				{ href: '/hovered-c', label: 'hovered-c-link' },
 			]);
 			const moduleUrl = new URL('./fixtures/page-from-props.tsx', import.meta.url).toString();
-			const createHtml = (label: string) => `
-				<html>
-					<body>
-						<script id="__ECO_PAGE_DATA__" type="application/json">${JSON.stringify({ label })}</script>
-						<script type="module">window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.page={module:'${moduleUrl}',props:${JSON.stringify({ label })}};import Page from '${moduleUrl}'; hydrateRoot(document, Page);</script>
-					</body>
-				</html>
-			`;
+			const createHtml = (label: string) => createNavigablePageHtml(moduleUrl, { label });
 			const slowFetch = createDeferred();
 			const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
 				const url = input.toString();
@@ -879,14 +892,7 @@ describe('EcoRouter HMR Integration', () => {
 				{ href: '/fast', label: 'fast-link' },
 			]);
 			const moduleUrl = new URL('./fixtures/page-from-props.tsx', import.meta.url).toString();
-			const createHtml = (label: string) => `
-				<html>
-					<body>
-						<script id="__ECO_PAGE_DATA__" type="application/json">${JSON.stringify({ label })}</script>
-						<script type="module">window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.page={module:'${moduleUrl}',props:${JSON.stringify({ label })}};import Page from '${moduleUrl}'; hydrateRoot(document, Page);</script>
-					</body>
-				</html>
-			`;
+			const createHtml = (label: string) => createNavigablePageHtml(moduleUrl, { label });
 
 			vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
 				const url = input.toString();
@@ -949,14 +955,7 @@ describe('EcoRouter HMR Integration', () => {
 				owner: 'browser-router',
 				handoffNavigation: handoffSpy,
 			});
-			const createHtml = (label: string) => `
-				<html>
-					<body>
-						<script id="__ECO_PAGE_DATA__" type="application/json">${JSON.stringify({ label })}</script>
-						<script type="module">window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.page={module:'${moduleUrl}',props:${JSON.stringify({ label })}};import Page from '${moduleUrl}'; hydrateRoot(document, Page);</script>
-					</body>
-				</html>
-			`;
+			const createHtml = (label: string) => createNavigablePageHtml(moduleUrl, { label });
 
 			vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
 				const url = input.toString();
@@ -1004,6 +1003,47 @@ describe('EcoRouter HMR Integration', () => {
 			expect(handoffSpy).not.toHaveBeenCalled();
 			expect(container.textContent).toContain('fast');
 			unregister();
+		});
+
+		it('clears isNavigating after a successful SPA navigation', async () => {
+			const Page = createMultiLinkPage('NavTerminal', [{ href: '/next', label: 'next-link' }]);
+			const NavigatingProbe = () => {
+				const { isNavigating } = useRouter();
+				return createElement('span', { 'data-testid': 'is-navigating' }, isNavigating ? 'yes' : 'no');
+			};
+			const moduleUrl = new URL('./fixtures/page-from-props.tsx', import.meta.url).toString();
+
+			vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+				htmlPageResponse(createNavigablePageHtml(moduleUrl, { label: 'next' }), { status: 200 }),
+			);
+
+			root = createRoot(container);
+			root.render(
+				createElement(EcoRouter, {
+					page: Page,
+					pageProps: {},
+					options: { viewTransitions: false },
+					// oxlint-disable-next-line no-children-prop
+					children: createElement(
+						'div',
+						null,
+						createElement(PageContent),
+						createElement(NavigatingProbe),
+					),
+				}),
+			);
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			expect(container.querySelector('[data-testid="is-navigating"]')?.textContent).toBe('no');
+
+			const link = container.querySelector('[data-testid="NavTerminal-next-link"]') as HTMLAnchorElement | null;
+			expect(link).not.toBeNull();
+			await user.click(link as HTMLAnchorElement);
+
+			await vi.waitFor(() => {
+				expect(window.__ECO_PAGES__?.page?.props).toEqual({ label: 'next' });
+				expect(container.querySelector('[data-testid="is-navigating"]')?.textContent).toBe('no');
+			});
 		});
 	});
 });

--- a/packages/react-router/test/navigation.test.browser.ts
+++ b/packages/react-router/test/navigation.test.browser.ts
@@ -139,7 +139,7 @@ describe('extractProps', () => {
 		const doc = createMockDocument(`
 			<html><body>
 				<script id="__ECO_PAGE_DATA__" type="application/json">
-					{"v":1,"navigationOwner":"react-router","module":"/assets/docs.js","props":{"slug":"intro"}}
+					{"schemaVersion":1,"navigationOwner":"react-router","moduleUrl":"/assets/docs.js","props":{"slug":"intro"}}
 				</script>
 			</body></html>
 		`);
@@ -260,7 +260,7 @@ describe('extractComponentUrl', () => {
 		const doc = createMockDocument(`
 			<html><body>
 				<script id="__ECO_PAGE_DATA__" type="application/json">
-					{"v":1,"navigationOwner":"react-router","module":"/assets/pages/docs.js","props":{}}
+					{"schemaVersion":1,"navigationOwner":"react-router","moduleUrl":"/assets/pages/docs.js","props":{}}
 				</script>
 			</body></html>
 		`);

--- a/packages/react-router/test/navigation.test.browser.ts
+++ b/packages/react-router/test/navigation.test.browser.ts
@@ -266,7 +266,7 @@ describe('extractComponentUrl', () => {
 		`);
 		const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
-		await expect(extractComponentUrl(doc)).resolves.toBe('/assets/pages/docs.js');
+		expect(extractComponentUrl(doc)).toBe('/assets/pages/docs.js');
 		expect(fetchSpy).not.toHaveBeenCalled();
 		fetchSpy.mockRestore();
 	});

--- a/packages/react-router/test/navigation.test.browser.ts
+++ b/packages/react-router/test/navigation.test.browser.ts
@@ -271,165 +271,38 @@ describe('extractComponentUrl', () => {
 		fetchSpy.mockRestore();
 	});
 
-	it('should extract from inline hydration script in fetched document', async () => {
-		const html = `
-			<html>
-				<body>
-					<script type="module" src="/assets/scripts/ecopages-react-123-hydration.js">
-						import Content from './pages/about.js';
-					</script>
-				</body>
-			</html>
-		`;
-		const doc = createMockDocument(html);
-
-		const fetchSpy = vi
-			.spyOn(globalThis, 'fetch')
-			.mockResolvedValue(new Response("import Content from './pages/about.js';", { status: 200 }));
-
-		const url = await extractComponentUrl(doc);
-		expect(url).toBe('./pages/about.js');
-
-		fetchSpy.mockRestore();
-	});
-
-	it('should extract from explicit page-module markers in fetched hydration scripts', async () => {
-		const html = `
-			<html>
-				<body>
-					<script src="/assets/scripts/ecopages-react-123-hydration.js" type="module"></script>
-				</body>
-			</html>
-		`;
-		const doc = createMockDocument(html);
-
-		const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-			new Response(
-				'window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.page={module:"/assets/pages/about.js",props:{}};',
-				{
-					status: 200,
-				},
-			),
-		);
-
-		const url = await extractComponentUrl(doc);
-		expect(url).toBe('/assets/pages/about.js');
-
-		fetchSpy.mockRestore();
-	});
-
-	it('should fall back to the hydration script URL for self-owned bundled page entries', async () => {
-		const html = `
-			<html>
-				<body>
-					<script src="/assets/scripts/ecopages-react-123-page.js" type="module"></script>
-				</body>
-			</html>
-		`;
-		const doc = createMockDocument(html);
-
-		const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-			new Response(
-				'window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.page={module:import.meta.url,props:{}};',
-				{
-					status: 200,
-				},
-			),
-		);
-
-		const url = await extractComponentUrl(doc);
-		expect(url).toBe('http://localhost:63315/assets/scripts/ecopages-react-123-page.js');
-
-		fetchSpy.mockRestore();
-	});
-
-	it('should prefer the explicit page bootstrap marker when grouped route assets do not match legacy filenames', async () => {
-		const html = `
+	it('should use the explicit page bootstrap script src when the envelope is absent', async () => {
+		const doc = createMockDocument(`
 			<html>
 				<body>
 					<script src="/assets/grouped/react-pages-dashboard.js" type="module" data-eco-page-bootstrap="react-router"></script>
 				</body>
 			</html>
-		`;
-		const doc = createMockDocument(html);
-
-		const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-			new Response(
-				'window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.page={module:import.meta.url,props:{}};',
-				{
-					status: 200,
-				},
-			),
-		);
+		`);
+		const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
 		const url = await extractComponentUrl(doc);
 		expect(url).toBe('http://localhost:63315/assets/grouped/react-pages-dashboard.js');
-
+		expect(fetchSpy).not.toHaveBeenCalled();
 		fetchSpy.mockRestore();
 	});
 
-	it('should resolve aliased import.meta.url markers in generated production route bootstrap scripts', async () => {
+	it('should ignore hydration scripts that are not the page bootstrap entry', async () => {
 		const html = `
 			<html>
 				<body>
-					<script src="/assets/ecopages-react-123.js" type="module"></script>
-				</body>
-			</html>
-		`;
-		const doc = createMockDocument(html);
-
-		const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-			new Response(
-				'var N=import.meta.url,V=p;window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.page={module:N,props:{}};',
-				{
-					status: 200,
-				},
-			),
-		);
-
-		const url = await extractComponentUrl(doc);
-		expect(url).toBe('http://localhost:63315/assets/ecopages-react-123.js');
-
-		fetchSpy.mockRestore();
-	});
-
-	it('should ignore unrelated Vite noModule fragments when resolving the page module marker', async () => {
-		const html = `
-			<html>
-				<body>
-					<script src="/assets/ecopages-react-123.js" type="module"></script>
-				</body>
-			</html>
-		`;
-		const doc = createMockDocument(html);
-
-		const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-			new Response(
-				'var attrs={module:noModule,nomodule:"noModule"};var u=import.meta.url;window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.page={module:u,props:{}};',
-				{
-					status: 200,
-				},
-			),
-		);
-
-		const url = await extractComponentUrl(doc);
-		expect(url).toBe('http://localhost:63315/assets/ecopages-react-123.js');
-
-		fetchSpy.mockRestore();
-	});
-
-	it('should ignore island hydration assets when extracting a page module URL', async () => {
-		const html = `
-			<html>
-				<body>
+					<script src="/assets/scripts/ecopages-react-123-hydration.js" type="module"></script>
 					<script src="/assets/scripts/ecopages-react-island-123-hydration.js" type="module"></script>
 				</body>
 			</html>
 		`;
 		const doc = createMockDocument(html);
+		const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
 		const url = await extractComponentUrl(doc);
 		expect(url).toBeNull();
+		expect(fetchSpy).not.toHaveBeenCalled();
+		fetchSpy.mockRestore();
 	});
 });
 
@@ -522,8 +395,7 @@ describe('loadPageModule', () => {
 			[
 				`<html ${ECO_DOCUMENT_OWNER_ATTRIBUTE}="react-router">`,
 				'<body>',
-				'<script id="__ECO_PAGE_DATA__" type="application/json">{"message":"hello"}</script>',
-				`<script type="module">window.__ECO_PAGES__=window.__ECO_PAGES__||{};window.__ECO_PAGES__.page={module:"${moduleUrl}",props:{message:"hello"}};import Page from "${moduleUrl}"; hydrateRoot(document, Page);</script>`,
+				`<script id="__ECO_PAGE_DATA__" type="application/json">{"schemaVersion":1,"navigationOwner":"react-router","moduleUrl":"${moduleUrl}","props":{"message":"hello"}}</script>`,
 				'</body>',
 				'</html>',
 			].join(''),
@@ -717,41 +589,5 @@ describe('getLinkNavigationDecision', () => {
 		const result = getLinkNavigationDecision(event, link, linkNavigationPolicyOptions(options)).shouldIntercept;
 
 		expect(result).toBe(false);
-	});
-});
-
-describe('Cache busting in development', () => {
-	let fetchSpy: ReturnType<typeof vi.spyOn>;
-
-	beforeEach(() => {
-		fetchSpy = vi.spyOn(globalThis, 'fetch');
-	});
-
-	afterEach(() => {
-		vi.restoreAllMocks();
-	});
-
-	it('should add cache buster timestamp to hydration script URL in development', async () => {
-		const mockHtml = `
-			<html>
-				<body>
-					<script type="module" src="/assets/scripts/ecopages-react-123-hydration.js">
-						import Content from './page.js';
-					</script>
-				</body>
-			</html>
-		`;
-
-		fetchSpy.mockResolvedValue(new Response("import Content from './page.js';", { status: 200 }));
-
-		const doc = createMockDocument(mockHtml);
-		await extractComponentUrl(doc);
-
-		const hydrationCalls = fetchSpy.mock.calls.filter((call: [RequestInfo | URL, RequestInit?]) =>
-			call[0].toString().includes('ecopages-react-123-hydration.js'),
-		);
-
-		expect(hydrationCalls.length).toBe(1);
-		expect(hydrationCalls[0][0].toString()).toMatch(/ecopages-react-123-hydration\.js\?t=\d+/);
 	});
 });

--- a/playground/kitchen-sink/e2e/counters.ts
+++ b/playground/kitchen-sink/e2e/counters.ts
@@ -103,6 +103,33 @@ async function incrementLitCounter(counter: Locator, expectedValue: string) {
 		.toBe(expectedValue);
 }
 
+async function waitForRadiantCounterReady(counter: Locator) {
+	await expect(counter).toHaveCount(1);
+	await expect
+		.poll(
+			async () =>
+				counter.evaluate(async (element) => {
+					const tagName = 'radiant-counter';
+					if (!customElements.get(tagName)) {
+						await customElements.whenDefined(tagName);
+					}
+
+					const RadiantCounter = customElements.get(tagName);
+					if (!RadiantCounter || !(element instanceof RadiantCounter)) {
+						return false;
+					}
+
+					const value = element.querySelector('[data-radiant-value]')?.textContent?.trim() ?? '';
+					return value !== '';
+				}),
+			{
+				intervals: [100, 200, 350, 500],
+				timeout: 5000,
+			},
+		)
+		.toBe(true);
+}
+
 export async function incrementCounter(button: Locator, value: Locator, expectedValue: string) {
 	await expect
 		.poll(
@@ -149,6 +176,7 @@ export async function assertRadiantCounterInteractivity(counter: Locator, initia
 	const increment = counter.locator('[data-radiant-inc]');
 
 	await expect(counter).toBeVisible();
+	await waitForRadiantCounterReady(counter);
 	await expect(value).toHaveText(initialValue);
 	await incrementCounter(increment, value, String(Number(initialValue) + 1));
 }
@@ -167,6 +195,7 @@ export async function assertFourCountersVisible(root: Locator) {
 	await waitForLitCounterReady(litCounter);
 	await expect(reactCounter).toHaveCount(1);
 	await expect(radiantCounter).toHaveCount(1);
+	await waitForRadiantCounterReady(radiantCounter);
 
 	await expect(kitaCounter).toBeVisible();
 	await expect.poll(() => readLitCounterValue(litCounter), { timeout: 5000 }).not.toBe('');

--- a/playground/kitchen-sink/src/components/radiant-counter-element.script.ts
+++ b/playground/kitchen-sink/src/components/radiant-counter-element.script.ts
@@ -1,4 +1,5 @@
 /** @jsxImportSource @ecopages/jsx */
+import '@ecopages/radiant/client/install-hydrator';
 import { RadiantElement, query, onEvent, onUpdated } from '@ecopages/radiant';
 import { customElement } from '@ecopages/radiant/decorators/custom-element';
 import { prop } from '@ecopages/radiant/decorators/prop';

--- a/playground/react-router/src/includes/html.tsx
+++ b/playground/react-router/src/includes/html.tsx
@@ -16,7 +16,7 @@ const HtmlTemplate = eco.html<ReactNode>({
 			<html lang={language}>
 				<Head metadata={metadata}>
 					{headContent}
-					<EcoPropsScript data={pageProps} module={pageModuleUrl} />
+					<EcoPropsScript data={pageProps} moduleUrl={pageModuleUrl} />
 				</Head>
 				<body>{children}</body>
 			</html>

--- a/playground/react-router/src/includes/html.tsx
+++ b/playground/react-router/src/includes/html.tsx
@@ -11,12 +11,12 @@ const HtmlTemplate = eco.html<ReactNode>({
 		scripts: [{ content: themeScript }],
 	},
 
-	render: ({ children, metadata, headContent, language = 'en', pageProps }) => {
+	render: ({ children, metadata, headContent, language = 'en', pageProps, pageModuleUrl }) => {
 		return (
 			<html lang={language}>
 				<Head metadata={metadata}>
 					{headContent}
-					<EcoPropsScript data={pageProps} />
+					<EcoPropsScript data={pageProps} module={pageModuleUrl} />
 				</Head>
 				<body>{children}</body>
 			</html>

--- a/playground/react/src/includes/html.tsx
+++ b/playground/react/src/includes/html.tsx
@@ -14,7 +14,7 @@ const HtmlTemplate = eco.component<HtmlTemplateProps, ReactNode>({
 			<html lang={language as string}>
 				<Head metadata={metadata}>
 					{headContent}
-					<EcoPropsScript data={pageProps} module={pageModuleUrl} />
+					<EcoPropsScript data={pageProps} moduleUrl={pageModuleUrl} />
 				</Head>
 				{children as ReactNode}
 			</html>

--- a/playground/react/src/includes/html.tsx
+++ b/playground/react/src/includes/html.tsx
@@ -9,12 +9,12 @@ const HtmlTemplate = eco.component<HtmlTemplateProps, ReactNode>({
 		components: [Head],
 	},
 
-	render: ({ children, metadata, headContent, pageProps, language = 'en' }) => {
+	render: ({ children, metadata, headContent, pageProps, pageModuleUrl, language = 'en' }) => {
 		return (
 			<html lang={language as string}>
 				<Head metadata={metadata}>
 					{headContent}
-					<EcoPropsScript data={pageProps} />
+					<EcoPropsScript data={pageProps} module={pageModuleUrl} />
 				</Head>
 				{children as ReactNode}
 			</html>

--- a/playground/with-react-better-auth/src/includes/html.tsx
+++ b/playground/with-react-better-auth/src/includes/html.tsx
@@ -13,12 +13,12 @@ const HtmlTemplate = eco.html<ReactNode>({
 		scripts: [{ content: themeScript }, { content: announcementScript }],
 	},
 
-	render: ({ children, metadata, headContent, language = 'en', pageProps }) => {
+	render: ({ children, metadata, headContent, language = 'en', pageProps, pageModuleUrl }) => {
 		return (
 			<html lang={language} suppressHydrationWarning>
 				<Head metadata={metadata}>
 					{headContent}
-					<EcoPropsScript data={pageProps} />
+					<EcoPropsScript data={pageProps} module={pageModuleUrl} />
 				</Head>
 				<body>{children}</body>
 			</html>

--- a/playground/with-react-better-auth/src/includes/html.tsx
+++ b/playground/with-react-better-auth/src/includes/html.tsx
@@ -18,7 +18,7 @@ const HtmlTemplate = eco.html<ReactNode>({
 			<html lang={language} suppressHydrationWarning>
 				<Head metadata={metadata}>
 					{headContent}
-					<EcoPropsScript data={pageProps} module={pageModuleUrl} />
+					<EcoPropsScript data={pageProps} moduleUrl={pageModuleUrl} />
 				</Head>
 				<body>{children}</body>
 			</html>

--- a/playground/with-react-better-auth/src/pages/skills.mdx
+++ b/playground/with-react-better-auth/src/pages/skills.mdx
@@ -503,12 +503,12 @@ const HtmlTemplate = eco.html<ReactNode>({
 		scripts: [{ content: themeScript }], 
 	},
 
-	render: ({ children, metadata, headContent, language = 'en', pageProps }) => {
+	render: ({ children, metadata, headContent, language = 'en', pageProps, pageModuleUrl }) => {
 		return (
 			<html lang={language} suppressHydrationWarning>
 				<Head metadata={metadata}>
 					{headContent}
-					<EcoPropsScript data={pageProps} />
+					<EcoPropsScript data={pageProps} module={pageModuleUrl} />
 				</Head>
 				<body>{children}</body>
 			</html>

--- a/playground/with-react-better-auth/src/pages/skills.mdx
+++ b/playground/with-react-better-auth/src/pages/skills.mdx
@@ -508,7 +508,7 @@ const HtmlTemplate = eco.html<ReactNode>({
 			<html lang={language} suppressHydrationWarning>
 				<Head metadata={metadata}>
 					{headContent}
-					<EcoPropsScript data={pageProps} module={pageModuleUrl} />
+					<EcoPropsScript data={pageProps} moduleUrl={pageModuleUrl} />
 				</Head>
 				<body>{children}</body>
 			</html>


### PR DESCRIPTION
## Summary

- Collapse Radiant SSR caches to instance ownership (delete `resetForTests`)
- Lazy Lit static-render session + identity recreate; locals stay in-process
- One `schemaVersion` page-data codec; explicit `pageModuleUrl`; drop `__ecoPageModule`
- Manifest/bootstrap module discovery only (no hydration-script parsing)
- One layout tree composer with persisted-tier resolver
- Explicit React navigation outcomes (`spa` / `handoff` / `hard` / `stale`)
- Inline page-data reader in hydration bootstrap (native ESM cannot resolve bare `@ecopages/react/*`); sync test guards drift
- Wire `serializePageDataManifestScript` as the router envelope emission path; drop dead hydration-asset alias helpers

Rebased onto `release/v0.2.0` after #212 merged.

## Test plan

- [x] `pnpm run test:ci:fast`
- [x] `pnpm run test:all` (vitest + full e2e matrix, local)
- [x] React Router browser navigation / HMR / handoff suites
- [x] `react-router-persist-layouts-dev-e2e` HMR page refresh
