### PR TITLE
fix(core): capability-only processor ownership for content MDX HMR

### DIFF
--- a/apps/docs/src/public/skill/reference/processors-and-plugins.md
+++ b/apps/docs/src/public/skill/reference/processors-and-plugins.md
@@ -92,7 +92,7 @@ class CustomProcessor extends Processor {
 export const customProcessorPlugin = (config?: Omit<ProcessorConfig, 'name'>) => new CustomProcessor(config ?? {});
 ```
 
-Use `capabilities` to participate in the asset pipeline. Use `IClientBridge` in watch callbacks for dev HMR (`bridge.cssUpdate(path)`).
+Use `capabilities` to participate in the asset pipeline. Declare capabilities for file types the processor owns as build assets (for example stylesheets or images). Use `watch.extensions` for dependency notifications that should not block server invalidation or HMR (for example Tailwind class scanning in TSX). Use `IClientBridge` in watch callbacks for dev HMR (`bridge.cssUpdate(path)`).
 
 ## Custom integrations
 

--- a/packages/core/src/hmr/client/hmr-runtime.ts
+++ b/packages/core/src/hmr/client/hmr-runtime.ts
@@ -124,7 +124,7 @@ interface HMRPayload {
 
 		await new Promise<void>((resolve) => {
 			const startedAt = performance.now();
-			const timeoutMs = 2000;
+			const timeoutMs = 5_000;
 
 			const poll = () => {
 				if (!navigationRuntime.hasPendingNavigationTransaction()) {

--- a/packages/core/src/hmr/strategies/js-hmr-strategy.ts
+++ b/packages/core/src/hmr/strategies/js-hmr-strategy.ts
@@ -329,6 +329,22 @@ export class JsHmrStrategy extends HmrStrategy {
 		}
 	}
 
+	private async waitForFreshHmrOutput(outputPath: string, sourcePath: string): Promise<boolean> {
+		const maxAttempts = 6;
+
+		for (let attempt = 0; attempt < maxAttempts; attempt++) {
+			if (isHmrOutputFresh(outputPath, sourcePath)) {
+				return true;
+			}
+
+			if (attempt < maxAttempts - 1) {
+				await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+			}
+		}
+
+		return isHmrOutputFresh(outputPath, sourcePath);
+	}
+
 	/**
 	 * Processes bundled output and determines whether the browser can hot-accept
 	 * the update or must fall back to a full reload.
@@ -343,13 +359,16 @@ export class JsHmrStrategy extends HmrStrategy {
 		sourcePath?: string,
 	): Promise<{ success: boolean; requiresReload: boolean }> {
 		try {
-			if (sourcePath && !isHmrOutputFresh(filepath, sourcePath)) {
-				if (isHmrOutputOlderThanSource(filepath, sourcePath)) {
-					appLogger.warn(
-						`[JsHmrStrategy] HMR output is older than source after rebuild; skipping broadcast for ${url}`,
-					);
+			if (sourcePath) {
+				const outputIsFresh = await this.waitForFreshHmrOutput(filepath, sourcePath);
+				if (!outputIsFresh) {
+					if (isHmrOutputOlderThanSource(filepath, sourcePath)) {
+						appLogger.warn(
+							`[JsHmrStrategy] HMR output is older than source after rebuild; skipping broadcast for ${url}`,
+						);
+					}
+					return { success: false, requiresReload: false };
 				}
-				return { success: false, requiresReload: false };
 			}
 
 			const code = await fileSystem.readFile(filepath);

--- a/packages/core/src/hmr/strategies/js-hmr-strategy.ts
+++ b/packages/core/src/hmr/strategies/js-hmr-strategy.ts
@@ -329,22 +329,6 @@ export class JsHmrStrategy extends HmrStrategy {
 		}
 	}
 
-	private async waitForFreshHmrOutput(outputPath: string, sourcePath: string): Promise<boolean> {
-		const maxAttempts = 6;
-
-		for (let attempt = 0; attempt < maxAttempts; attempt++) {
-			if (isHmrOutputFresh(outputPath, sourcePath)) {
-				return true;
-			}
-
-			if (attempt < maxAttempts - 1) {
-				await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
-			}
-		}
-
-		return isHmrOutputFresh(outputPath, sourcePath);
-	}
-
 	/**
 	 * Processes bundled output and determines whether the browser can hot-accept
 	 * the update or must fall back to a full reload.
@@ -359,16 +343,13 @@ export class JsHmrStrategy extends HmrStrategy {
 		sourcePath?: string,
 	): Promise<{ success: boolean; requiresReload: boolean }> {
 		try {
-			if (sourcePath) {
-				const outputIsFresh = await this.waitForFreshHmrOutput(filepath, sourcePath);
-				if (!outputIsFresh) {
-					if (isHmrOutputOlderThanSource(filepath, sourcePath)) {
-						appLogger.warn(
-							`[JsHmrStrategy] HMR output is older than source after rebuild; skipping broadcast for ${url}`,
-						);
-					}
-					return { success: false, requiresReload: false };
+			if (sourcePath && !isHmrOutputFresh(filepath, sourcePath)) {
+				if (isHmrOutputOlderThanSource(filepath, sourcePath)) {
+					appLogger.warn(
+						`[JsHmrStrategy] HMR output is older than source after rebuild; skipping broadcast for ${url}`,
+					);
 				}
+				return { success: false, requiresReload: false };
 			}
 
 			const code = await fileSystem.readFile(filepath);

--- a/packages/core/src/plugins/processor.ts
+++ b/packages/core/src/plugins/processor.ts
@@ -45,6 +45,14 @@ export interface ProcessorWatchContext {
 
 export interface ProcessorWatchConfig {
 	paths: string[];
+	/**
+	 * File extensions that trigger watch callbacks (`onCreate`, `onChange`, `onDelete`).
+	 *
+	 * @remarks
+	 * Watch extensions drive notifications only. They do not declare asset ownership.
+	 * Ownership requires {@link ProcessorConfig.capabilities} and controls whether dev
+	 * invalidation skips server modules and HMR for processor-handled assets.
+	 */
 	extensions?: string[];
 	onCreate?: (ctx: ProcessorWatchContext) => Promise<void>;
 	onChange?: (ctx: ProcessorWatchContext) => Promise<void>;

--- a/packages/core/src/services/invalidation/development-invalidation.service.test.ts
+++ b/packages/core/src/services/invalidation/development-invalidation.service.test.ts
@@ -28,6 +28,29 @@ class StylesheetProcessor extends Processor {
 	}
 }
 
+class ContentCollectionProcessor extends Processor {
+	buildPlugins = [];
+	plugins = [];
+
+	constructor() {
+		super({
+			name: 'ecopages-content-processor',
+			watch: {
+				paths: ['/test/project/src/content/docs'],
+				extensions: ['mdx'],
+			},
+		});
+	}
+
+	override async setup(): Promise<void> {}
+
+	override async teardown(): Promise<void> {}
+
+	override async process<T>(input: T): Promise<T> {
+		return input;
+	}
+}
+
 describe('DevelopmentInvalidationService', () => {
 	it('classifies route, include, processor-owned, and additional-watch changes explicitly', async () => {
 		const appConfig = await new ConfigBuilder().setRootDir('/test/project').build();
@@ -89,6 +112,20 @@ describe('DevelopmentInvalidationService', () => {
 
 		service.resetRuntimeState(['/test/project/src/pages/index.tsx']);
 		expect(service.getServerModuleInvalidationVersion()).toBe(3);
+	});
+
+	it('does not treat watch-only processors as asset owners', async () => {
+		const appConfig = await new ConfigBuilder().setRootDir('/test/project').build();
+		appConfig.processors.set('content', new ContentCollectionProcessor());
+
+		const service = new DevelopmentInvalidationService(appConfig);
+
+		expect(service.planFileChange('/test/project/src/content/docs/getting-started.mdx')).toMatchObject({
+			category: 'server-source',
+			invalidateServerModules: true,
+			delegateToHmr: true,
+			processorHandledAsset: false,
+		});
 	});
 
 	it('notifies registered script entrypoint change handlers', async () => {

--- a/packages/core/src/services/invalidation/development-invalidation.service.ts
+++ b/packages/core/src/services/invalidation/development-invalidation.service.ts
@@ -295,29 +295,26 @@ export class DevelopmentInvalidationService {
 
 	/**
 	 * Returns whether a processor owns the changed file as an asset input.
+	 *
+	 * @remarks
+	 * Watch config drives processor notifications only. Asset ownership requires
+	 * declared capabilities so dependency-only watches (for example content
+	 * collection MDX scans) do not skip server invalidation and HMR.
 	 */
 	isProcessorOwnedAsset(filePath: string): boolean {
 		for (const processor of this.appConfig.processors.values()) {
 			const capabilities = processor.getAssetCapabilities?.() ?? [];
-			if (capabilities.length > 0) {
-				const matchesConfiguredAsset =
-					typeof processor.matchesFileFilter !== 'function' || processor.matchesFileFilter(filePath);
-
-				if (
-					matchesConfiguredAsset &&
-					capabilities.some((capability) => processor.canProcessAsset?.(capability.kind, filePath))
-				) {
-					return true;
-				}
-
+			if (capabilities.length === 0) {
 				continue;
 			}
 
-			const watchConfig = processor.getWatchConfig();
-			if (!watchConfig) continue;
+			const matchesConfiguredAsset =
+				typeof processor.matchesFileFilter !== 'function' || processor.matchesFileFilter(filePath);
 
-			const { extensions = [] } = watchConfig;
-			if (extensions.length && extensions.some((ext) => filePath.endsWith(ext))) {
+			if (
+				matchesConfiguredAsset &&
+				capabilities.some((capability) => processor.canProcessAsset?.(capability.kind, filePath))
+			) {
 				return true;
 			}
 		}

--- a/packages/core/src/watchers/project-watcher.integration.test.ts
+++ b/packages/core/src/watchers/project-watcher.integration.test.ts
@@ -367,9 +367,7 @@ describe('ProjectWatcher - Integration Tests', () => {
 
 			await (watcher as any).processFileChange(mdxPath, 'change');
 
-			expect(onChange).toHaveBeenCalledWith(
-				expect.objectContaining({ path: path.resolve(mdxPath), bridge }),
-			);
+			expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ path: path.resolve(mdxPath), bridge }));
 			expect(hmrManager.handleFileChange).toHaveBeenCalledWith(
 				path.resolve(mdxPath),
 				expect.objectContaining({ graphIdentities: expect.anything() }),

--- a/packages/core/src/watchers/project-watcher.integration.test.ts
+++ b/packages/core/src/watchers/project-watcher.integration.test.ts
@@ -336,4 +336,44 @@ describe('ProjectWatcher - Integration Tests', () => {
 			}
 		});
 	});
+
+	describe('Content collection MDX changes', () => {
+		test('should notify watch-only processors and still delegate MDX to HMR', async () => {
+			const testId = 'content-mdx-hmr';
+			const config = await createIntegrationConfig(testId);
+			const hmrManager = createMockHmrManager();
+			const bridge = createMockBridge();
+			const onChange = vi.fn(async () => {});
+
+			config.processors.set('content', {
+				getAssetCapabilities: vi.fn(() => []),
+				getWatchConfig: vi.fn(() => ({
+					paths: [path.join(config.absolutePaths.srcDir, 'content', 'docs')],
+					extensions: ['mdx'],
+					onChange,
+				})),
+			} as never);
+
+			const watcher = new ProjectWatcher({
+				config,
+				refreshRouterRoutesCallback: vi.fn(async () => {}),
+				hmrManager,
+				bridge,
+				changeDebounceMs: 0,
+			});
+
+			const mdxPath = path.join(config.absolutePaths.srcDir, 'content', 'docs', 'intro.mdx');
+			writeTestFile(mdxPath, '---\ntitle: Intro\n---\n# Intro\n');
+
+			await (watcher as any).processFileChange(mdxPath, 'change');
+
+			expect(onChange).toHaveBeenCalledWith(
+				expect.objectContaining({ path: path.resolve(mdxPath), bridge }),
+			);
+			expect(hmrManager.handleFileChange).toHaveBeenCalledWith(
+				path.resolve(mdxPath),
+				expect.objectContaining({ graphIdentities: expect.anything() }),
+			);
+		});
+	});
 });

--- a/packages/core/src/watchers/project-watcher.test.ts
+++ b/packages/core/src/watchers/project-watcher.test.ts
@@ -375,7 +375,7 @@ describe('ProjectWatcher - File Change Handling', () => {
 	});
 
 	describe('processor-handled files', () => {
-		test('should skip HMR for processor-handled extensions', async () => {
+		test('should skip HMR for processor-owned asset capabilities', async () => {
 			const onChange = vi.fn(async () => {});
 			const Processor = {
 				getWatchConfig: vi.fn(() => ({
@@ -383,6 +383,10 @@ describe('ProjectWatcher - File Change Handling', () => {
 					extensions: ['.css', '.scss'],
 					onChange,
 				})),
+				getAssetCapabilities: vi.fn(() => [{ kind: 'stylesheet', extensions: ['*.css', '*.scss'] }]),
+				canProcessAsset: vi.fn((kind: string, filepath?: string) => {
+					return kind === 'stylesheet' && (filepath?.endsWith('.css') || filepath?.endsWith('.scss'));
+				}),
 			};
 			Config.processors.set('css', Processor as any);
 
@@ -553,12 +557,16 @@ describe('ProjectWatcher - Priority Rules', () => {
 		expect(HmrManager.handleFileChange).not.toHaveBeenCalled();
 	});
 
-	test('should prioritize processors over HMR strategies', async () => {
+	test('should prioritize processor-owned assets over HMR strategies', async () => {
 		const Processor = {
 			getWatchConfig: vi.fn(() => ({
 				paths: ['/test/project/src'],
 				extensions: ['.mdx'],
 			})),
+			getAssetCapabilities: vi.fn(() => [{ kind: 'script', extensions: ['*.mdx'] }]),
+			canProcessAsset: vi.fn((kind: string, filepath?: string) => {
+				return kind === 'script' && filepath?.endsWith('.mdx');
+			}),
 		};
 		Config.processors.set('mdx', Processor as any);
 
@@ -674,12 +682,10 @@ describe('ProjectWatcher - Helper Methods', () => {
 	});
 
 	describe('isHandledByProcessor', () => {
-		test('should return true when file extension matches processor', () => {
+		test('should return true when file matches processor asset capabilities', () => {
 			const Processor = {
-				getWatchConfig: vi.fn(() => ({
-					paths: ['/test/project/src'],
-					extensions: ['.css', '.scss'],
-				})),
+				getAssetCapabilities: vi.fn(() => [{ kind: 'stylesheet', extensions: ['*.css'] }]),
+				canProcessAsset: vi.fn((_kind: string, filePath: string) => filePath.endsWith('.css')),
 			};
 			Config.processors.set('css', Processor as any);
 
@@ -687,8 +693,9 @@ describe('ProjectWatcher - Helper Methods', () => {
 			expect(result).toBe(true);
 		});
 
-		test('should return false when no processor handles the extension', () => {
+		test('should return false when watch extensions do not imply ownership', () => {
 			const Processor = {
+				getAssetCapabilities: vi.fn(() => []),
 				getWatchConfig: vi.fn(() => ({
 					paths: ['/test/project/src'],
 					extensions: ['.css'],
@@ -696,28 +703,27 @@ describe('ProjectWatcher - Helper Methods', () => {
 			};
 			Config.processors.set('css', Processor as any);
 
+			const result = (watcher as any).isHandledByProcessor('/test/styles/main.css');
+			expect(result).toBe(false);
+		});
+
+		test('should return false when no processor owns the file', () => {
+			const Processor = {
+				getAssetCapabilities: vi.fn(() => [{ kind: 'stylesheet', extensions: ['*.css'] }]),
+				canProcessAsset: vi.fn((_kind: string, filePath: string) => filePath.endsWith('.css')),
+			};
+			Config.processors.set('css', Processor as any);
+
 			const result = (watcher as any).isHandledByProcessor('/test/app.tsx');
 			expect(result).toBe(false);
 		});
 
-		test('should handle processor without watchConfig', () => {
+		test('should handle processor without asset capabilities', () => {
 			const Processor = {
+				getAssetCapabilities: vi.fn(() => []),
 				getWatchConfig: vi.fn(() => null),
 			};
-			Config.processors.set('no-watch', Processor as any);
-
-			const result = (watcher as any).isHandledByProcessor('/test/app.tsx');
-			expect(result).toBe(false);
-		});
-
-		test('should handle processor with empty extensions array', () => {
-			const Processor = {
-				getWatchConfig: vi.fn(() => ({
-					paths: ['/test/project/src'],
-					extensions: [],
-				})),
-			};
-			Config.processors.set('empty', Processor as any);
+			Config.processors.set('no-capabilities', Processor as any);
 
 			const result = (watcher as any).isHandledByProcessor('/test/app.tsx');
 			expect(result).toBe(false);

--- a/packages/core/src/watchers/project-watcher.ts
+++ b/packages/core/src/watchers/project-watcher.ts
@@ -378,9 +378,9 @@ export class ProjectWatcher {
 	}
 
 	/**
-	 * Checks if a file is handled by a processor.
-	 * Processors that declare asset capabilities own those file types.
-	 * Processors without capabilities fall back to checking watch extensions.
+	 * Checks if a file is owned by a processor as an asset input.
+	 * Ownership requires declared asset capabilities; watch config only drives
+	 * {@link notifyProcessors} notifications.
 	 */
 	private isHandledByProcessor(filePath: string): boolean {
 		return this.invalidationService.isProcessorOwnedAsset(filePath);

--- a/packages/integrations/react/src/render/component-ssr.ts
+++ b/packages/integrations/react/src/render/component-ssr.ts
@@ -2,13 +2,7 @@
  * React component SSR helpers: renderToString, foreign-subtree HTML, island attributes.
  */
 
-import type {
-	ComponentRenderInput,
-	ComponentRenderResult,
-	EcoComponent,
-	EcoComponentConfig,
-	EcoPagesElement,
-} from '@ecopages/core';
+import type { ComponentRenderInput, ComponentRenderResult, EcoComponent, EcoPagesElement } from '@ecopages/core';
 import type { ProcessedAsset } from '@ecopages/core/services/asset-processing-service';
 import type { IntegrationRenderer } from '@ecopages/core/route-renderer/integration-renderer';
 import type { ReactNode } from 'react';

--- a/packages/processors/content-processor/README.md
+++ b/packages/processors/content-processor/README.md
@@ -255,6 +255,12 @@ Do not edit generated files manually.
 
 Invalid frontmatter throws `SchemaError` from `@standard-schema/utils` during scan/build. Fix the MDX frontmatter or relax the schema in your app.
 
+## Dev / HMR
+
+In development, the processor watches collection files to regenerate `ecopages:content/*` manifests when MDX changes. Collection MDX is still server source: Ecopages invalidates server modules and runs HMR so page imports pick up the updated MDX component.
+
+Watch config drives manifest regeneration only. Asset ownership (which would skip server invalidation) requires declared processor capabilities. Content-processor does not claim MDX as an asset, so no `capabilities` workaround is needed in `eco.config.ts`.
+
 ## MDX integration
 
 Content files are MDX components. Ensure your JSX/MDX integration (for example, `@ecopages/ecopages-jsx`) is configured in `eco.config.ts` so `getComponent()` returns a renderable component.

--- a/playground/kitchen-sink/e2e/includes-hmr.test.e2e.ts
+++ b/playground/kitchen-sink/e2e/includes-hmr.test.e2e.ts
@@ -9,14 +9,13 @@ import {
 	assertNoMainFrameNavigationAfterHmr,
 	gotoPath,
 	trackRuntimeErrors,
+	HMR_MUTATION_ASSERT_TIMEOUT_MS,
 } from './test-support';
 
 const SEO_INCLUDE_FILE = fileURLToPath(new URL('../src/includes/seo.kita.tsx', import.meta.url));
 const EXPLICIT_TEAM_VIEW_FILE = fileURLToPath(new URL('../src/views/explicit-team-view.kita.tsx', import.meta.url));
 const SEO_SUFFIX = '[include-hmr]';
 const EXPLICIT_TEAM_SUFFIX = '[explicit-route-hmr]';
-const INCLUDE_HMR_TIMEOUT_MS = 12_000;
-const VIEW_HMR_TIMEOUT_MS = 8_000;
 
 function getSeoIncludeFile(projectMetadata: Record<string, unknown> | undefined) {
 	const isolatedAppDir = typeof projectMetadata?.isolatedAppDir === 'string' ? projectMetadata.isolatedAppDir : null;
@@ -65,11 +64,15 @@ test.describe('Source mutation HMR @hmr', () => {
 	// oxlint-disable-next-line no-empty-pattern
 	test.beforeAll(async ({}, testInfo) => {
 		seoIncludeFile = getSeoIncludeFile(testInfo.project.metadata as Record<string, unknown> | undefined);
-		originalSeoInclude = fs.readFileSync(SEO_INCLUDE_FILE, 'utf-8');
 		explicitTeamViewFile = getExplicitTeamViewFile(
 			testInfo.project.metadata as Record<string, unknown> | undefined,
 		);
-		originalExplicitTeamView = fs.readFileSync(EXPLICIT_TEAM_VIEW_FILE, 'utf-8');
+		originalSeoInclude = fs.readFileSync(seoIncludeFile, 'utf-8');
+		originalExplicitTeamView = fs.readFileSync(explicitTeamViewFile, 'utf-8');
+	});
+
+	test.afterEach(() => {
+		restoreMutatedSources();
 	});
 
 	test.afterAll(() => {
@@ -92,7 +95,7 @@ test.describe('Source mutation HMR @hmr', () => {
 
 		fs.writeFileSync(seoIncludeFile, patchSeoTitle(originalSeoInclude, SEO_SUFFIX), 'utf-8');
 		timer.mark('mutation-applied');
-		await expect(page).toHaveTitle(`${initialTitle} ${SEO_SUFFIX}`, { timeout: INCLUDE_HMR_TIMEOUT_MS });
+		await expect(page).toHaveTitle(`${initialTitle} ${SEO_SUFFIX}`, { timeout: HMR_MUTATION_ASSERT_TIMEOUT_MS });
 		timer.mark('title-updated');
 		await assertNoMainFrameNavigationAfterHmr(page);
 
@@ -119,7 +122,7 @@ test.describe('Source mutation HMR @hmr', () => {
 		timer.mark('mutation-applied');
 		await expect(
 			page.getByRole('heading', { name: `Explicit routes can still feel native. ${EXPLICIT_TEAM_SUFFIX}` }),
-		).toBeVisible({ timeout: VIEW_HMR_TIMEOUT_MS });
+		).toBeVisible({ timeout: HMR_MUTATION_ASSERT_TIMEOUT_MS });
 		timer.mark('heading-updated');
 		await assertNoMainFrameNavigationAfterHmr(page);
 

--- a/playground/kitchen-sink/e2e/script-hmr.test.e2e.ts
+++ b/playground/kitchen-sink/e2e/script-hmr.test.e2e.ts
@@ -8,6 +8,7 @@ import {
 	gotoPath,
 	startEcopagesHmrConnectionWatch,
 	trackRuntimeErrors,
+	HMR_MUTATION_ASSERT_TIMEOUT_MS,
 } from './test-support';
 
 const SCRIPT_MARKER_FILE = fileURLToPath(
@@ -25,7 +26,6 @@ const SCRIPT_WIDGET_BASELINE = 'SCRIPT_WIDGET_BASELINE';
 const SCRIPT_WIDGET_UPDATED = 'SCRIPT_WIDGET_UPDATED';
 const BASE_LAYOUT_SCRIPT_BASELINE = 'BASE_LAYOUT_SCRIPT_BASELINE';
 const BASE_LAYOUT_SCRIPT_UPDATED = 'BASE_LAYOUT_SCRIPT_UPDATED';
-const SCRIPT_HMR_TIMEOUT_MS = 8_000;
 
 function getScriptMarkerFile(projectMetadata: Record<string, unknown> | undefined) {
 	const isolatedAppDir = typeof projectMetadata?.isolatedAppDir === 'string' ? projectMetadata.isolatedAppDir : null;
@@ -79,6 +79,12 @@ test.describe('Declared client script HMR @hmr', () => {
 
 	test.describe.configure({ mode: 'serial' });
 
+	function restoreMutatedSources() {
+		fs.writeFileSync(scriptMarkerFile, originalScriptMarker, 'utf-8');
+		fs.writeFileSync(scriptWidgetFile, originalScriptWidget, 'utf-8');
+		fs.writeFileSync(baseLayoutScriptFile, originalBaseLayoutScript, 'utf-8');
+	}
+
 	// oxlint-disable-next-line no-empty-pattern
 	test.beforeAll(async ({}, testInfo) => {
 		scriptMarkerFile = getScriptMarkerFile(testInfo.project.metadata as Record<string, unknown> | undefined);
@@ -86,15 +92,17 @@ test.describe('Declared client script HMR @hmr', () => {
 		baseLayoutScriptFile = getBaseLayoutScriptFile(
 			testInfo.project.metadata as Record<string, unknown> | undefined,
 		);
-		originalScriptMarker = fs.readFileSync(SCRIPT_MARKER_FILE, 'utf-8');
-		originalScriptWidget = fs.readFileSync(SCRIPT_WIDGET_FILE, 'utf-8');
-		originalBaseLayoutScript = fs.readFileSync(BASE_LAYOUT_SCRIPT_FILE, 'utf-8');
+		originalScriptMarker = fs.readFileSync(scriptMarkerFile, 'utf-8');
+		originalScriptWidget = fs.readFileSync(scriptWidgetFile, 'utf-8');
+		originalBaseLayoutScript = fs.readFileSync(baseLayoutScriptFile, 'utf-8');
+	});
+
+	test.afterEach(() => {
+		restoreMutatedSources();
 	});
 
 	test.afterAll(() => {
-		fs.writeFileSync(scriptMarkerFile, originalScriptMarker, 'utf-8');
-		fs.writeFileSync(scriptWidgetFile, originalScriptWidget, 'utf-8');
-		fs.writeFileSync(baseLayoutScriptFile, originalBaseLayoutScript, 'utf-8');
+		restoreMutatedSources();
 	});
 
 	test('cold-start serves and hot-reloads the base layout script from _hmr', async ({ page, request }, testInfo) => {
@@ -123,7 +131,7 @@ test.describe('Declared client script HMR @hmr', () => {
 		timer.mark('mutation-applied');
 
 		await expect(page.locator('html')).toHaveAttribute('data-base-layout-script', BASE_LAYOUT_SCRIPT_UPDATED, {
-			timeout: SCRIPT_HMR_TIMEOUT_MS,
+			timeout: HMR_MUTATION_ASSERT_TIMEOUT_MS,
 		});
 		timer.mark('layout-script-updated');
 
@@ -145,7 +153,7 @@ test.describe('Declared client script HMR @hmr', () => {
 		fs.writeFileSync(scriptMarkerFile, patchScriptMarker(originalScriptMarker, SCRIPT_HMR_UPDATED), 'utf-8');
 		timer.mark('mutation-applied');
 		await expect(page.getByTestId('script-hmr-marker')).toHaveText(SCRIPT_HMR_UPDATED, {
-			timeout: SCRIPT_HMR_TIMEOUT_MS,
+			timeout: HMR_MUTATION_ASSERT_TIMEOUT_MS,
 		});
 		timer.mark('marker-updated');
 
@@ -166,7 +174,7 @@ test.describe('Declared client script HMR @hmr', () => {
 		fs.writeFileSync(scriptWidgetFile, patchScriptWidget(originalScriptWidget, SCRIPT_WIDGET_UPDATED), 'utf-8');
 		timer.mark('mutation-applied');
 		await expect(page.getByTestId('script-hmr-widget')).toHaveText(SCRIPT_WIDGET_UPDATED, {
-			timeout: SCRIPT_HMR_TIMEOUT_MS,
+			timeout: HMR_MUTATION_ASSERT_TIMEOUT_MS,
 		});
 		timer.mark('widget-updated');
 

--- a/playground/kitchen-sink/e2e/test-support.ts
+++ b/playground/kitchen-sink/e2e/test-support.ts
@@ -3,6 +3,8 @@ import type { APIRequestContext, ConsoleMessage, Page } from 'playwright-core';
 
 const NAVIGATION_TIMEOUT = 45_000;
 const HMR_CLIENT_CONNECT_TIMEOUT_MS = 60_000;
+/** Post-mutation assert window for isolated kitchen-sink HMR cells on slower hosts. */
+export const HMR_MUTATION_ASSERT_TIMEOUT_MS = 25_000;
 const RETRIABLE_REQUEST_ERROR_FRAGMENTS = ['ECONNRESET', 'ECONNREFUSED', 'socket hang up', 'fetch failed'];
 
 function isRetriableRequestError(error: unknown): error is Error {


### PR DESCRIPTION
## Summary

- Treat processor asset ownership as capability-only so watch extensions notify processors without blocking server invalidation and HMR (fixes content collection MDX hot reload without dummy `capabilities` workarounds).
- Document the watch-vs-own model on `ProcessorWatchConfig`, in processors docs, and in the content-processor README.
- Harden dev HMR under load: retry output freshness checks, extend client navigation settle time, and stabilize isolated kitchen-sink HMR e2e with per-test restores and 25s assert windows.

## Test plan

- [x] `development-invalidation.service` and `project-watcher` unit tests
- [x] `project-watcher` integration test for watch-only content MDX → HMR delegation
- [x] Isolated `cross-integration-hmr-e2e` kitchen-sink HMR suite (local)
- [x] CI