### PR TITLE
fix(react): resolve HMR bootstraps and foreign island vendors

### DIFF
--- a/packages/core/src/route-renderer/orchestration/foreign-subtree-execution.service.ts
+++ b/packages/core/src/route-renderer/orchestration/foreign-subtree-execution.service.ts
@@ -68,7 +68,7 @@ export interface ForeignSubtreeExecutionRenderOptions {
 	getOwningRenderer(
 		integrationName: string,
 		rendererCache: Map<string, ForeignSubtreeExecutionOwningRenderer>,
-	): ForeignSubtreeExecutionOwningRenderer;
+	): Promise<ForeignSubtreeExecutionOwningRenderer>;
 }
 
 export interface ForeignSubtreeQueuedRuntimeOptions<TContext extends QueuedForeignSubtreeResolutionContext> {
@@ -91,7 +91,7 @@ export interface ForeignSubtreeStringQueuedHtmlOptions {
 	getOwningRenderer(
 		integrationName: string,
 		rendererCache: Map<string, ForeignSubtreeExecutionOwningRenderer>,
-	): ForeignSubtreeExecutionOwningRenderer;
+	): Promise<ForeignSubtreeExecutionOwningRenderer>;
 	applyAttributesToFirstElement(html: string, attributes: Record<string, string>): string;
 	dedupeProcessedAssets(assets: ProcessedAsset[]): ProcessedAsset[];
 }
@@ -110,7 +110,7 @@ export interface ForeignSubtreeQueuedHtmlOptions<TContext extends QueuedForeignS
 	getOwningRenderer(
 		integrationName: string,
 		rendererCache: Map<string, ForeignSubtreeExecutionOwningRenderer>,
-	): ForeignSubtreeExecutionOwningRenderer;
+	): Promise<ForeignSubtreeExecutionOwningRenderer>;
 	applyAttributesToFirstElement(html: string, attributes: Record<string, string>): string;
 	dedupeProcessedAssets(assets: ProcessedAsset[]): ProcessedAsset[];
 }
@@ -540,7 +540,7 @@ export class ForeignSubtreeExecutionService {
 		getOwningRenderer(
 			integrationName: string,
 			rendererCache: Map<string, ForeignSubtreeExecutionOwningRenderer>,
-		): ForeignSubtreeExecutionOwningRenderer;
+		): Promise<ForeignSubtreeExecutionOwningRenderer>;
 	}): Promise<ComponentRenderResult | undefined> {
 		return await this.runInForeignOwningRenderer({
 			currentIntegrationName: options.currentIntegrationName,
@@ -558,7 +558,7 @@ export class ForeignSubtreeExecutionService {
 		getOwningRenderer(
 			integrationName: string,
 			rendererCache: Map<string, ForeignSubtreeExecutionOwningRenderer>,
-		): ForeignSubtreeExecutionOwningRenderer;
+		): Promise<ForeignSubtreeExecutionOwningRenderer>;
 	}): Promise<ForeignSubtreeRenderPayload | undefined> {
 		return await this.runInForeignOwningRenderer({
 			currentIntegrationName: options.currentIntegrationName,
@@ -577,7 +577,7 @@ export class ForeignSubtreeExecutionService {
 		getOwningRenderer(
 			integrationName: string,
 			rendererCache: Map<string, ForeignSubtreeExecutionOwningRenderer>,
-		): ForeignSubtreeExecutionOwningRenderer;
+		): Promise<ForeignSubtreeExecutionOwningRenderer>;
 		run(
 			owningRenderer: ForeignSubtreeExecutionOwningRenderer,
 			delegatedInput: ComponentRenderInput,
@@ -591,7 +591,7 @@ export class ForeignSubtreeExecutionService {
 			return undefined;
 		}
 
-		const owningRenderer = options.getOwningRenderer(foreignOwnerIntegrationName, options.rendererCache);
+		const owningRenderer = await options.getOwningRenderer(foreignOwnerIntegrationName, options.rendererCache);
 		if (owningRenderer.name === options.currentIntegrationName) {
 			return undefined;
 		}

--- a/packages/core/src/route-renderer/orchestration/integration-renderer.test.ts
+++ b/packages/core/src/route-renderer/orchestration/integration-renderer.test.ts
@@ -32,7 +32,6 @@ function createUnresolvedMarkerArtifact(nodeId: string, componentRef: string, pr
 	return `<eco-marker data-eco-node-id="${nodeId}" data-eco-component-ref="${componentRef}" data-eco-props-ref="${propsRef}"></eco-marker>`;
 }
 
-
 function createMockIntegrationPlugin(
 	plugin: { name: string } & Record<string, unknown>,
 ): EcoPagesAppConfig['integrations'][number] {
@@ -43,7 +42,6 @@ function createMockIntegrationPlugin(
 		...plugin,
 	} as unknown as EcoPagesAppConfig['integrations'][number];
 }
-
 
 /**
  * Concrete implementation with ed file loading for testing purposes.

--- a/packages/core/src/route-renderer/orchestration/integration-renderer.test.ts
+++ b/packages/core/src/route-renderer/orchestration/integration-renderer.test.ts
@@ -32,6 +32,19 @@ function createUnresolvedMarkerArtifact(nodeId: string, componentRef: string, pr
 	return `<eco-marker data-eco-node-id="${nodeId}" data-eco-component-ref="${componentRef}" data-eco-props-ref="${propsRef}"></eco-marker>`;
 }
 
+
+function createMockIntegrationPlugin(
+	plugin: { name: string } & Record<string, unknown>,
+): EcoPagesAppConfig['integrations'][number] {
+	return {
+		setConfig: vi.fn(),
+		setRuntimeOrigin: vi.fn(),
+		setup: vi.fn(async () => {}),
+		...plugin,
+	} as unknown as EcoPagesAppConfig['integrations'][number];
+}
+
+
 /**
  * Concrete implementation with ed file loading for testing purposes.
  */
@@ -871,6 +884,7 @@ describe('IntegrationRenderer', () => {
 
 	it('should delegate foreign component boundaries through the shared execution seam', async () => {
 		const foreignRenderer = {
+			name: 'foreign-renderer',
 			renderComponentWithForeignChildren: vi.fn(async () => ({
 				html: '<aside>Owned by foreign renderer</aside>',
 				canAttachAttributes: true,
@@ -880,14 +894,16 @@ describe('IntegrationRenderer', () => {
 		} as unknown as IntegrationRenderer;
 
 		const initializeRenderer = vi.fn(() => foreignRenderer);
+		const setup = vi.fn(async () => {});
 		const renderer = new TestIntegrationRenderer({
 			appConfig: {
 				...AppConfig,
 				integrations: [
-					{
+					createMockIntegrationPlugin({
 						name: 'foreign-renderer',
 						initializeRenderer,
-					} as unknown as EcoPagesAppConfig['integrations'][number],
+						setup,
+					}),
 				],
 			} as EcoPagesAppConfig,
 			assetProcessingService: AssetService,
@@ -917,6 +933,7 @@ describe('IntegrationRenderer', () => {
 				integrationName: 'foreign-renderer',
 			}),
 		);
+		expect(setup).toHaveBeenCalledTimes(1);
 		expect(initializeRenderer).toHaveBeenCalledTimes(1);
 		expect(foreignRenderer.renderComponentWithForeignChildren).toHaveBeenCalledTimes(1);
 	});
@@ -938,10 +955,10 @@ describe('IntegrationRenderer', () => {
 			appConfig: {
 				...AppConfig,
 				integrations: [
-					{
+					createMockIntegrationPlugin({
 						name: 'foreign-renderer',
 						initializeRenderer,
-					} as unknown as EcoPagesAppConfig['integrations'][number],
+					}),
 				],
 			} as EcoPagesAppConfig,
 			assetProcessingService: AssetService,
@@ -981,10 +998,10 @@ describe('IntegrationRenderer', () => {
 			appConfig: {
 				...AppConfig,
 				integrations: [
-					{
+					createMockIntegrationPlugin({
 						name: 'foreign-renderer',
 						initializeRenderer: () => renderer,
-					} as unknown as EcoPagesAppConfig['integrations'][number],
+					}),
 				],
 			} as EcoPagesAppConfig,
 			assetProcessingService: AssetService,
@@ -1333,10 +1350,10 @@ describe('IntegrationRenderer', () => {
 			const appConfig = {
 				...AppConfig,
 				integrations: [
-					{
+					createMockIntegrationPlugin({
 						name: 'explicit-renderer',
 						initializeRenderer: () => explicitRenderer,
-					},
+					}),
 				],
 			} as unknown as EcoPagesAppConfig;
 
@@ -1405,11 +1422,11 @@ describe('IntegrationRenderer', () => {
 			const appConfig = {
 				...AppConfig,
 				integrations: [
-					{
+					createMockIntegrationPlugin({
 						name: 'react',
 						initializeRenderer: () => renderer as unknown as IntegrationRenderer,
 						getResolvedIntegrationDependencies: () => [explicitIntegrationDependency],
-					},
+					}),
 				],
 			} as unknown as EcoPagesAppConfig;
 
@@ -1486,10 +1503,10 @@ describe('IntegrationRenderer', () => {
 			const appConfig = {
 				...AppConfig,
 				integrations: [
-					{
+					createMockIntegrationPlugin({
 						name: 'explicit-renderer',
 						initializeRenderer: () => explicitRenderer,
-					},
+					}),
 				],
 			} as unknown as EcoPagesAppConfig;
 
@@ -1566,10 +1583,10 @@ describe('IntegrationRenderer', () => {
 			const appConfig = {
 				...AppConfig,
 				integrations: [
-					{
+					createMockIntegrationPlugin({
 						name: 'explicit-renderer',
 						initializeRenderer: () => explicitRenderer,
-					},
+					}),
 				],
 			} as unknown as EcoPagesAppConfig;
 
@@ -1663,10 +1680,10 @@ describe('IntegrationRenderer', () => {
 			const appConfig = {
 				...AppConfig,
 				integrations: [
-					{
+					createMockIntegrationPlugin({
 						name: 'explicit-renderer',
 						initializeRenderer: () => explicitRenderer,
-					},
+					}),
 				],
 			} as unknown as EcoPagesAppConfig;
 
@@ -1757,10 +1774,10 @@ describe('IntegrationRenderer', () => {
 			const appConfig = {
 				...AppConfig,
 				integrations: [
-					{
+					createMockIntegrationPlugin({
 						name: 'explicit-renderer',
 						initializeRenderer: () => explicitRenderer,
-					},
+					}),
 				],
 			} as unknown as EcoPagesAppConfig;
 
@@ -1864,10 +1881,10 @@ describe('IntegrationRenderer', () => {
 			const appConfig = {
 				...AppConfig,
 				integrations: [
-					{
+					createMockIntegrationPlugin({
 						name: 'foreign-renderer',
 						initializeRenderer: () => foreignRenderer,
-					},
+					}),
 				],
 			} as unknown as EcoPagesAppConfig;
 
@@ -1949,10 +1966,10 @@ describe('IntegrationRenderer', () => {
 			const appConfig = {
 				...AppConfig,
 				integrations: [
-					{
+					createMockIntegrationPlugin({
 						name: 'explicit-renderer',
 						initializeRenderer: () => explicitRenderer,
-					},
+					}),
 				],
 			} as unknown as EcoPagesAppConfig;
 
@@ -2170,10 +2187,10 @@ describe('IntegrationRenderer', () => {
 			const appConfig = {
 				...AppConfig,
 				integrations: [
-					{
+					createMockIntegrationPlugin({
 						name: 'foreign-renderer',
 						initializeRenderer,
-					},
+					}),
 				],
 			} as unknown as EcoPagesAppConfig;
 

--- a/packages/core/src/route-renderer/orchestration/integration-renderer.ts
+++ b/packages/core/src/route-renderer/orchestration/integration-renderer.ts
@@ -985,16 +985,18 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 	 * Returns a renderer instance for a given integration name.
 	 *
 	 * Uses a per-execution cache to avoid repeated renderer initialization.
+	 * Activates the foreign integration runtime before creating its renderer so
+	 * global assets (for example React vendor ESM) exist before island scripts import them.
 	 *
 	 * @param integrationName Target integration name.
 	 * @param cache Render-pass renderer cache.
 	 * @returns Renderer for the requested integration.
 	 * @throws Error when no integration plugin matches `integrationName`.
 	 */
-	protected getIntegrationRendererForName(
+	protected async getIntegrationRendererForName(
 		integrationName: string,
 		cache: Map<string, ForeignSubtreeExecutionOwningRenderer>,
-	): ForeignSubtreeExecutionOwningRenderer {
+	): Promise<ForeignSubtreeExecutionOwningRenderer> {
 		if (cache.has(integrationName)) {
 			return cache.get(integrationName) as ForeignSubtreeExecutionOwningRenderer;
 		}
@@ -1003,6 +1005,12 @@ export abstract class IntegrationRenderer<C = EcoPagesElement> {
 			cache.set(integrationName, this);
 			return this;
 		}
+
+		await ensureIntegrationRuntimeReady({
+			appConfig: this.appConfig,
+			integrationName,
+			runtimeOrigin: this.runtimeOrigin,
+		});
 
 		const integrationPlugin = this.appConfig.integrations.find(
 			(integration) => integration.name === integrationName,

--- a/packages/integrations/react/src/hydration/hydration-asset.test.ts
+++ b/packages/integrations/react/src/hydration/hydration-asset.test.ts
@@ -97,7 +97,7 @@ describe('HydrationAssetService', () => {
 		});
 	});
 
-	it('keeps router-managed page entries unbundled in development', () => {
+	it('bundles router-managed page bootstraps in development while keeping the HMR page module external', () => {
 		const service = new HydrationAssetService({
 			srcDir: '/app/src',
 			routerAdapter: {
@@ -130,19 +130,80 @@ describe('HydrationAssetService', () => {
 			componentName: 'ecopages-react-docs',
 			importPath: '/assets/_hmr/pages/docs/index.js',
 			pageModuleUrlExpression: '"/assets/_hmr/pages/docs/index.js"',
-			bundleOptions: {},
+			bundleOptions: {
+				external: ['/assets/vendors/react-router-esm.js'],
+			},
 			hmrEnabled: true,
 			useBrowserRuntimeImports: true,
 			isMdx: false,
 		});
 
 		expect(dependencies[0]).toMatchObject({
-			bundle: false,
-			groupedBundle: {
-				id: 'ecopages-react-router-pages',
-				entryName: 'pages__docs__index',
+			bundle: true,
+			groupedBundle: undefined,
+			bundleOptions: {
+				external: expect.arrayContaining([
+					'/assets/vendors/react-router-esm.js',
+					'/assets/_hmr/pages/docs/index.js',
+				]),
+			},
+			attributes: {
+				'data-eco-page-bootstrap': 'react-router',
 			},
 		});
+		expect(String((dependencies[0] as { content?: string }).content ?? '')).toContain(
+			'from "/assets/_hmr/pages/docs/index.js"',
+		);
+	});
+
+	it('bundles MDX page bootstraps that import layout normalization helpers', () => {
+		const service = new HydrationAssetService({
+			srcDir: '/app/src',
+			routerAdapter: {
+				name: 'eco-router',
+				bundle: {
+					outputName: 'react-router-esm',
+					importPath: '@ecopages/react-router/browser',
+					externals: [],
+				},
+				components: {
+					router: 'EcoRouter',
+					pageContent: 'PageContent',
+				},
+				getRouterProps: () => '{}',
+			},
+			assetProcessingService: {
+				getHmrManager: () => ({ isEnabled: () => true }),
+			} as any,
+			bundleService: {
+				getRuntimeImports: () => ({
+					react: '/assets/vendors/react.js',
+					reactDomClient: '/assets/vendors/react-dom.js',
+					router: '/assets/vendors/react-router-esm.js',
+				}),
+			} as any,
+		});
+
+		const dependencies = service.createPageDependencies({
+			pagePath: '/app/src/pages/react-content.mdx',
+			componentName: 'ecopages-react-mdx',
+			importPath: '/assets/_hmr/pages/react-content.js',
+			pageModuleUrlExpression: '"/assets/_hmr/pages/react-content.js"',
+			bundleOptions: {},
+			hmrEnabled: true,
+			useBrowserRuntimeImports: true,
+			isMdx: true,
+		});
+
+		const content = String((dependencies[0] as { content?: string }).content ?? '');
+		expect(dependencies[0]).toMatchObject({
+			bundle: true,
+			bundleOptions: {
+				external: ['/assets/_hmr/pages/react-content.js'],
+			},
+		});
+		expect(content).toContain('@ecopages/core/eco/page-layout-normalization');
+		expect(content).toContain('from "/assets/_hmr/pages/react-content.js"');
 	});
 
 	it('bundles the React runtime into production page browser graph entries', async () => {

--- a/packages/integrations/react/src/hydration/hydration-asset.ts
+++ b/packages/integrations/react/src/hydration/hydration-asset.ts
@@ -113,12 +113,28 @@ export class HydrationAssetService {
 			isMdx,
 		} = options;
 		const runtimeImports = this.config.bundleService.getRuntimeImports();
-		const groupedBundle = this.config.routerAdapter
+		/**
+		 * @remarks
+		 * Production router pages share a grouped bundle. Development HMR keeps each
+		 * page bootstrap independent so the hot page module URL stays external while
+		 * bare `@ecopages/*` helpers resolve through the browser bundler.
+		 */
+		const groupedBundle =
+			!hmrEnabled && this.config.routerAdapter
+				? {
+						id: HydrationAssetService.ROUTER_PAGE_GROUPED_BUNDLE_ID,
+						entryName: this.getRouterPageGroupedEntryName(pagePath),
+					}
+				: undefined;
+		const existingExternal = Array.isArray(bundleOptions.external)
+			? bundleOptions.external.filter((value): value is string => typeof value === 'string')
+			: [];
+		const pageBootstrapBundleOptions = hmrEnabled
 			? {
-					id: HydrationAssetService.ROUTER_PAGE_GROUPED_BUNDLE_ID,
-					entryName: this.getRouterPageGroupedEntryName(pagePath),
+					...bundleOptions,
+					external: [...new Set([...existingExternal, importPath])],
 				}
-			: undefined;
+			: bundleOptions;
 		return [
 			AssetFactory.createContentScript({
 				position: 'head',
@@ -139,9 +155,16 @@ export class HydrationAssetService {
 				}),
 				name: componentName,
 				packageRole: 'page-script',
-				bundle: !hmrEnabled,
+				/**
+				 * @remarks
+				 * Always bundle page bootstraps. Unbundled HMR entries are evaluated as
+				 * native browser ESM and cannot resolve bare package imports such as
+				 * `@ecopages/core/eco/page-layout-normalization` or
+				 * `@ecopages/react/layout-compose`.
+				 */
+				bundle: true,
 				groupedBundle,
-				bundleOptions,
+				bundleOptions: pageBootstrapBundleOptions,
 				attributes: {
 					type: 'module',
 					defer: '',

--- a/packages/integrations/react/src/hydration/hydration-scripts.test.ts
+++ b/packages/integrations/react/src/hydration/hydration-scripts.test.ts
@@ -34,7 +34,7 @@ describe('createHydrationScript', () => {
 		expect(script).toContain('window.__ECO_PAGES__.hmrHandlers');
 	});
 
-	test('development output passes serialized locals to layout hydration for non-router MDX pages', () => {
+	test('development MDX output emits layout helpers for the browser bundler to resolve', () => {
 		const script = createHydrationScript({
 			...baseOptions,
 			hmrEnabled: true,
@@ -42,6 +42,9 @@ describe('createHydrationScript', () => {
 		});
 
 		expect(script).toContain('import { composeLayoutPageTree } from "@ecopages/react/layout-compose";');
+		expect(script).toContain('import { ensurePageConfigLayouts } from "@ecopages/core/eco/page-layout-normalization";');
+		expect(script).toContain('import * as MDXModule from "/assets/page.js";');
+		expect(script).toContain('ensurePageConfigLayouts(Page.config);');
 		expect(script).toContain('const createTree = (Component, props) => composeLayoutPageTree(Component, props);');
 	});
 

--- a/packages/integrations/react/src/hydration/hydration-scripts.test.ts
+++ b/packages/integrations/react/src/hydration/hydration-scripts.test.ts
@@ -42,7 +42,9 @@ describe('createHydrationScript', () => {
 		});
 
 		expect(script).toContain('import { composeLayoutPageTree } from "@ecopages/react/layout-compose";');
-		expect(script).toContain('import { ensurePageConfigLayouts } from "@ecopages/core/eco/page-layout-normalization";');
+		expect(script).toContain(
+			'import { ensurePageConfigLayouts } from "@ecopages/core/eco/page-layout-normalization";',
+		);
 		expect(script).toContain('import * as MDXModule from "/assets/page.js";');
 		expect(script).toContain('ensurePageConfigLayouts(Page.config);');
 		expect(script).toContain('const createTree = (Component, props) => composeLayoutPageTree(Component, props);');

--- a/packages/integrations/react/src/hydration/hydration-scripts.ts
+++ b/packages/integrations/react/src/hydration/hydration-scripts.ts
@@ -41,8 +41,9 @@ export type HydrationScriptOptions = {
 	 * When true, emit HMR registration and hot-reload handlers.
 	 *
 	 * @remarks
-	 * The asset layer uses the same flag to leave HMR entries unbundled. When
-	 * false, this generator emits the same readable bootstrap without HMR hooks.
+	 * Page bootstraps are always bundled so bare package imports resolve through
+	 * the browser build pipeline. When false, this generator emits the same
+	 * readable bootstrap without HMR hooks.
 	 */
 	hmrEnabled: boolean;
 	/** Whether the source file is an MDX file */

--- a/packages/integrations/react/src/render/component-ssr.ts
+++ b/packages/integrations/react/src/render/component-ssr.ts
@@ -2,13 +2,7 @@
  * React component SSR helpers: renderToString, foreign-subtree HTML, island attributes.
  */
 
-import type {
-	ComponentRenderInput,
-	ComponentRenderResult,
-	EcoComponent,
-	EcoComponentConfig,
-	EcoPagesElement,
-} from '@ecopages/core';
+import type { ComponentRenderInput, ComponentRenderResult, EcoComponent, EcoPagesElement } from '@ecopages/core';
 import type { ProcessedAsset } from '@ecopages/core/services/asset-processing-service';
 import type { IntegrationRenderer } from '@ecopages/core/route-renderer/integration-renderer';
 import type { ReactNode } from 'react';

--- a/playground/kitchen-sink/e2e/react-routes.test.e2e.ts
+++ b/playground/kitchen-sink/e2e/react-routes.test.e2e.ts
@@ -17,7 +17,10 @@ async function waitForReactPageHydration(page: Page) {
 }
 
 async function assertReactPageBootstrapHasNoBareCoreImports(page: Page) {
-	const bootstrapSrc = await page.locator('script[data-eco-page-bootstrap="react-router"]').first().getAttribute('src');
+	const bootstrapSrc = await page
+		.locator('script[data-eco-page-bootstrap="react-router"]')
+		.first()
+		.getAttribute('src');
 	expect(bootstrapSrc).toBeTruthy();
 
 	const response = await page.request.get(bootstrapSrc!);

--- a/playground/kitchen-sink/e2e/react-routes.test.e2e.ts
+++ b/playground/kitchen-sink/e2e/react-routes.test.e2e.ts
@@ -1,0 +1,106 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from 'playwright-core';
+import { integrationMatrixTestIds } from '../src/data/integration-matrix';
+import {
+	assertAllCountersInteractivity,
+	gotoPath,
+	incrementCounter,
+	recoverToPath,
+	trackRuntimeErrors,
+} from './helpers';
+import { fireRapidLinkClicks, settleAfterRapidHops } from './rapid-navigation-sequences';
+
+async function waitForReactPageHydration(page: Page) {
+	await page.waitForFunction(() => !!window.__ECO_PAGES__?.react?.pageRoot, null, {
+		timeout: 10000,
+	});
+}
+
+async function assertReactPageBootstrapHasNoBareCoreImports(page: Page) {
+	const bootstrapSrc = await page.locator('script[data-eco-page-bootstrap="react-router"]').first().getAttribute('src');
+	expect(bootstrapSrc).toBeTruthy();
+
+	const response = await page.request.get(bootstrapSrc!);
+	expect(response.ok()).toBe(true);
+	const body = await response.text();
+	expect(body).not.toMatch(/from\s+["']@ecopages\/core\//);
+	expect(body).not.toMatch(/from\s+["']@ecopages\/react\/layout-compose["']/);
+}
+
+test.describe('React routes interactivity @content', () => {
+	test('cold-loads React MDX and increments the page counter', async ({ page }) => {
+		const runtime = trackRuntimeErrors(page);
+
+		await gotoPath(page, '/react-content');
+		await expect(page.getByTestId('page-react-content')).toBeVisible();
+		await waitForReactPageHydration(page);
+		await assertReactPageBootstrapHasNoBareCoreImports(page);
+
+		const root = page.getByTestId('page-react-content');
+		await expect(root.locator('[data-react-value]')).toHaveText('0');
+		await incrementCounter(root.locator('[data-react-inc]'), root.locator('[data-react-value]'), '1');
+		await expect(root.locator('lit-counter')).toHaveCount(1);
+
+		runtime.assertClean();
+	});
+
+	test('keeps React MDX counters interactive after browser-router and react-router handoffs', async ({ page }) => {
+		const runtime = trackRuntimeErrors(page);
+
+		await gotoPath(page, '/docs');
+		await page.getByTestId('primary-link-react-content').click();
+		await expect(page.getByTestId('page-react-content')).toBeVisible({ timeout: 15_000 });
+		await waitForReactPageHydration(page);
+		await incrementCounter(
+			page.getByTestId('page-react-content').locator('[data-react-inc]'),
+			page.getByTestId('page-react-content').locator('[data-react-value]'),
+			'1',
+		);
+
+		await page.getByTestId('route-link-react-lab').click();
+		await expect(page.getByRole('heading', { name: 'React Page Route' })).toBeVisible({ timeout: 15_000 });
+		await waitForReactPageHydration(page);
+
+		await page.getByTestId('primary-link-react-content').click();
+		await expect(page.getByTestId('page-react-content')).toBeVisible({ timeout: 15_000 });
+		await waitForReactPageHydration(page);
+		await incrementCounter(
+			page.getByTestId('page-react-content').locator('[data-react-inc]'),
+			page.getByTestId('page-react-content').locator('[data-react-value]'),
+			'1',
+		);
+
+		runtime.assertClean();
+	});
+
+	test('keeps the React-shell matrix counter interactive after cross-runtime hops', async ({ page }) => {
+		const runtime = trackRuntimeErrors(page);
+		const priorHops = ['/docs', '/react-lab', '/react-content', '/integration-matrix/lit-entry'];
+
+		await gotoPath(page, '/');
+		await fireRapidLinkClicks(page, priorHops);
+		await settleAfterRapidHops(page);
+		await recoverToPath(page, '/integration-matrix/react-entry');
+
+		await expect(page.getByTestId(integrationMatrixTestIds.hostShellStack)).toBeVisible({ timeout: 15_000 });
+		await assertAllCountersInteractivity(page.getByTestId('integration-matrix-shell-counters-react'));
+
+		runtime.assertClean();
+	});
+
+	test('cold-loads Kita-hosted React islands without prior React page activation', async ({ page }) => {
+		const runtime = trackRuntimeErrors(page);
+
+		await gotoPath(page, '/integration-matrix/react-entry');
+		await expect(page.getByTestId(integrationMatrixTestIds.hostShellStack)).toBeVisible({ timeout: 15_000 });
+
+		const reactVendor = await page.request.get('/assets/vendors/react.development.js');
+		const reactDomVendor = await page.request.get('/assets/vendors/react-dom.development.js');
+		expect(reactVendor.ok()).toBe(true);
+		expect(reactDomVendor.ok()).toBe(true);
+
+		await assertAllCountersInteractivity(page.getByTestId('integration-matrix-shell-counters-react'));
+
+		runtime.assertClean();
+	});
+});

--- a/playground/kitchen-sink/e2e/test-support.ts
+++ b/playground/kitchen-sink/e2e/test-support.ts
@@ -29,6 +29,7 @@ const RUNTIME_ERROR_PATTERNS = [
 	/Missing props reference/i,
 	/Failed to execute 'appendChild'/i,
 	/Hydration failed/i,
+	/Failed to resolve module specifier/i,
 ] as const;
 
 /** Cancel an in-flight browser-router / react-router morph so Playwright can navigate again. */


### PR DESCRIPTION
## Summary
- Bundle React page bootstraps in HMR so bare `@ecopages/*` imports resolve through the browser build pipeline
- Activate foreign integrations before renderer init so React vendor ESM exists for Kita-hosted islands
- Add kitchen-sink E2E coverage for React MDX interactivity and cold-load foreign React islands

## Test plan
- [x] Unit: hydration-asset / hydration-scripts / integration-renderer / foreign-subtree
- [x] E2E: `node e2e/scripts/playwright/run-each-project.mjs --grep 'React routes interactivity' cross-integration-dev-e2e`
- [x] Manual: cold-load `/react-content` and increment counter
- [x] Manual: cold-load `/integration-matrix/react-entry` without visiting React pages first; confirm vendors 200 and counters hydrate