### PR TITLE
feat(core): generate opt-in sitemap.xml after static export

### DIFF
--- a/packages/core/src/config/config-builder.test.ts
+++ b/packages/core/src/config/config-builder.test.ts
@@ -313,6 +313,31 @@ describe('EcoConfigBuilder', () => {
 		expect(config.robotsTxt).toEqual(robotsTxt);
 	});
 
+	test('should set sitemap with defaults merged', async () => {
+		const config = await builder
+			.setBaseUrl('https://example.com')
+			.setRootDir('/project')
+			.setSitemap({ enabled: true, extraUrls: ['/rss.xml'] })
+			.build();
+
+		expect(config.sitemap).toEqual({
+			enabled: true,
+			fileName: 'sitemap.xml',
+			extraUrls: ['/rss.xml'],
+			exclude: [],
+		});
+	});
+
+	test('should default sitemap to disabled', async () => {
+		const config = await builder.setBaseUrl('https://example.com').setRootDir('/project').build();
+		expect(config.sitemap).toEqual({
+			enabled: false,
+			fileName: 'sitemap.xml',
+			extraUrls: [],
+			exclude: [],
+		});
+	});
+
 	test('should set integrations', async () => {
 		const integrations: IntegrationPlugin[] = [createMockIntegration('test-integration', ['.test'])];
 		const config = await builder

--- a/packages/core/src/config/config-builder.ts
+++ b/packages/core/src/config/config-builder.ts
@@ -289,7 +289,9 @@ export class ConfigBuilder {
 	 *
 	 * @remarks
 	 * Merged over `{ enabled: false, fileName: 'sitemap.xml', extraUrls: [], exclude: [] }`.
-	 * Existing apps stay unchanged until `enabled: true` is set.
+	 * Existing apps stay unchanged until `enabled: true` is set. Page-level
+	 * `metadata.robots.index: false` and metadata resolution failures are handled
+	 * during static generation (not by this config merge).
 	 */
 	setSitemap(sitemap: SitemapConfig): this {
 		const defaults: Required<Pick<SitemapConfig, 'enabled' | 'fileName' | 'extraUrls' | 'exclude'>> = {

--- a/packages/core/src/config/config-builder.ts
+++ b/packages/core/src/config/config-builder.ts
@@ -27,7 +27,7 @@ import type { AnyIntegrationPlugin } from '../plugins/integration-plugin.ts';
 import type { Processor } from '../plugins/processor.ts';
 import type { EcoSourceTransform } from '../plugins/source-transform.ts';
 import type { RuntimeCapabilityDeclaration, RuntimeCapabilityTag } from '../plugins/runtime-capability.ts';
-import type { PageMetadataProps } from '../types/public-types.ts';
+import type { PageMetadataProps, SitemapConfig } from '../types/public-types.ts';
 import type { CacheConfig } from '../services/cache/cache.types.ts';
 import {
 	NoopEntrypointDependencyGraph,
@@ -118,6 +118,12 @@ export class ConfigBuilder {
 			preferences: {
 				'*': [],
 			},
+		},
+		sitemap: {
+			enabled: false,
+			fileName: 'sitemap.xml',
+			extraUrls: [],
+			exclude: [],
 		},
 		integrations: [],
 		integrationsDependencies: [],
@@ -275,6 +281,30 @@ export class ConfigBuilder {
 	 */
 	setRobotsTxt(robotsTxt: { preferences: RobotsPreference }): this {
 		this.config.robotsTxt = robotsTxt;
+		return this;
+	}
+
+	/**
+	 * Sets automatic sitemap.xml generation during static export.
+	 *
+	 * @remarks
+	 * Merged over `{ enabled: false, fileName: 'sitemap.xml', extraUrls: [], exclude: [] }`.
+	 * Existing apps stay unchanged until `enabled: true` is set.
+	 */
+	setSitemap(sitemap: SitemapConfig): this {
+		const defaults: Required<Pick<SitemapConfig, 'enabled' | 'fileName' | 'extraUrls' | 'exclude'>> = {
+			enabled: false,
+			fileName: 'sitemap.xml',
+			extraUrls: [],
+			exclude: [],
+		};
+		this.config.sitemap = {
+			...defaults,
+			...this.config.sitemap,
+			...sitemap,
+			extraUrls: sitemap.extraUrls ?? this.config.sitemap.extraUrls ?? defaults.extraUrls,
+			exclude: sitemap.exclude ?? this.config.sitemap.exclude ?? defaults.exclude,
+		};
 		return this;
 	}
 

--- a/packages/core/src/services/assets/asset-processing-service/processors/script/content-script.processor.test.ts
+++ b/packages/core/src/services/assets/asset-processing-service/processors/script/content-script.processor.test.ts
@@ -19,6 +19,7 @@ function createMockConfig(): EcoPagesAppConfig {
 		templatesExt: [],
 		componentsDir: 'components',
 		robotsTxt: { preferences: { '*': [] } },
+		sitemap: { enabled: false, fileName: 'sitemap.xml', extraUrls: [], exclude: [] },
 		additionalWatchPaths: [],
 		defaultMetadata: { title: 'Test', description: 'Test' },
 		integrations: [],

--- a/packages/core/src/services/assets/asset-processing-service/processors/stylesheet/content-stylesheet.processor.test.ts
+++ b/packages/core/src/services/assets/asset-processing-service/processors/stylesheet/content-stylesheet.processor.test.ts
@@ -19,6 +19,7 @@ function createMockConfig(processors = new Map<string, Processor>()): EcoPagesAp
 		templatesExt: [],
 		componentsDir: 'components',
 		robotsTxt: { preferences: { '*': [] } },
+		sitemap: { enabled: false, fileName: 'sitemap.xml', extraUrls: [], exclude: [] },
 		additionalWatchPaths: [],
 		defaultMetadata: { title: 'Test', description: 'Test' },
 		integrations: [],

--- a/packages/core/src/static-site-generator/README.md
+++ b/packages/core/src/static-site-generator/README.md
@@ -29,8 +29,10 @@ It should not invent a parallel rendering stack just for build mode.
 
 | File                           | Role                                                                         |
 | ------------------------------ | ---------------------------------------------------------------------------- |
-| `static-site-generator.ts`     | Route enumeration, HTML artifact writes, integration export hooks            |
+| `static-site-generator.ts`     | Route enumeration, HTML artifact writes, integration export hooks, sitemap   |
 | `static-export-context.ts`     | Hook context type for `beforeStaticExport` / `afterStaticExport`             |
+| `sitemap.ts`                   | Pure sitemap.xml renderer                                                    |
+| `sitemap-routes.ts`            | Sitemap pathname filtering (`exclude`, `noindex`, `extraUrls`)               |
 | `static-build-invalidation.ts` | `dist/` reset policy, production cache clearing, static-render cache context |
 
 Build-input fingerprinting (`hashAppConfigFile`, `createBuildInputsFingerprint`) lives in `packages/core/src/build/cache/build-input-fingerprint.ts` and is shared with server-entry and unified-graph caches.
@@ -55,5 +57,9 @@ Integrations may implement:
 
 - `beforeStaticExport(context)` — runs after unified-graph prebuild, before page rendering
 - `afterStaticExport(context)` — runs in a `finally` block after generation completes
+
+When `appConfig.sitemap.enabled` is true, `sitemap.xml` is written **after** `afterStaticExport` so integration-generated URLs can be listed via `extraUrls`.
+
+`StaticExportContext.routes` is the unfiltered static-generation route list. Sitemap filtering (`exclude`, `noindex`, successfully exported pathnames) is applied separately.
 
 See `StaticExportContext` in `static-export-context.ts`.

--- a/packages/core/src/static-site-generator/README.md
+++ b/packages/core/src/static-site-generator/README.md
@@ -32,7 +32,7 @@ It should not invent a parallel rendering stack just for build mode.
 | `static-site-generator.ts`     | Route enumeration, HTML artifact writes, integration export hooks, sitemap   |
 | `static-export-context.ts`     | Hook context type for `beforeStaticExport` / `afterStaticExport`             |
 | `sitemap.ts`                   | Pure sitemap.xml renderer                                                    |
-| `sitemap-routes.ts`            | Sitemap pathname filtering (`exclude`, `noindex`, `extraUrls`)               |
+| `sitemap-routes.ts`            | Sitemap location assembly (`exclude`, `extraUrls`, dedupe)                   |
 | `static-build-invalidation.ts` | `dist/` reset policy, production cache clearing, static-render cache context |
 
 Build-input fingerprinting (`hashAppConfigFile`, `createBuildInputsFingerprint`) lives in `packages/core/src/build/cache/build-input-fingerprint.ts` and is shared with server-entry and unified-graph caches.
@@ -60,6 +60,8 @@ Integrations may implement:
 
 When `appConfig.sitemap.enabled` is true, `sitemap.xml` is written **after** `afterStaticExport` so integration-generated URLs can be listed via `extraUrls`.
 
-`StaticExportContext.routes` is the unfiltered static-generation route list. Sitemap filtering (`exclude`, `noindex`, successfully exported pathnames) is applied separately.
+Sitemap eligibility is decided during successful page export (`activeStaticPathnames` plus `robots.index !== false`, fail-closed on metadata errors). `resolveSitemapLocations` then applies `exclude` and appends `extraUrls`.
+
+`StaticExportContext.routes` is the unfiltered static-generation route list. Sitemap filtering is applied separately.
 
 See `StaticExportContext` in `static-export-context.ts`.

--- a/packages/core/src/static-site-generator/sitemap-routes.test.ts
+++ b/packages/core/src/static-site-generator/sitemap-routes.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test, vi } from 'vitest';
+import { resolveSitemapPathnames } from './sitemap-routes.ts';
+
+describe('resolveSitemapPathnames', () => {
+	test('keeps only active pathnames and appends extraUrls', async () => {
+		const locations = await resolveSitemapPathnames({
+			baseUrl: 'https://example.com',
+			activeStaticPathnames: new Set(['/', '/blog']),
+			candidates: [
+				{ pathname: '/', params: {} },
+				{ pathname: '/blog', params: {} },
+				{ pathname: '/draft', params: {} },
+			],
+			sitemap: { enabled: true, extraUrls: ['/rss.xml'] },
+			resolveMetadata: async () => undefined,
+		});
+
+		expect(locations).toEqual(['https://example.com/', 'https://example.com/blog', 'https://example.com/rss.xml']);
+	});
+
+	test('drops exclude matches and noindex pages', async () => {
+		const resolveMetadata = vi.fn(async ({ pathname }: { pathname: string }) => {
+			if (pathname === '/secret') {
+				return { robots: { index: false } };
+			}
+			return undefined;
+		});
+
+		const locations = await resolveSitemapPathnames({
+			baseUrl: 'https://example.com',
+			activeStaticPathnames: new Set(['/', '/admin', '/admin/users', '/secret', '/about']),
+			candidates: [
+				{ pathname: '/', params: {}, filePath: '/pages/index.tsx' },
+				{ pathname: '/admin', params: {}, filePath: '/pages/admin.tsx' },
+				{ pathname: '/admin/users', params: {}, filePath: '/pages/admin/users.tsx' },
+				{ pathname: '/secret', params: {}, filePath: '/pages/secret.tsx' },
+				{ pathname: '/about', params: {}, filePath: '/pages/about.tsx' },
+			],
+			sitemap: { enabled: true, exclude: ['/admin/**'] },
+			resolveMetadata,
+		});
+
+		expect(locations).toEqual(['https://example.com/', 'https://example.com/about']);
+		expect(resolveMetadata).toHaveBeenCalled();
+	});
+
+	test('deduplicates overlapping candidates and extraUrls', async () => {
+		const locations = await resolveSitemapPathnames({
+			baseUrl: 'https://example.com',
+			activeStaticPathnames: new Set(['/feed']),
+			candidates: [{ pathname: '/feed', params: {} }],
+			sitemap: { enabled: true, extraUrls: ['/feed', '/rss.xml'] },
+			resolveMetadata: async () => undefined,
+		});
+
+		expect(locations).toEqual(['https://example.com/feed', 'https://example.com/rss.xml']);
+	});
+});

--- a/packages/core/src/static-site-generator/sitemap-routes.test.ts
+++ b/packages/core/src/static-site-generator/sitemap-routes.test.ts
@@ -1,56 +1,36 @@
-import { describe, expect, test, vi } from 'vitest';
-import { resolveSitemapPathnames } from './sitemap-routes.ts';
+import { describe, expect, test } from 'vitest';
+import { resolveSitemapLocations } from './sitemap-routes.ts';
 
-describe('resolveSitemapPathnames', () => {
-	test('keeps only active pathnames and appends extraUrls', async () => {
-		const locations = await resolveSitemapPathnames({
+describe('resolveSitemapLocations', () => {
+	test('keeps eligible pathnames and appends extraUrls', () => {
+		const locations = resolveSitemapLocations({
 			baseUrl: 'https://example.com',
-			activeStaticPathnames: new Set(['/', '/blog']),
-			candidates: [
-				{ pathname: '/', params: {} },
-				{ pathname: '/blog', params: {} },
-				{ pathname: '/draft', params: {} },
-			],
+			eligiblePathnames: ['/', '/blog'],
 			sitemap: { enabled: true, extraUrls: ['/rss.xml'] },
-			resolveMetadata: async () => undefined,
 		});
 
 		expect(locations).toEqual(['https://example.com/', 'https://example.com/blog', 'https://example.com/rss.xml']);
 	});
 
-	test('drops exclude matches and noindex pages', async () => {
-		const resolveMetadata = vi.fn(async ({ pathname }: { pathname: string }) => {
-			if (pathname === '/secret') {
-				return { robots: { index: false } };
-			}
-			return undefined;
-		});
-
-		const locations = await resolveSitemapPathnames({
+	test('drops exclude matches and always includes extraUrls', () => {
+		const locations = resolveSitemapLocations({
 			baseUrl: 'https://example.com',
-			activeStaticPathnames: new Set(['/', '/admin', '/admin/users', '/secret', '/about']),
-			candidates: [
-				{ pathname: '/', params: {}, filePath: '/pages/index.tsx' },
-				{ pathname: '/admin', params: {}, filePath: '/pages/admin.tsx' },
-				{ pathname: '/admin/users', params: {}, filePath: '/pages/admin/users.tsx' },
-				{ pathname: '/secret', params: {}, filePath: '/pages/secret.tsx' },
-				{ pathname: '/about', params: {}, filePath: '/pages/about.tsx' },
-			],
-			sitemap: { enabled: true, exclude: ['/admin/**'] },
-			resolveMetadata,
+			eligiblePathnames: ['/', '/admin', '/admin/users', '/about'],
+			sitemap: { enabled: true, exclude: ['/admin/**'], extraUrls: ['/admin/manifest.json'] },
 		});
 
-		expect(locations).toEqual(['https://example.com/', 'https://example.com/about']);
-		expect(resolveMetadata).toHaveBeenCalled();
+		expect(locations).toEqual([
+			'https://example.com/',
+			'https://example.com/about',
+			'https://example.com/admin/manifest.json',
+		]);
 	});
 
-	test('deduplicates overlapping candidates and extraUrls', async () => {
-		const locations = await resolveSitemapPathnames({
+	test('deduplicates overlapping eligible paths and extraUrls', () => {
+		const locations = resolveSitemapLocations({
 			baseUrl: 'https://example.com',
-			activeStaticPathnames: new Set(['/feed']),
-			candidates: [{ pathname: '/feed', params: {} }],
+			eligiblePathnames: ['/feed'],
 			sitemap: { enabled: true, extraUrls: ['/feed', '/rss.xml'] },
-			resolveMetadata: async () => undefined,
 		});
 
 		expect(locations).toEqual(['https://example.com/feed', 'https://example.com/rss.xml']);

--- a/packages/core/src/static-site-generator/sitemap-routes.ts
+++ b/packages/core/src/static-site-generator/sitemap-routes.ts
@@ -1,0 +1,81 @@
+import type { PageMetadataProps, SitemapConfig } from '../types/public-types.ts';
+import { matchesAnyPathPattern, normalizePathname } from '../utils/path-pattern.ts';
+import { buildSitemapLocation } from './sitemap.ts';
+
+/**
+ * A route candidate considered for sitemap inclusion.
+ */
+export type SitemapRouteCandidate = {
+	pathname: string;
+	params: Record<string, string>;
+	/** Filesystem page path when metadata can be resolved via the page module loader. */
+	filePath?: string;
+};
+
+export type ResolveSitemapMetadata = (input: {
+	pathname: string;
+	params: Record<string, string>;
+	filePath?: string;
+}) => Promise<Pick<PageMetadataProps, 'robots'> | undefined>;
+
+/**
+ * Filters static-export pathnames into the ordered list that should appear in sitemap.xml.
+ *
+ * @remarks
+ * Precedence (all must pass before a page URL is listed):
+ * 1. Pathname is in `activeStaticPathnames` (successfully exported)
+ * 2. Pathname does not match any `sitemap.exclude` pattern
+ * 3. Resolved `metadata.robots?.index !== false`
+ *
+ * `extraUrls` are always appended after page URLs and are not subject to page metadata.
+ */
+export async function resolveSitemapPathnames(input: {
+	candidates: readonly SitemapRouteCandidate[];
+	activeStaticPathnames: ReadonlySet<string>;
+	sitemap: SitemapConfig;
+	baseUrl: string;
+	resolveMetadata: ResolveSitemapMetadata;
+}): Promise<string[]> {
+	const exclude = input.sitemap.exclude ?? [];
+	const locations: string[] = [];
+	const seen = new Set<string>();
+
+	for (const candidate of input.candidates) {
+		const pathname = normalizePathname(candidate.pathname);
+		if (!input.activeStaticPathnames.has(pathname) && !input.activeStaticPathnames.has(candidate.pathname)) {
+			continue;
+		}
+
+		if (matchesAnyPathPattern(pathname, exclude)) {
+			continue;
+		}
+
+		const metadata = await input.resolveMetadata({
+			pathname,
+			params: candidate.params,
+			filePath: candidate.filePath,
+		});
+
+		if (metadata?.robots?.index === false) {
+			continue;
+		}
+
+		const location = buildSitemapLocation(input.baseUrl, pathname);
+		if (seen.has(location)) {
+			continue;
+		}
+		seen.add(location);
+		locations.push(location);
+	}
+
+	for (const extraUrl of input.sitemap.extraUrls ?? []) {
+		const location = buildSitemapLocation(input.baseUrl, extraUrl);
+		if (seen.has(location)) {
+			continue;
+		}
+		seen.add(location);
+		locations.push(location);
+	}
+
+	return locations;
+}

--- a/packages/core/src/static-site-generator/sitemap-routes.ts
+++ b/packages/core/src/static-site-generator/sitemap-routes.ts
@@ -1,66 +1,31 @@
-import type { PageMetadataProps, SitemapConfig } from '../types/public-types.ts';
+import type { SitemapConfig } from '../types/public-types.ts';
 import { matchesAnyPathPattern, normalizePathname } from '../utils/path-pattern.ts';
 import { buildSitemapLocation } from './sitemap.ts';
 
 /**
- * A route candidate considered for sitemap inclusion.
- */
-export type SitemapRouteCandidate = {
-	pathname: string;
-	params: Record<string, string>;
-	/** Filesystem page path when metadata can be resolved via the page module loader. */
-	filePath?: string;
-};
-
-export type ResolveSitemapMetadata = (input: {
-	pathname: string;
-	params: Record<string, string>;
-	filePath?: string;
-}) => Promise<Pick<PageMetadataProps, 'robots'> | undefined>;
-
-/**
- * Filters static-export pathnames into the ordered list that should appear in sitemap.xml.
+ * Builds the ordered absolute locations for sitemap.xml.
  *
  * @remarks
- * Precedence (all must pass before a page URL is listed):
- * 1. Pathname is in `activeStaticPathnames` (successfully exported)
- * 2. Pathname does not match any `sitemap.exclude` pattern
- * 3. Resolved `metadata.robots?.index !== false`
- *
- * `extraUrls` are always appended after page URLs and are not subject to page metadata.
+ * `eligiblePathnames` must already be successfully exported and robots-indexable.
+ * Filtering here is only `sitemap.exclude`, then `extraUrls` are appended.
+ * `extraUrls` always include (deduped) and are not subject to `exclude` or page robots.
  */
-export async function resolveSitemapPathnames(input: {
-	candidates: readonly SitemapRouteCandidate[];
-	activeStaticPathnames: ReadonlySet<string>;
+export function resolveSitemapLocations(input: {
+	eligiblePathnames: readonly string[];
 	sitemap: SitemapConfig;
 	baseUrl: string;
-	resolveMetadata: ResolveSitemapMetadata;
-}): Promise<string[]> {
+}): string[] {
 	const exclude = input.sitemap.exclude ?? [];
 	const locations: string[] = [];
 	const seen = new Set<string>();
 
-	for (const candidate of input.candidates) {
-		const pathname = normalizePathname(candidate.pathname);
-		if (!input.activeStaticPathnames.has(pathname) && !input.activeStaticPathnames.has(candidate.pathname)) {
+	for (const pathname of input.eligiblePathnames) {
+		const normalized = normalizePathname(pathname);
+		if (matchesAnyPathPattern(normalized, exclude)) {
 			continue;
 		}
 
-		if (matchesAnyPathPattern(pathname, exclude)) {
-			continue;
-		}
-
-		const metadata = await input.resolveMetadata({
-			pathname,
-			params: candidate.params,
-			filePath: candidate.filePath,
-		});
-
-		if (metadata?.robots?.index === false) {
-			continue;
-		}
-
-		const location = buildSitemapLocation(input.baseUrl, pathname);
+		const location = buildSitemapLocation(input.baseUrl, normalized);
 		if (seen.has(location)) {
 			continue;
 		}

--- a/packages/core/src/static-site-generator/sitemap.test.ts
+++ b/packages/core/src/static-site-generator/sitemap.test.ts
@@ -28,8 +28,8 @@ describe('renderSitemap', () => {
 		);
 	});
 
-	test('renders locations with XML escaping and deduplication', () => {
-		const xml = renderSitemap(['https://example.com/a&b', 'https://example.com/blog/', 'https://example.com/blog']);
+	test('renders locations with XML escaping', () => {
+		const xml = renderSitemap(['https://example.com/a&b', 'https://example.com/blog']);
 
 		expect(xml).toContain('<loc>https://example.com/a&amp;b</loc>');
 		expect(xml).toContain('<loc>https://example.com/blog</loc>');

--- a/packages/core/src/static-site-generator/sitemap.test.ts
+++ b/packages/core/src/static-site-generator/sitemap.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest';
+import { buildSitemapLocation, renderSitemap } from './sitemap.ts';
+
+describe('buildSitemapLocation', () => {
+	test('joins origin and pathname without trailing slash except root', () => {
+		expect(buildSitemapLocation('https://example.com', '/')).toBe('https://example.com/');
+		expect(buildSitemapLocation('https://example.com/', '/blog')).toBe('https://example.com/blog');
+		expect(buildSitemapLocation('https://example.com', '/blog/')).toBe('https://example.com/blog');
+	});
+
+	test('passes through absolute http(s) URLs', () => {
+		expect(buildSitemapLocation('https://example.com', 'https://cdn.example.com/rss.xml')).toBe(
+			'https://cdn.example.com/rss.xml',
+		);
+	});
+});
+
+describe('renderSitemap', () => {
+	test('renders an empty urlset', () => {
+		expect(renderSitemap([])).toBe(
+			[
+				'<?xml version="1.0" encoding="UTF-8"?>',
+				'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+				'',
+				'</urlset>',
+				'',
+			].join('\n'),
+		);
+	});
+
+	test('renders locations with XML escaping and deduplication', () => {
+		const xml = renderSitemap(['https://example.com/a&b', 'https://example.com/blog/', 'https://example.com/blog']);
+
+		expect(xml).toContain('<loc>https://example.com/a&amp;b</loc>');
+		expect(xml).toContain('<loc>https://example.com/blog</loc>');
+		expect(xml.match(/<url>/g)?.length).toBe(2);
+	});
+
+	test('preserves entry order of first occurrence', () => {
+		const xml = renderSitemap(['https://example.com/', 'https://example.com/about']);
+		const rootIndex = xml.indexOf('https://example.com/');
+		const aboutIndex = xml.indexOf('https://example.com/about');
+		expect(rootIndex).toBeLessThan(aboutIndex);
+	});
+});

--- a/packages/core/src/static-site-generator/sitemap.ts
+++ b/packages/core/src/static-site-generator/sitemap.ts
@@ -21,10 +21,14 @@ export function buildSitemapLocation(baseUrl: string, pathnameOrUrl: string): st
 
 /**
  * Renders a sitemap.org 0.9 urlset document from absolute location URLs.
+ *
+ * @remarks
+ * Callers are responsible for deduplication; this serializer preserves input order.
  */
 export function renderSitemap(locations: readonly string[]): string {
-	const uniqueLocations = [...new Set(locations.map((location) => normalizeLocation(location)))];
-	const urls = uniqueLocations.map((loc) => `  <url>\n    <loc>${escapeXmlText(loc)}</loc>\n  </url>`).join('\n');
+	const urls = locations
+		.map((loc) => `  <url>\n    <loc>${escapeXmlText(normalizeLocation(loc))}</loc>\n  </url>`)
+		.join('\n');
 
 	return [
 		'<?xml version="1.0" encoding="UTF-8"?>',

--- a/packages/core/src/static-site-generator/sitemap.ts
+++ b/packages/core/src/static-site-generator/sitemap.ts
@@ -1,0 +1,44 @@
+import { escapeXmlText } from '../utils/html-escaping.ts';
+import { normalizePathname } from '../utils/path-pattern.ts';
+
+/**
+ * Joins a base origin with a pathname or absolute URL into a sitemap `<loc>` value.
+ *
+ * @remarks
+ * Trailing slashes are stripped except for the site root (`/`). Absolute `http(s)`
+ * URLs in `extraUrls` are returned as-is (still slash-normalized).
+ */
+export function buildSitemapLocation(baseUrl: string, pathnameOrUrl: string): string {
+	const trimmed = pathnameOrUrl.trim();
+	if (/^https?:\/\//i.test(trimmed)) {
+		return normalizeLocation(trimmed);
+	}
+
+	const origin = baseUrl.replace(/\/+$/, '');
+	const pathname = normalizePathname(trimmed);
+	return pathname === '/' ? `${origin}/` : `${origin}${pathname}`;
+}
+
+/**
+ * Renders a sitemap.org 0.9 urlset document from absolute location URLs.
+ */
+export function renderSitemap(locations: readonly string[]): string {
+	const uniqueLocations = [...new Set(locations.map((location) => normalizeLocation(location)))];
+	const urls = uniqueLocations.map((loc) => `  <url>\n    <loc>${escapeXmlText(loc)}</loc>\n  </url>`).join('\n');
+
+	return [
+		'<?xml version="1.0" encoding="UTF-8"?>',
+		'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+		urls,
+		'</urlset>',
+		'',
+	].join('\n');
+}
+
+function normalizeLocation(location: string): string {
+	if (/^https?:\/\/[^/]+\/?$/i.test(location)) {
+		return `${location.replace(/\/+$/, '')}/`;
+	}
+
+	return location.replace(/\/+$/, '');
+}

--- a/packages/core/src/static-site-generator/static-export-context.ts
+++ b/packages/core/src/static-site-generator/static-export-context.ts
@@ -1,5 +1,5 @@
 import type { EcoPagesAppConfig } from '../types/internal-types.ts';
-import type { StaticRoute } from '../types/public-types.ts';
+import type { EcopagesRouteInfo, StaticRoute } from '../types/public-types.ts';
 import type { StaticGenerationRendererResolver } from '../route-renderer/route-renderer.ts';
 import type { StaticGenerationRoute } from '../router/server/route-registry.ts';
 
@@ -18,4 +18,12 @@ export interface StaticExportContext {
 	staticRoutes?: StaticRoute[];
 	force: boolean;
 	preserveExportDirectory: boolean;
+	/**
+	 * Unfiltered static-generation routes (exact + expanded dynamic).
+	 *
+	 * @remarks
+	 * Sitemap filtering is applied separately; integrations that build custom
+	 * artifacts should start from this full list.
+	 */
+	routes: EcopagesRouteInfo[];
 }

--- a/packages/core/src/static-site-generator/static-site-generator.test.ts
+++ b/packages/core/src/static-site-generator/static-site-generator.test.ts
@@ -39,6 +39,12 @@ const createMockConfig = (overrides: Partial<EcoPagesAppConfig> = {}): EcoPagesA
 				Googlebot: ['/no-google'],
 			},
 		},
+		sitemap: {
+			enabled: false,
+			fileName: 'sitemap.xml',
+			extraUrls: [],
+			exclude: [],
+		},
 		absolutePaths: {
 			distDir: '/test/project/dist',
 			workDir: '/test/project/.eco',
@@ -471,11 +477,13 @@ describe('StaticSiteGenerator', () => {
 					baseUrl: 'http://localhost:3000',
 					force: false,
 					preserveExportDirectory: false,
+					routes: [],
 				}),
 			);
 			expect(afterStaticExport).toHaveBeenCalledWith(
 				expect.objectContaining({
 					baseUrl: 'http://localhost:3000',
+					routes: [],
 				}),
 			);
 			expect(beforeStaticExport.mock.invocationCallOrder[0]).toBeLessThan(
@@ -496,6 +504,87 @@ describe('StaticSiteGenerator', () => {
 
 			expect(ensureDirMock).toHaveBeenCalled();
 			expect(writeMock).toHaveBeenCalledWith('/test/project/dist/robots.txt', expect.any(String));
+		});
+
+		test('should write sitemap.xml after afterStaticExport when enabled', async () => {
+			const afterStaticExport = vi.fn(async () => {});
+			const ssg = new StaticSiteGenerator({
+				appConfig: createMockConfig({
+					baseUrl: 'https://example.com',
+					sitemap: {
+						enabled: true,
+						fileName: 'sitemap.xml',
+						extraUrls: ['/rss.xml'],
+						exclude: ['/admin/**'],
+					},
+					integrations: [
+						{
+							name: 'test',
+							extensions: ['.tsx'],
+							afterStaticExport,
+						},
+					] as unknown as EcoPagesAppConfig['integrations'],
+				}),
+			});
+
+			const RendererFactory = {
+				getPageRenderer: vi.fn(() => ({
+					loadPageModule: vi.fn(async () => ({
+						default: Object.assign(() => null, { cache: 'static' }),
+					})),
+					execute: vi.fn(async () => ({ body: '<html>Page</html>' })),
+				})),
+			} satisfies StaticPageRouteRendererFactory;
+
+			await ssg.run({
+				router: {
+					listStaticGenerationRoutes: vi.fn(async () => [
+						{
+							requestUrl: 'https://example.com/',
+							pathname: '/',
+							templateRoute: {
+								pathname: '/',
+								kind: 'exact' as const,
+								filePath: '/src/pages/index.tsx',
+								paramNames: [],
+							},
+							params: {},
+						},
+						{
+							requestUrl: 'https://example.com/admin',
+							pathname: '/admin',
+							templateRoute: {
+								pathname: '/admin',
+								kind: 'exact' as const,
+								filePath: '/src/pages/admin.tsx',
+								paramNames: [],
+							},
+							params: {},
+						},
+					]),
+				} satisfies StaticGenerationRunnerInput['router'],
+				baseUrl: 'https://example.com',
+				routeRendererFactory: {
+					getPageRenderer: RendererFactory.getPageRenderer,
+					getExplicitViewRenderer: vi.fn(),
+				} satisfies StaticGenerationRendererFactory,
+			});
+
+			expect(afterStaticExport).toHaveBeenCalled();
+			const sitemapWrite = writeMock.mock.calls.find((call: unknown[]) =>
+				String(call[0]).endsWith('sitemap.xml'),
+			);
+			expect(sitemapWrite).toBeDefined();
+			const sitemapContent = String(sitemapWrite?.[1]);
+			expect(sitemapContent).toContain('<loc>https://example.com/</loc>');
+			expect(sitemapContent).toContain('<loc>https://example.com/rss.xml</loc>');
+			expect(sitemapContent).not.toContain('/admin');
+			const sitemapWriteIndex = writeMock.mock.calls.findIndex((call: unknown[]) =>
+				String(call[0]).endsWith('sitemap.xml'),
+			);
+			expect(afterStaticExport.mock.invocationCallOrder[0]).toBeLessThan(
+				writeMock.mock.invocationCallOrder[sitemapWriteIndex]!,
+			);
 		});
 
 		test('should skip explicit static routes backed by cache dynamic views', async () => {

--- a/packages/core/src/static-site-generator/static-site-generator.test.ts
+++ b/packages/core/src/static-site-generator/static-site-generator.test.ts
@@ -33,6 +33,10 @@ const createMockConfig = (overrides: Partial<EcoPagesAppConfig> = {}): EcoPagesA
 		distDir: 'dist',
 		workDir: DEFAULT_ECOPAGES_WORK_DIR,
 		srcDir: 'src',
+		defaultMetadata: {
+			title: 'Test',
+			description: 'Test site',
+		},
 		robotsTxt: {
 			preferences: {
 				'*': ['/admin', '/private'],
@@ -585,6 +589,156 @@ describe('StaticSiteGenerator', () => {
 			expect(afterStaticExport.mock.invocationCallOrder[0]).toBeLessThan(
 				writeMock.mock.invocationCallOrder[sitemapWriteIndex]!,
 			);
+		});
+
+		test('should omit noindex pages and metadata failures from sitemap', async () => {
+			const ssg = new StaticSiteGenerator({
+				appConfig: createMockConfig({
+					baseUrl: 'https://example.com',
+					sitemap: {
+						enabled: true,
+						fileName: 'sitemap.xml',
+						extraUrls: [],
+						exclude: [],
+					},
+				}),
+			});
+
+			const RendererFactory = {
+				getPageRenderer: vi.fn((filePath: string) => ({
+					loadPageModule: vi.fn(async () => {
+						if (filePath.includes('draft')) {
+							return {
+								default: Object.assign(() => null, {
+									cache: 'static',
+									metadata: async () => ({
+										title: 'Draft',
+										description: 'Draft',
+										robots: { index: false },
+									}),
+								}),
+							};
+						}
+						if (filePath.includes('broken')) {
+							return {
+								default: Object.assign(() => null, {
+									cache: 'static',
+									metadata: async () => {
+										throw new Error('metadata boom');
+									},
+								}),
+							};
+						}
+						return {
+							default: Object.assign(() => null, { cache: 'static' }),
+						};
+					}),
+					execute: vi.fn(async () => ({ body: '<html>Page</html>' })),
+				})),
+			} satisfies StaticPageRouteRendererFactory;
+
+			await ssg.run({
+				router: {
+					listStaticGenerationRoutes: vi.fn(async () => [
+						{
+							requestUrl: 'https://example.com/',
+							pathname: '/',
+							templateRoute: {
+								pathname: '/',
+								kind: 'exact' as const,
+								filePath: '/src/pages/index.tsx',
+								paramNames: [],
+							},
+							params: {},
+						},
+						{
+							requestUrl: 'https://example.com/draft',
+							pathname: '/draft',
+							templateRoute: {
+								pathname: '/draft',
+								kind: 'exact' as const,
+								filePath: '/src/pages/draft.tsx',
+								paramNames: [],
+							},
+							params: {},
+						},
+						{
+							requestUrl: 'https://example.com/broken',
+							pathname: '/broken',
+							templateRoute: {
+								pathname: '/broken',
+								kind: 'exact' as const,
+								filePath: '/src/pages/broken.tsx',
+								paramNames: [],
+							},
+							params: {},
+						},
+					]),
+				} satisfies StaticGenerationRunnerInput['router'],
+				baseUrl: 'https://example.com',
+				routeRendererFactory: {
+					getPageRenderer: RendererFactory.getPageRenderer,
+					getExplicitViewRenderer: vi.fn(),
+				} satisfies StaticGenerationRendererFactory,
+			});
+
+			const sitemapWrite = writeMock.mock.calls.find((call: unknown[]) =>
+				String(call[0]).endsWith('sitemap.xml'),
+			);
+			expect(sitemapWrite).toBeDefined();
+			const sitemapContent = String(sitemapWrite?.[1]);
+			expect(sitemapContent).toContain('<loc>https://example.com/</loc>');
+			expect(sitemapContent).not.toContain('/draft');
+			expect(sitemapContent).not.toContain('/broken');
+		});
+
+		test('should honor robots.index on explicit static views in sitemap', async () => {
+			const ssg = new StaticSiteGenerator({
+				appConfig: createMockConfig({
+					baseUrl: 'https://example.com',
+					sitemap: {
+						enabled: true,
+						fileName: 'sitemap.xml',
+						extraUrls: [],
+						exclude: [],
+					},
+				}),
+			});
+			const renderToResponse = vi.fn(async () => new Response('<html>Private</html>'));
+			const privateView = Object.assign(() => null, {
+				cache: 'static',
+				config: { __eco: { ...testInjectedMeta, file: '/src/views/private.tsx' } },
+				metadata: async () => ({
+					title: 'Private',
+					description: 'Private',
+					robots: { index: false },
+				}),
+			}) as any;
+
+			await ssg.run({
+				router: {
+					listStaticGenerationRoutes: vi.fn(async () => []),
+				} satisfies StaticGenerationRunnerInput['router'],
+				baseUrl: 'https://example.com',
+				routeRendererFactory: {
+					getPageRenderer: vi.fn(),
+					getExplicitViewRenderer: vi.fn(() => ({
+						renderToResponse,
+					})),
+				} satisfies StaticGenerationRendererFactory,
+				staticRoutes: [
+					{
+						path: '/private',
+						loader: async () => ({ default: privateView }),
+					},
+				],
+			});
+
+			const sitemapWrite = writeMock.mock.calls.find((call: unknown[]) =>
+				String(call[0]).endsWith('sitemap.xml'),
+			);
+			expect(sitemapWrite).toBeDefined();
+			expect(String(sitemapWrite?.[1])).not.toContain('/private');
 		});
 
 		test('should skip explicit static routes backed by cache dynamic views', async () => {

--- a/packages/core/src/static-site-generator/static-site-generator.test.ts
+++ b/packages/core/src/static-site-generator/static-site-generator.test.ts
@@ -64,8 +64,10 @@ const testInjectedMeta = {
 	integration: 'test',
 };
 
-type StaticGenerationRouteSource = Parameters<StaticSiteGenerator['generateStaticPages']>[0];
-type StaticPageRouteRendererFactory = NonNullable<Parameters<StaticSiteGenerator['generateStaticPages']>[2]>;
+type StaticGenerationRouteSource = Parameters<StaticSiteGenerator['generateStaticPages']>[0]['router'];
+type StaticPageRouteRendererFactory = NonNullable<
+	Parameters<StaticSiteGenerator['generateStaticPages']>[0]['routeRendererFactory']
+>;
 type StaticGenerationRendererFactory = NonNullable<Parameters<StaticSiteGenerator['run']>[0]['routeRendererFactory']>;
 type StaticGenerationRunnerInput = Parameters<StaticSiteGenerator['run']>[0];
 
@@ -228,7 +230,11 @@ describe('StaticSiteGenerator', () => {
 				})),
 			} satisfies StaticPageRouteRendererFactory;
 
-			await ssg.generateStaticPages(Router, 'http://localhost:3000', RendererFactory);
+			await ssg.generateStaticPages({
+				router: Router,
+				baseUrl: 'http://localhost:3000',
+				routeRendererFactory: RendererFactory,
+			});
 
 			expect(writeMock).toHaveBeenCalledTimes(1);
 		});
@@ -246,7 +252,11 @@ describe('StaticSiteGenerator', () => {
 				})),
 			} satisfies StaticPageRouteRendererFactory;
 
-			await ssg.generateStaticPages(Router, 'http://localhost:3000', RendererFactory);
+			await ssg.generateStaticPages({
+				router: Router,
+				baseUrl: 'http://localhost:3000',
+				routeRendererFactory: RendererFactory,
+			});
 
 			expect(ensureDirMock).toHaveBeenCalled();
 		});
@@ -257,7 +267,11 @@ describe('StaticSiteGenerator', () => {
 				'/page': { filePath: '/src/pages/page.ghtml.ts', pathname: '/page' },
 			});
 
-			await ssg.generateStaticPages(Router, 'http://localhost:3000', undefined);
+			await ssg.generateStaticPages({
+				router: Router,
+				baseUrl: 'http://localhost:3000',
+				routeRendererFactory: undefined,
+			});
 		});
 
 		test('should write index.html for root path', async () => {
@@ -273,7 +287,11 @@ describe('StaticSiteGenerator', () => {
 				})),
 			} satisfies StaticPageRouteRendererFactory;
 
-			await ssg.generateStaticPages(Router, 'http://localhost:3000', RendererFactory);
+			await ssg.generateStaticPages({
+				router: Router,
+				baseUrl: 'http://localhost:3000',
+				routeRendererFactory: RendererFactory,
+			});
 
 			expect(writeMock).toHaveBeenCalledWith(expect.stringContaining('index.html'), '<html>Home</html>');
 		});
@@ -292,7 +310,11 @@ describe('StaticSiteGenerator', () => {
 				})),
 			} satisfies StaticPageRouteRendererFactory;
 
-			await ssg.generateStaticPages(Router, 'http://localhost:3000', RendererFactory);
+			await ssg.generateStaticPages({
+				router: Router,
+				baseUrl: 'http://localhost:3000',
+				routeRendererFactory: RendererFactory,
+			});
 
 			expect(writeMock).toHaveBeenCalledWith(expect.stringContaining('index.html'), bufferContent);
 		});
@@ -314,7 +336,11 @@ describe('StaticSiteGenerator', () => {
 				})),
 			} satisfies StaticPageRouteRendererFactory;
 
-			await ssg.generateStaticPages(Router, 'http://localhost:3000', RendererFactory);
+			await ssg.generateStaticPages({
+				router: Router,
+				baseUrl: 'http://localhost:3000',
+				routeRendererFactory: RendererFactory,
+			});
 
 			expect(RendererFactory.getPageRenderer).toHaveBeenCalledWith('/src/pages/dashboard.tsx');
 			expect(loadPageModule).toHaveBeenCalledWith('/src/pages/dashboard.tsx');
@@ -335,7 +361,11 @@ describe('StaticSiteGenerator', () => {
 				getPageRenderer: vi.fn(() => pageRenderer),
 			} satisfies StaticPageRouteRendererFactory;
 
-			await ssg.generateStaticPages(Router, 'http://localhost:3000', RendererFactory);
+			await ssg.generateStaticPages({
+				router: Router,
+				baseUrl: 'http://localhost:3000',
+				routeRendererFactory: RendererFactory,
+			});
 
 			expect(loadPageModule).toHaveBeenCalledTimes(1);
 			expect(loadPageModule).toHaveBeenCalledWith(filePath);
@@ -371,7 +401,11 @@ describe('StaticSiteGenerator', () => {
 				getPageRenderer: vi.fn(() => pageRenderer),
 			} satisfies StaticPageRouteRendererFactory;
 
-			await ssg.generateStaticPages(Router, 'http://localhost:3000', RendererFactory);
+			await ssg.generateStaticPages({
+				router: Router,
+				baseUrl: 'http://localhost:3000',
+				routeRendererFactory: RendererFactory,
+			});
 
 			expect(routeModuleBuildCache.canReuseStaticRender).toHaveBeenCalled();
 			expect(execute).not.toHaveBeenCalled();

--- a/packages/core/src/static-site-generator/static-site-generator.ts
+++ b/packages/core/src/static-site-generator/static-site-generator.ts
@@ -4,6 +4,7 @@ import { appLogger } from '../global/app-logger.ts';
 import type { EcoPagesAppConfig } from '../types/internal-types.ts';
 import type {
 	EcoPageComponent,
+	EcoPageFile,
 	EcopagesRouteInfo,
 	PageMetadataProps,
 	SitemapConfig,
@@ -137,11 +138,10 @@ export class StaticSiteGenerator {
 		filePath: string,
 		routeRendererFactory: StaticPageRouteRendererFactory,
 	): Promise<boolean> {
-		const module = (await routeRendererFactory.getPageRenderer(filePath).loadPageModule(filePath)) as {
-			default?: EcoPageComponent<any>;
-		};
+		const pageModule: EcoPageFile = await routeRendererFactory.getPageRenderer(filePath).loadPageModule(filePath);
+		const Page = pageModule.default as EcoPageComponent<any>;
 
-		return module.default?.cache === 'dynamic';
+		return Page.cache === 'dynamic';
 	}
 
 	private shouldSkipStaticView(_routePath: string, view: EcoPageComponent<any>): boolean {
@@ -311,20 +311,13 @@ export class StaticSiteGenerator {
 		baseUrl: string;
 		routeRendererFactory: StaticPageRouteRendererFactory;
 	}): Promise<PageMetadataProps> {
-		const pageModule = (await input.routeRendererFactory
-			.getPageRenderer(input.filePath)
-			.loadPageModule(input.filePath)) as {
-			default?: EcoPageComponent<any>;
-			getStaticProps?: EcoPageComponent<any>['staticProps'];
-			getMetadata?: EcoPageComponent<any>['metadata'];
-		};
-		const Page = pageModule.default;
 		const loader = this.getPageModuleLoader(input.baseUrl);
+		const pageModule = await loader.resolvePageModule({
+			file: input.filePath,
+			importPageFileFn: (file) => input.routeRendererFactory.getPageRenderer(file).loadPageModule(file),
+		});
 		const { metadata } = await loader.resolvePageData({
-			pageModule: {
-				getStaticProps: Page?.staticProps ?? pageModule.getStaticProps,
-				getMetadata: Page?.metadata ?? pageModule.getMetadata,
-			},
+			pageModule,
 			routeOptions: {
 				file: input.filePath,
 				params: input.params,
@@ -365,16 +358,20 @@ export class StaticSiteGenerator {
 		}
 	}
 
-	private async createFilesystemStaticContents(
-		route: StaticGenerationRoute,
-		_baseUrl: string,
-		routeRendererFactory?: StaticPageRouteRendererFactory,
-		skipped?: string[],
-	): Promise<string | Buffer | null> {
+	private async createFilesystemStaticContents(input: {
+		route: StaticGenerationRoute;
+		baseUrl: string;
+		routeRendererFactory?: StaticPageRouteRendererFactory;
+		skipped?: string[];
+	}): Promise<string | Buffer | null> {
 		const {
-			templateRoute: { filePath },
-			params,
-		} = route;
+			route: {
+				templateRoute: { filePath },
+				params,
+			},
+			routeRendererFactory,
+			skipped,
+		} = input;
 
 		if (!routeRendererFactory) {
 			throw new Error(STATIC_SITE_GENERATOR_ERRORS.ROUTE_RENDERER_FACTORY_REQUIRED);
@@ -409,16 +406,24 @@ export class StaticSiteGenerator {
 	 * @remarks
 	 * Routes are rendered through the normal route renderer directly.
 	 */
-	async generateStaticPages(
-		router: StaticGenerationRouteSource,
-		baseUrl: string,
-		routeRendererFactory?: StaticPageRouteRendererFactory,
-		skipped?: string[],
-		activeStaticPathnames?: Set<string>,
-		preloadedRoutes?: readonly StaticGenerationRoute[],
-		sitemapEligiblePathnames?: Set<string>,
-	) {
-		const routes = preloadedRoutes ?? (await router.listStaticGenerationRoutes({ runtimeOrigin: baseUrl }));
+	async generateStaticPages(input: {
+		router: StaticGenerationRouteSource;
+		baseUrl: string;
+		routeRendererFactory?: StaticPageRouteRendererFactory;
+		skipped?: string[];
+		activeStaticPathnames?: Set<string>;
+		preloadedRoutes?: readonly StaticGenerationRoute[];
+		sitemapEligiblePathnames?: Set<string>;
+	}) {
+		const {
+			router,
+			baseUrl,
+			routeRendererFactory,
+			skipped,
+			activeStaticPathnames,
+			sitemapEligiblePathnames,
+		} = input;
+		const routes = input.preloadedRoutes ?? (await router.listStaticGenerationRoutes({ runtimeOrigin: baseUrl }));
 
 		appLogger.debug(
 			'Static Pages',
@@ -452,7 +457,12 @@ export class StaticSiteGenerator {
 							},
 						}),
 					createContents: () =>
-						this.createFilesystemStaticContents(route, baseUrl, routeRendererFactory, skipped),
+						this.createFilesystemStaticContents({
+							route,
+							baseUrl,
+							routeRendererFactory,
+							skipped,
+						}),
 				});
 			} catch (error) {
 				appLogger.error(
@@ -562,24 +572,24 @@ export class StaticSiteGenerator {
 			}
 
 			this.generateRobotsTxt();
-			await this.generateStaticPages(
+			await this.generateStaticPages({
 				router,
 				baseUrl,
 				routeRendererFactory,
-				skippedDynamicPages,
+				skipped: skippedDynamicPages,
 				activeStaticPathnames,
-				routes,
+				preloadedRoutes: routes,
 				sitemapEligiblePathnames,
-			);
+			});
 
 			if (staticRoutes && staticRoutes.length > 0 && routeRendererFactory) {
-				await this.generateExplicitStaticPages(
+				await this.generateExplicitStaticPages({
 					staticRoutes,
 					routeRendererFactory,
-					skippedDynamicPages,
+					skipped: skippedDynamicPages,
 					activeStaticPathnames,
 					sitemapEligiblePathnames,
-				);
+				});
 			}
 
 			if (preserveExportDirectory) {
@@ -611,34 +621,34 @@ export class StaticSiteGenerator {
 		}
 	}
 
-	private async generateExplicitStaticPages(
-		staticRoutes: StaticRoute[],
-		routeRendererFactory: ExplicitStaticRouteRendererFactory,
-		skipped?: string[],
-		activeStaticPathnames?: Set<string>,
-		sitemapEligiblePathnames?: Set<string>,
-	): Promise<void> {
+	private async generateExplicitStaticPages(input: {
+		staticRoutes: StaticRoute[];
+		routeRendererFactory: ExplicitStaticRouteRendererFactory;
+		skipped?: string[];
+		activeStaticPathnames?: Set<string>;
+		sitemapEligiblePathnames?: Set<string>;
+	}): Promise<void> {
 		appLogger.debug(
 			'Generating explicit static routes',
-			staticRoutes.map((r) => r.path),
+			input.staticRoutes.map((r) => r.path),
 		);
 
-		for (const route of staticRoutes) {
+		for (const route of input.staticRoutes) {
 			try {
 				const mod = await route.loader();
 				const view = mod.default;
 				if (this.shouldSkipStaticView(route.path, view)) {
-					skipped?.push(route.path);
+					input.skipped?.push(route.path);
 					continue;
 				}
 
-				await this.generateExplicitStaticRoute(
-					route.path,
+				await this.generateExplicitStaticRoute({
+					routePath: route.path,
 					view,
-					routeRendererFactory,
-					activeStaticPathnames,
-					sitemapEligiblePathnames,
-				);
+					routeRendererFactory: input.routeRendererFactory,
+					activeStaticPathnames: input.activeStaticPathnames,
+					sitemapEligiblePathnames: input.sitemapEligiblePathnames,
+				});
 			} catch (error) {
 				appLogger.error(
 					`Error generating explicit static page for ${route.path}:`,
@@ -657,14 +667,19 @@ export class StaticSiteGenerator {
 		return path.isAbsolute(sourceFile) ? sourceFile : path.join(this.appConfig.rootDir, sourceFile);
 	}
 
-	private async generateExplicitStaticRoute(
-		routePath: string,
-		view: EcoPageComponent<any>,
-		routeRendererFactory: ExplicitStaticRouteRendererFactory,
-		activeStaticPathnames?: Set<string>,
-		sitemapEligiblePathnames?: Set<string>,
-	): Promise<void> {
-		const { renderer, routeEntries } = await this.planExplicitStaticRoute(routePath, view, routeRendererFactory);
+	private async generateExplicitStaticRoute(input: {
+		routePath: string;
+		view: EcoPageComponent<any>;
+		routeRendererFactory: ExplicitStaticRouteRendererFactory;
+		activeStaticPathnames?: Set<string>;
+		sitemapEligiblePathnames?: Set<string>;
+	}): Promise<void> {
+		const { routePath, view, routeRendererFactory, activeStaticPathnames, sitemapEligiblePathnames } = input;
+		const { renderer, routeEntries } = await this.planExplicitStaticRoute({
+			routePath,
+			view,
+			routeRendererFactory,
+		});
 		const sourceFile = this.resolveExplicitViewSourceFile(view);
 
 		for (const { pathname, params } of routeEntries) {
@@ -691,52 +706,58 @@ export class StaticSiteGenerator {
 						},
 					}),
 				createContents: () =>
-					this.createExplicitStaticContents(routePath, view, params, routeRendererFactory, renderer),
+					this.createExplicitStaticContents({
+						routePath,
+						view,
+						params,
+						routeRendererFactory,
+						renderer,
+					}),
 			});
 
 			appLogger.debug(`Generated static page: ${pathname}`);
 		}
 	}
 
-	private async planExplicitStaticRoute(
-		routePath: string,
-		view: EcoPageComponent<any>,
-		routeRendererFactory: ExplicitStaticRouteRendererFactory,
-	): Promise<{ renderer: ExplicitViewRenderer; routeEntries: ExplicitStaticRouteEntry[] }> {
+	private async planExplicitStaticRoute(input: {
+		routePath: string;
+		view: EcoPageComponent<any>;
+		routeRendererFactory: ExplicitStaticRouteRendererFactory;
+	}): Promise<{ renderer: ExplicitViewRenderer; routeEntries: ExplicitStaticRouteEntry[] }> {
 		const { renderer } = await prepareExplicitStaticRender({
-			routePath,
-			view,
+			routePath: input.routePath,
+			view: input.view,
 			params: {},
 			appConfig: this.appConfig,
 			runtimeOrigin: this.appConfig.baseUrl,
-			routeRendererFactory,
+			routeRendererFactory: input.routeRendererFactory,
 			errors: STATIC_SITE_GENERATOR_ERRORS,
 		});
 
 		return {
 			renderer,
-			routeEntries: await this.listExplicitStaticRouteEntries(routePath, view),
+			routeEntries: await this.listExplicitStaticRouteEntries(input.routePath, input.view),
 		};
 	}
 
-	private async createExplicitStaticContents(
-		routePath: string,
-		view: EcoPageComponent<any>,
-		params: Record<string, string | string[]>,
-		routeRendererFactory: ExplicitStaticRouteRendererFactory,
-		renderer: ExplicitViewRenderer,
-	): Promise<string> {
+	private async createExplicitStaticContents(input: {
+		routePath: string;
+		view: EcoPageComponent<any>;
+		params: Record<string, string | string[]>;
+		routeRendererFactory: ExplicitStaticRouteRendererFactory;
+		renderer: ExplicitViewRenderer;
+	}): Promise<string> {
 		const { props, view: renderableView } = await prepareExplicitStaticRender({
-			routePath,
-			view,
-			params,
+			routePath: input.routePath,
+			view: input.view,
+			params: input.params,
 			appConfig: this.appConfig,
 			runtimeOrigin: this.appConfig.baseUrl,
-			routeRendererFactory,
+			routeRendererFactory: input.routeRendererFactory,
 			errors: STATIC_SITE_GENERATOR_ERRORS,
 		});
 
-		const response = await renderer.renderToResponse(renderableView, props, {});
+		const response = await input.renderer.renderToResponse(renderableView, props, {});
 		return response.text();
 	}
 

--- a/packages/core/src/static-site-generator/static-site-generator.ts
+++ b/packages/core/src/static-site-generator/static-site-generator.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { availableParallelism } from 'node:os';
 import { appLogger } from '../global/app-logger.ts';
 import type { EcoPagesAppConfig } from '../types/internal-types.ts';
-import type { EcoPageComponent, StaticRoute } from '../types/public-types.ts';
+import type { EcoPageComponent, EcopagesRouteInfo, SitemapConfig, StaticRoute } from '../types/public-types.ts';
 import type {
 	ExplicitViewRenderer,
 	ExplicitViewRendererResolver,
@@ -28,6 +28,10 @@ import {
 	prebuildProductionPageBrowserGraphs,
 	shouldPrebuildProductionPageBrowserGraphs,
 } from './production-page-browser-graph-prebuild.ts';
+import { PageModuleLoaderService } from '../route-renderer/page-loading/page-module-loader.ts';
+import { renderSitemap } from './sitemap.ts';
+import { resolveSitemapPathnames, type SitemapRouteCandidate } from './sitemap-routes.ts';
+import { normalizePathname } from '../utils/path-pattern.ts';
 
 type StaticGenerationRouteSource = {
 	listStaticGenerationRoutes(input: { runtimeOrigin: string }): Promise<readonly StaticGenerationRoute[]>;
@@ -156,6 +160,15 @@ export class StaticSiteGenerator {
 	}
 
 	/**
+	 * Writes the configured sitemap file to the export directory.
+	 */
+	generateSitemap(locations: readonly string[], sitemap: SitemapConfig): void {
+		const fileName = sitemap.fileName ?? 'sitemap.xml';
+		fileSystem.ensureDir(this.getExportDir());
+		fileSystem.write(path.join(this.getExportDir(), fileName), renderSitemap(locations));
+	}
+
+	/**
 	 * Returns whether the input path points at the root directory.
 	 */
 	isRootDir(path: string) {
@@ -198,8 +211,6 @@ export class StaticSiteGenerator {
 		reuseRenderedOutput?: boolean;
 		activeStaticPathnames?: Set<string>;
 	}): Promise<void> {
-		options.activeStaticPathnames?.add(options.pathname);
-
 		const directories = options.directories ?? this.getDirectories([options.pathname]);
 		const renderedOutputPath = this.getOutputPath(options.pathname, directories);
 		const routeModuleBuildCache = this.getRouteModuleBuildCache();
@@ -215,6 +226,7 @@ export class StaticSiteGenerator {
 				force: this.forceFullStaticGeneration,
 			})
 		) {
+			options.activeStaticPathnames?.add(options.pathname);
 			appLogger.debug(`Skipped unchanged static page: ${options.debugLabel ?? options.pathname}`);
 			return;
 		}
@@ -225,6 +237,7 @@ export class StaticSiteGenerator {
 		}
 
 		const outputPath = this.writeStaticOutput(options.pathname, contents, directories);
+		options.activeStaticPathnames?.add(options.pathname);
 
 		if (options.sourceFile) {
 			routeModuleBuildCache.recordStaticRender({
@@ -338,6 +351,7 @@ export class StaticSiteGenerator {
 		staticRoutes?: StaticRoute[];
 		force: boolean;
 		preserveExportDirectory: boolean;
+		routes: EcopagesRouteInfo[];
 	}): StaticExportContext {
 		return {
 			appConfig: this.appConfig,
@@ -347,6 +361,7 @@ export class StaticSiteGenerator {
 			staticRoutes: input.staticRoutes,
 			force: input.force,
 			preserveExportDirectory: input.preserveExportDirectory,
+			routes: input.routes,
 		};
 	}
 
@@ -394,6 +409,7 @@ export class StaticSiteGenerator {
 		}
 
 		const routes = await router.listStaticGenerationRoutes({ runtimeOrigin: baseUrl });
+		const exportRoutes = routes.map((route) => toEcopagesRouteInfo(route));
 
 		if (shouldBuildPagesUnifiedGraph()) {
 			await ensurePagesUnifiedGraphBuilt({
@@ -411,6 +427,7 @@ export class StaticSiteGenerator {
 			staticRoutes,
 			force,
 			preserveExportDirectory,
+			routes: exportRoutes,
 		});
 
 		await this.invokeStaticExportHook('beforeStaticExport', staticExportContext);
@@ -454,12 +471,83 @@ export class StaticSiteGenerator {
 			await this.invokeStaticExportHook('afterStaticExport', staticExportContext);
 		}
 
+		if (this.appConfig.sitemap?.enabled) {
+			await this.writeSitemapAfterExport({
+				baseUrl,
+				routes,
+				activeStaticPathnames,
+				sitemap: this.appConfig.sitemap,
+			});
+		}
+
 		if (skippedDynamicPages.length > 0) {
 			appLogger.debug(
 				`Skipped ${skippedDynamicPages.length} page(s) with cache: 'dynamic' (not supported in static generation)`,
 				skippedDynamicPages,
 			);
 		}
+	}
+
+	private async writeSitemapAfterExport(input: {
+		baseUrl: string;
+		routes: readonly StaticGenerationRoute[];
+		activeStaticPathnames: ReadonlySet<string>;
+		sitemap: SitemapConfig;
+	}): Promise<void> {
+		const routeByPathname = new Map(
+			input.routes.map((route) => [normalizePathname(route.pathname), route] as const),
+		);
+
+		const candidates: SitemapRouteCandidate[] = [...input.activeStaticPathnames].map((pathname) => {
+			const normalized = normalizePathname(pathname);
+			const route = routeByPathname.get(normalized) ?? routeByPathname.get(pathname);
+			return {
+				pathname: normalized,
+				params: normalizeRouteParams(route?.params ?? {}),
+				filePath: route?.templateRoute.filePath,
+			};
+		});
+
+		let pageModuleLoader: PageModuleLoaderService | undefined;
+		const getPageModuleLoader = () => {
+			pageModuleLoader ??= new PageModuleLoaderService(this.appConfig, input.baseUrl);
+			return pageModuleLoader;
+		};
+
+		const locations = await resolveSitemapPathnames({
+			candidates,
+			activeStaticPathnames: new Set(
+				[...input.activeStaticPathnames].map((pathname) => normalizePathname(pathname)),
+			),
+			sitemap: input.sitemap,
+			baseUrl: input.baseUrl,
+			resolveMetadata: async ({ filePath, params }) => {
+				if (!filePath) {
+					return undefined;
+				}
+
+				try {
+					const loader = getPageModuleLoader();
+					const pageModule = await loader.resolvePageModule({ file: filePath });
+					const { metadata } = await loader.resolvePageData({
+						pageModule,
+						routeOptions: {
+							file: filePath,
+							params,
+						},
+					});
+					return metadata;
+				} catch (error) {
+					appLogger.debug(
+						`Sitemap metadata resolution failed for ${filePath}; including URL`,
+						error instanceof Error ? error.message : String(error),
+					);
+					return undefined;
+				}
+			},
+		});
+
+		this.generateSitemap(locations, input.sitemap);
 	}
 
 	/**
@@ -629,4 +717,19 @@ export class StaticSiteGenerator {
 
 		return path.join(this.getExportDir(), outputName);
 	}
+}
+
+function toEcopagesRouteInfo(route: StaticGenerationRoute): EcopagesRouteInfo {
+	return {
+		pathname: normalizePathname(route.pathname),
+		params: normalizeRouteParams(route.params),
+	};
+}
+
+function normalizeRouteParams(params: Record<string, string | string[]>): Record<string, string> {
+	const normalized: Record<string, string> = {};
+	for (const [key, value] of Object.entries(params)) {
+		normalized[key] = Array.isArray(value) ? value.join('/') : value;
+	}
+	return normalized;
 }

--- a/packages/core/src/static-site-generator/static-site-generator.ts
+++ b/packages/core/src/static-site-generator/static-site-generator.ts
@@ -2,7 +2,13 @@ import path from 'node:path';
 import { availableParallelism } from 'node:os';
 import { appLogger } from '../global/app-logger.ts';
 import type { EcoPagesAppConfig } from '../types/internal-types.ts';
-import type { EcoPageComponent, EcopagesRouteInfo, SitemapConfig, StaticRoute } from '../types/public-types.ts';
+import type {
+	EcoPageComponent,
+	EcopagesRouteInfo,
+	PageMetadataProps,
+	SitemapConfig,
+	StaticRoute,
+} from '../types/public-types.ts';
 import type {
 	ExplicitViewRenderer,
 	ExplicitViewRendererResolver,
@@ -30,7 +36,8 @@ import {
 } from './production-page-browser-graph-prebuild.ts';
 import { PageModuleLoaderService } from '../route-renderer/page-loading/page-module-loader.ts';
 import { renderSitemap } from './sitemap.ts';
-import { resolveSitemapPathnames, type SitemapRouteCandidate } from './sitemap-routes.ts';
+import { resolveSitemapLocations } from './sitemap-routes.ts';
+import { toEcopagesRouteInfo } from '../utils/ecopages-route-info.ts';
 import { normalizePathname } from '../utils/path-pattern.ts';
 
 type StaticGenerationRouteSource = {
@@ -98,6 +105,7 @@ export class StaticSiteGenerator {
 	private readonly routeModuleBuildCacheOverride?: RouteModuleBuildCache;
 	private staticRenderCacheContext: ReturnType<typeof createRouteModuleStaticRenderCacheContext>;
 	private forceFullStaticGeneration = false;
+	private pageModuleLoader?: PageModuleLoaderService;
 
 	/**
 	 * Creates the static-site generator for one app config.
@@ -210,6 +218,7 @@ export class StaticSiteGenerator {
 		debugLabel?: string;
 		reuseRenderedOutput?: boolean;
 		activeStaticPathnames?: Set<string>;
+		onSuccessfulExport?: () => Promise<void>;
 	}): Promise<void> {
 		const directories = options.directories ?? this.getDirectories([options.pathname]);
 		const renderedOutputPath = this.getOutputPath(options.pathname, directories);
@@ -227,6 +236,7 @@ export class StaticSiteGenerator {
 			})
 		) {
 			options.activeStaticPathnames?.add(options.pathname);
+			await options.onSuccessfulExport?.();
 			appLogger.debug(`Skipped unchanged static page: ${options.debugLabel ?? options.pathname}`);
 			return;
 		}
@@ -240,14 +250,106 @@ export class StaticSiteGenerator {
 		options.activeStaticPathnames?.add(options.pathname);
 
 		if (options.sourceFile) {
-			routeModuleBuildCache.recordStaticRender({
-				filePath: options.sourceFile,
-				pathname: options.pathname,
-				sourceHash: fileSystem.hash(options.sourceFile),
-				renderedOutputPath: outputPath,
-				context: this.staticRenderCacheContext,
-			});
+			try {
+				routeModuleBuildCache.recordStaticRender({
+					filePath: options.sourceFile,
+					pathname: options.pathname,
+					sourceHash: fileSystem.hash(options.sourceFile),
+					renderedOutputPath: outputPath,
+					context: this.staticRenderCacheContext,
+				});
+			} catch (error) {
+				appLogger.debug(
+					`Failed to record static render cache for ${options.pathname}`,
+					error instanceof Error ? error.message : String(error),
+				);
+			}
 		}
+
+		await options.onSuccessfulExport?.();
+	}
+
+	/**
+	 * Marks a successfully exported pathname as sitemap-eligible when robots allow indexing.
+	 *
+	 * @remarks
+	 * Fail-closed: metadata resolution errors omit the URL. `robots.index === false`
+	 * also omits it. Eligibility is decided during generation, not by reloading modules
+	 * after `afterStaticExport`.
+	 */
+	private async considerSitemapEligibility(input: {
+		pathname: string;
+		sitemapEligiblePathnames?: Set<string>;
+		resolveMetadata: () => Promise<PageMetadataProps>;
+	}): Promise<void> {
+		if (!input.sitemapEligiblePathnames || !this.appConfig.sitemap?.enabled) {
+			return;
+		}
+
+		try {
+			const metadata = await input.resolveMetadata();
+			if (metadata.robots?.index === false) {
+				return;
+			}
+			input.sitemapEligiblePathnames.add(normalizePathname(input.pathname));
+		} catch (error) {
+			appLogger.debug(
+				`Sitemap eligibility skipped for ${input.pathname}; metadata resolution failed`,
+				error instanceof Error ? error.message : String(error),
+			);
+		}
+	}
+
+	private getPageModuleLoader(baseUrl: string): PageModuleLoaderService {
+		this.pageModuleLoader ??= new PageModuleLoaderService(this.appConfig, baseUrl);
+		return this.pageModuleLoader;
+	}
+
+	private async resolveFilesystemPageMetadata(input: {
+		filePath: string;
+		params: Record<string, string | string[]>;
+		baseUrl: string;
+		routeRendererFactory: StaticPageRouteRendererFactory;
+	}): Promise<PageMetadataProps> {
+		const pageModule = (await input.routeRendererFactory
+			.getPageRenderer(input.filePath)
+			.loadPageModule(input.filePath)) as {
+			default?: EcoPageComponent<any>;
+			getStaticProps?: EcoPageComponent<any>['staticProps'];
+			getMetadata?: EcoPageComponent<any>['metadata'];
+		};
+		const Page = pageModule.default;
+		const loader = this.getPageModuleLoader(input.baseUrl);
+		const { metadata } = await loader.resolvePageData({
+			pageModule: {
+				getStaticProps: Page?.staticProps ?? pageModule.getStaticProps,
+				getMetadata: Page?.metadata ?? pageModule.getMetadata,
+			},
+			routeOptions: {
+				file: input.filePath,
+				params: input.params,
+			},
+		});
+		return metadata;
+	}
+
+	private async resolveExplicitViewMetadata(input: {
+		view: EcoPageComponent<any>;
+		params: Record<string, string | string[]>;
+		props: Record<string, unknown>;
+	}): Promise<PageMetadataProps> {
+		if (!input.view.metadata) {
+			return this.appConfig.defaultMetadata;
+		}
+
+		const dynamicMetadata = await input.view.metadata({
+			params: input.params,
+			query: {},
+			props: input.props,
+			appConfig: this.appConfig,
+		});
+
+		return { ...this.appConfig.defaultMetadata, ...dynamicMetadata };
 	}
 
 	private pruneStaleStaticOutputs(activeStaticPathnames: ReadonlySet<string>): void {
@@ -314,6 +416,7 @@ export class StaticSiteGenerator {
 		skipped?: string[],
 		activeStaticPathnames?: Set<string>,
 		preloadedRoutes?: readonly StaticGenerationRoute[],
+		sitemapEligiblePathnames?: Set<string>,
 	) {
 		const routes = preloadedRoutes ?? (await router.listStaticGenerationRoutes({ runtimeOrigin: baseUrl }));
 
@@ -332,6 +435,22 @@ export class StaticSiteGenerator {
 					directories,
 					debugLabel: route.requestUrl,
 					activeStaticPathnames,
+					onSuccessfulExport: () =>
+						this.considerSitemapEligibility({
+							pathname: route.pathname,
+							sitemapEligiblePathnames,
+							resolveMetadata: () => {
+								if (!routeRendererFactory) {
+									throw new Error(STATIC_SITE_GENERATOR_ERRORS.ROUTE_RENDERER_FACTORY_REQUIRED);
+								}
+								return this.resolveFilesystemPageMetadata({
+									filePath: route.templateRoute.filePath,
+									params: route.params,
+									baseUrl,
+									routeRendererFactory,
+								});
+							},
+						}),
 					createContents: () =>
 						this.createFilesystemStaticContents(route, baseUrl, routeRendererFactory, skipped),
 				});
@@ -397,8 +516,10 @@ export class StaticSiteGenerator {
 	}) {
 		const skippedDynamicPages: string[] = [];
 		const activeStaticPathnames = new Set<string>();
+		const sitemapEligiblePathnames = this.appConfig.sitemap?.enabled ? new Set<string>() : undefined;
 		this.forceFullStaticGeneration = force;
 		this.staticRenderCacheContext = createRouteModuleStaticRenderCacheContext(this.appConfig);
+		this.pageModuleLoader = undefined;
 
 		if (!force) {
 			this.getRouteModuleBuildCache().ensureIncrementalStaticGenerationContext(this.staticRenderCacheContext);
@@ -448,6 +569,7 @@ export class StaticSiteGenerator {
 				skippedDynamicPages,
 				activeStaticPathnames,
 				routes,
+				sitemapEligiblePathnames,
 			);
 
 			if (staticRoutes && staticRoutes.length > 0 && routeRendererFactory) {
@@ -456,6 +578,7 @@ export class StaticSiteGenerator {
 					routeRendererFactory,
 					skippedDynamicPages,
 					activeStaticPathnames,
+					sitemapEligiblePathnames,
 				);
 			}
 
@@ -471,13 +594,13 @@ export class StaticSiteGenerator {
 			await this.invokeStaticExportHook('afterStaticExport', staticExportContext);
 		}
 
-		if (this.appConfig.sitemap?.enabled) {
-			await this.writeSitemapAfterExport({
-				baseUrl,
-				routes,
-				activeStaticPathnames,
+		if (this.appConfig.sitemap?.enabled && sitemapEligiblePathnames) {
+			const locations = resolveSitemapLocations({
+				eligiblePathnames: [...sitemapEligiblePathnames],
 				sitemap: this.appConfig.sitemap,
+				baseUrl,
 			});
+			this.generateSitemap(locations, this.appConfig.sitemap);
 		}
 
 		if (skippedDynamicPages.length > 0) {
@@ -488,77 +611,12 @@ export class StaticSiteGenerator {
 		}
 	}
 
-	private async writeSitemapAfterExport(input: {
-		baseUrl: string;
-		routes: readonly StaticGenerationRoute[];
-		activeStaticPathnames: ReadonlySet<string>;
-		sitemap: SitemapConfig;
-	}): Promise<void> {
-		const routeByPathname = new Map(
-			input.routes.map((route) => [normalizePathname(route.pathname), route] as const),
-		);
-
-		const candidates: SitemapRouteCandidate[] = [...input.activeStaticPathnames].map((pathname) => {
-			const normalized = normalizePathname(pathname);
-			const route = routeByPathname.get(normalized) ?? routeByPathname.get(pathname);
-			return {
-				pathname: normalized,
-				params: normalizeRouteParams(route?.params ?? {}),
-				filePath: route?.templateRoute.filePath,
-			};
-		});
-
-		let pageModuleLoader: PageModuleLoaderService | undefined;
-		const getPageModuleLoader = () => {
-			pageModuleLoader ??= new PageModuleLoaderService(this.appConfig, input.baseUrl);
-			return pageModuleLoader;
-		};
-
-		const locations = await resolveSitemapPathnames({
-			candidates,
-			activeStaticPathnames: new Set(
-				[...input.activeStaticPathnames].map((pathname) => normalizePathname(pathname)),
-			),
-			sitemap: input.sitemap,
-			baseUrl: input.baseUrl,
-			resolveMetadata: async ({ filePath, params }) => {
-				if (!filePath) {
-					return undefined;
-				}
-
-				try {
-					const loader = getPageModuleLoader();
-					const pageModule = await loader.resolvePageModule({ file: filePath });
-					const { metadata } = await loader.resolvePageData({
-						pageModule,
-						routeOptions: {
-							file: filePath,
-							params,
-						},
-					});
-					return metadata;
-				} catch (error) {
-					appLogger.debug(
-						`Sitemap metadata resolution failed for ${filePath}; including URL`,
-						error instanceof Error ? error.message : String(error),
-					);
-					return undefined;
-				}
-			},
-		});
-
-		this.generateSitemap(locations, input.sitemap);
-	}
-
-	/**
-	 * Generates static pages from explicit static routes registered via app.static().
-	 * These routes use eco.page views via loader functions for HMR support.
-	 */
 	private async generateExplicitStaticPages(
 		staticRoutes: StaticRoute[],
 		routeRendererFactory: ExplicitStaticRouteRendererFactory,
 		skipped?: string[],
 		activeStaticPathnames?: Set<string>,
+		sitemapEligiblePathnames?: Set<string>,
 	): Promise<void> {
 		appLogger.debug(
 			'Generating explicit static routes',
@@ -574,7 +632,13 @@ export class StaticSiteGenerator {
 					continue;
 				}
 
-				await this.generateExplicitStaticRoute(route.path, view, routeRendererFactory, activeStaticPathnames);
+				await this.generateExplicitStaticRoute(
+					route.path,
+					view,
+					routeRendererFactory,
+					activeStaticPathnames,
+					sitemapEligiblePathnames,
+				);
 			} catch (error) {
 				appLogger.error(
 					`Error generating explicit static page for ${route.path}:`,
@@ -598,6 +662,7 @@ export class StaticSiteGenerator {
 		view: EcoPageComponent<any>,
 		routeRendererFactory: ExplicitStaticRouteRendererFactory,
 		activeStaticPathnames?: Set<string>,
+		sitemapEligiblePathnames?: Set<string>,
 	): Promise<void> {
 		const { renderer, routeEntries } = await this.planExplicitStaticRoute(routePath, view, routeRendererFactory);
 		const sourceFile = this.resolveExplicitViewSourceFile(view);
@@ -608,6 +673,23 @@ export class StaticSiteGenerator {
 				sourceFile,
 				debugLabel: pathname,
 				activeStaticPathnames,
+				onSuccessfulExport: () =>
+					this.considerSitemapEligibility({
+						pathname,
+						sitemapEligiblePathnames,
+						resolveMetadata: async () => {
+							const { props } = await prepareExplicitStaticRender({
+								routePath,
+								view,
+								params,
+								appConfig: this.appConfig,
+								runtimeOrigin: this.appConfig.baseUrl,
+								routeRendererFactory,
+								errors: STATIC_SITE_GENERATOR_ERRORS,
+							});
+							return this.resolveExplicitViewMetadata({ view, params, props });
+						},
+					}),
 				createContents: () =>
 					this.createExplicitStaticContents(routePath, view, params, routeRendererFactory, renderer),
 			});
@@ -717,19 +799,4 @@ export class StaticSiteGenerator {
 
 		return path.join(this.getExportDir(), outputName);
 	}
-}
-
-function toEcopagesRouteInfo(route: StaticGenerationRoute): EcopagesRouteInfo {
-	return {
-		pathname: normalizePathname(route.pathname),
-		params: normalizeRouteParams(route.params),
-	};
-}
-
-function normalizeRouteParams(params: Record<string, string | string[]>): Record<string, string> {
-	const normalized: Record<string, string> = {};
-	for (const [key, value] of Object.entries(params)) {
-		normalized[key] = Array.isArray(value) ? value.join('/') : value;
-	}
-	return normalized;
 }

--- a/packages/core/src/static-site-generator/static-site-generator.ts
+++ b/packages/core/src/static-site-generator/static-site-generator.ts
@@ -415,14 +415,8 @@ export class StaticSiteGenerator {
 		preloadedRoutes?: readonly StaticGenerationRoute[];
 		sitemapEligiblePathnames?: Set<string>;
 	}) {
-		const {
-			router,
-			baseUrl,
-			routeRendererFactory,
-			skipped,
-			activeStaticPathnames,
-			sitemapEligiblePathnames,
-		} = input;
+		const { router, baseUrl, routeRendererFactory, skipped, activeStaticPathnames, sitemapEligiblePathnames } =
+			input;
 		const routes = input.preloadedRoutes ?? (await router.listStaticGenerationRoutes({ runtimeOrigin: baseUrl }));
 
 		appLogger.debug(

--- a/packages/core/src/types/internal-types.ts
+++ b/packages/core/src/types/internal-types.ts
@@ -5,7 +5,7 @@ import type { BuildRuntime } from '../build/runtime/build-runtime.ts';
 import type { AnyIntegrationPlugin } from '../plugins/integration-plugin.ts';
 import type { Processor } from '../plugins/processor.ts';
 import type { EcoSourceTransform } from '../plugins/source-transform.ts';
-import type { PageMetadataProps } from './public-types.ts';
+import type { PageMetadataProps, SitemapConfig } from './public-types.ts';
 import type { RouteRegistry } from '../router/server/route-registry.ts';
 import type { CacheConfig } from '../services/cache/cache.types.ts';
 import type { DevGraphService } from '../services/runtime-state/dev-graph.service.ts';
@@ -102,6 +102,12 @@ export type EcoPagesAppConfig = {
 		 */
 		preferences: RobotsPreference;
 	};
+	/**
+	 * Automatic sitemap.xml generation during static export.
+	 *
+	 * @default { enabled: false, fileName: 'sitemap.xml', extraUrls: [], exclude: [] }
+	 */
+	sitemap: SitemapConfig;
 	/** Additional paths to watch. Use this to monitor extra files. It is relative to the rootDir */
 	additionalWatchPaths: string[];
 	/**

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -613,6 +613,20 @@ export type EcoComponent<P = any, R = any> =
 export type PageProps<T = unknown> = T & StaticPageContext & { locals?: RequestLocals };
 
 /**
+ * Page-level robots directives for the document head and sitemap filtering.
+ *
+ * @remarks
+ * When `index` is `false`, the page is omitted from the auto-generated sitemap
+ * and a `<meta name="robots">` tag is emitted (see robots meta contribution).
+ * Defaults when omitted: `index: true`, `follow: true`.
+ */
+export interface PageRobotsMetadata {
+	index?: boolean;
+	follow?: boolean;
+	nocache?: boolean;
+}
+
+/**
  * Represents the metadata for a page.
  */
 export interface PageMetadataProps {
@@ -621,6 +635,43 @@ export interface PageMetadataProps {
 	image?: string;
 	url?: string;
 	keywords?: string[];
+	robots?: PageRobotsMetadata;
+}
+
+/**
+ * Configuration for automatic `sitemap.xml` generation during static export.
+ *
+ * @remarks
+ * Disabled by default. When enabled, the sitemap is written after
+ * `afterStaticExport` so integration-generated URLs can be listed via
+ * `extraUrls`. Use `exclude` for bulk pathname filters and `metadata.robots.index: false`
+ * for page-level noindex that also removes the URL from the sitemap.
+ */
+export interface SitemapConfig {
+	/** Emit sitemap.xml during static generation. @default false */
+	enabled?: boolean;
+	/** Output file name. @default "sitemap.xml" */
+	fileName?: string;
+	/** Extra, non-page URLs to include (e.g. "/rss.xml"). Resolved against baseUrl. */
+	extraUrls?: string[];
+	/**
+	 * Pathname patterns to exclude even if a page exists.
+	 *
+	 * @remarks
+	 * Supported patterns: exact paths (`/admin`), prefix wildcards (`/admin/**`),
+	 * and `**` suffix segments. Not a full glob engine.
+	 */
+	exclude?: string[];
+}
+
+/**
+ * Slim route descriptor for static-export hooks and app-start callbacks.
+ */
+export interface EcopagesRouteInfo {
+	/** Resolved URL pathname, e.g. `/blog/my-post`. */
+	pathname: string;
+	/** Route params for dynamic routes (empty for static routes). */
+	params: Record<string, string>;
 }
 
 /**

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -617,8 +617,10 @@ export type PageProps<T = unknown> = T & StaticPageContext & { locals?: RequestL
  *
  * @remarks
  * When `index` is `false`, the page is omitted from the auto-generated sitemap
- * and a `<meta name="robots">` tag is emitted (see robots meta contribution).
- * Defaults when omitted: `index: true`, `follow: true`.
+ * for routes whose metadata can be resolved during static export (filesystem
+ * pages and `app.static()` views with `metadata`). Defaults when omitted:
+ * `index: true`, `follow: true`. A `<meta name="robots">` tag is emitted by the
+ * route HTML finalization path when directives differ from those defaults.
  */
 export interface PageRobotsMetadata {
 	index?: boolean;
@@ -645,27 +647,34 @@ export interface PageMetadataProps {
  * Disabled by default. When enabled, the sitemap is written after
  * `afterStaticExport` so integration-generated URLs can be listed via
  * `extraUrls`. Use `exclude` for bulk pathname filters and `metadata.robots.index: false`
- * for page-level noindex that also removes the URL from the sitemap.
+ * for page-level noindex that also removes the URL from the sitemap when metadata
+ * is available during export.
  */
 export interface SitemapConfig {
 	/** Emit sitemap.xml during static generation. @default false */
 	enabled?: boolean;
 	/** Output file name. @default "sitemap.xml" */
 	fileName?: string;
-	/** Extra, non-page URLs to include (e.g. "/rss.xml"). Resolved against baseUrl. */
+	/**
+	 * Extra, non-page URLs to include (e.g. "/rss.xml").
+	 *
+	 * @remarks
+	 * Relative paths are resolved against `baseUrl`. Absolute `http(s)` URLs pass
+	 * through. Always appended after page URLs; not filtered by `exclude` or page robots.
+	 */
 	extraUrls?: string[];
 	/**
 	 * Pathname patterns to exclude even if a page exists.
 	 *
 	 * @remarks
-	 * Supported patterns: exact paths (`/admin`), prefix wildcards (`/admin/**`),
-	 * and `**` suffix segments. Not a full glob engine.
+	 * Supported patterns: exact paths (`/admin`) and prefix wildcards (`/admin/**`).
+	 * Unsupported patterns are treated as exact matches. This is not a full glob engine.
 	 */
 	exclude?: string[];
 }
 
 /**
- * Slim route descriptor for static-export hooks and app-start callbacks.
+ * Slim route descriptor for static-export hooks and runtime consumers.
  */
 export interface EcopagesRouteInfo {
 	/** Resolved URL pathname, e.g. `/blog/my-post`. */

--- a/packages/core/src/utils/ecopages-route-info.ts
+++ b/packages/core/src/utils/ecopages-route-info.ts
@@ -1,0 +1,26 @@
+import type { EcopagesRouteInfo } from '../types/public-types.ts';
+import { normalizePathname } from './path-pattern.ts';
+
+/**
+ * Maps a static-generation or registry route into the public slim route shape.
+ */
+export function toEcopagesRouteInfo(route: {
+	pathname: string;
+	params: Record<string, string | string[]>;
+}): EcopagesRouteInfo {
+	return {
+		pathname: normalizePathname(route.pathname),
+		params: normalizeRouteParams(route.params),
+	};
+}
+
+/**
+ * Flattens string | string[] route params into string values for public APIs.
+ */
+export function normalizeRouteParams(params: Record<string, string | string[]>): Record<string, string> {
+	const normalized: Record<string, string> = {};
+	for (const [key, value] of Object.entries(params)) {
+		normalized[key] = Array.isArray(value) ? value.join('/') : value;
+	}
+	return normalized;
+}

--- a/packages/core/src/utils/html-escaping.ts
+++ b/packages/core/src/utils/html-escaping.ts
@@ -7,3 +7,18 @@
 export function escapeHtmlAttribute(value: string): string {
 	return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
 }
+
+/**
+ * Escapes a string for safe use as XML text content (e.g. `<loc>` values).
+ *
+ * @param value Raw text node value.
+ * @returns Escaped XML-safe string.
+ */
+export function escapeXmlText(value: string): string {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&apos;');
+}

--- a/packages/core/src/utils/path-pattern.test.ts
+++ b/packages/core/src/utils/path-pattern.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest';
+import { matchPathPattern, matchesAnyPathPattern } from './path-pattern.ts';
+
+describe('matchPathPattern', () => {
+	test('matches exact pathnames', () => {
+		expect(matchPathPattern('/admin', '/admin')).toBe(true);
+		expect(matchPathPattern('/admin/', '/admin')).toBe(true);
+		expect(matchPathPattern('/admin/users', '/admin')).toBe(false);
+	});
+
+	test('matches prefix/** patterns including the prefix itself', () => {
+		expect(matchPathPattern('/admin', '/admin/**')).toBe(true);
+		expect(matchPathPattern('/admin/users', '/admin/**')).toBe(true);
+		expect(matchPathPattern('/admin/users/edit', '/admin/**')).toBe(true);
+		expect(matchPathPattern('/administrator', '/admin/**')).toBe(false);
+		expect(matchPathPattern('/blog', '/admin/**')).toBe(false);
+	});
+
+	test('/** matches every pathname', () => {
+		expect(matchPathPattern('/', '/**')).toBe(true);
+		expect(matchPathPattern('/anything', '/**')).toBe(true);
+	});
+});
+
+describe('matchesAnyPathPattern', () => {
+	test('returns true when any pattern matches', () => {
+		expect(matchesAnyPathPattern('/preview/draft', ['/admin/**', '/preview/**'])).toBe(true);
+		expect(matchesAnyPathPattern('/blog', ['/admin/**', '/preview/**'])).toBe(false);
+	});
+});

--- a/packages/core/src/utils/path-pattern.ts
+++ b/packages/core/src/utils/path-pattern.ts
@@ -1,0 +1,47 @@
+/**
+ * Normalizes a URL pathname for matching and sitemap location building.
+ *
+ * @remarks
+ * Ensures a leading slash and strips trailing slashes except for `/`.
+ */
+export function normalizePathname(pathname: string): string {
+	if (!pathname || pathname === '/') {
+		return '/';
+	}
+
+	const withLeadingSlash = pathname.startsWith('/') ? pathname : `/${pathname}`;
+	return withLeadingSlash.replace(/\/+$/, '') || '/';
+}
+
+/**
+ * Matches a pathname against a small set of supported patterns.
+ *
+ * @remarks
+ * Supported forms:
+ * - exact: `/admin`
+ * - prefix wildcard: `/admin/**` (matches `/admin` and descendants)
+ * - trailing `**` only as a full segment after `/`
+ *
+ * This is not a full glob engine. Unsupported patterns are treated as exact matches.
+ */
+export function matchPathPattern(pathname: string, pattern: string): boolean {
+	const normalizedPath = normalizePathname(pathname);
+	const normalizedPattern = pattern.trim();
+
+	if (normalizedPattern.endsWith('/**')) {
+		const prefix = normalizePathname(normalizedPattern.slice(0, -3));
+		if (prefix === '/') {
+			return true;
+		}
+		return normalizedPath === prefix || normalizedPath.startsWith(`${prefix}/`);
+	}
+
+	return normalizedPath === normalizePathname(normalizedPattern);
+}
+
+/**
+ * Returns true when the pathname matches any of the patterns.
+ */
+export function matchesAnyPathPattern(pathname: string, patterns: readonly string[]): boolean {
+	return patterns.some((pattern) => matchPathPattern(pathname, pattern));
+}

--- a/packages/integrations/ecopages-jsx/src/test/ecopages-jsx-renderer.test.tsx
+++ b/packages/integrations/ecopages-jsx/src/test/ecopages-jsx-renderer.test.tsx
@@ -445,92 +445,88 @@ describe('EcopagesJsxRenderer', () => {
 		 * flakes under suite load; a timeout leaves the global JSX SSR scope stack
 		 * uncleared and pollutes later frame-depth probes.
 		 */
-		it(
-			'renders the real kitchen-sink mixed shell stack without leaking foreign renderer objects',
-			async () => {
-				const jsx = ecopagesJsxPlugin();
-				const kitajs = kitajsPlugin();
-				const lit = litPlugin();
-				const react = reactPlugin({
-					extensions: ['.react.tsx'],
-				});
-				const config = await new ConfigBuilder()
-					.setRootDir(KITCHEN_SINK_ROOT)
-					.setRobotsTxt({
-						preferences: {
-							'*': [],
-						},
-					})
-					.setIntegrations([jsx, kitajs, lit, react])
-					.setDefaultMetadata({
-						title: 'Ecopages',
-						description: 'Ecopages',
-					})
-					.setBaseUrl('http://localhost:3000')
-					.build();
-
-				jsx.setConfig(config);
-				jsx.setRuntimeOrigin('http://localhost:3000');
-				kitajs.setConfig(config);
-				kitajs.setRuntimeOrigin('http://localhost:3000');
-				lit.setConfig(config);
-				lit.setRuntimeOrigin('http://localhost:3000');
-				react.setConfig(config);
-				react.setRuntimeOrigin('http://localhost:3000');
-
-				const renderer = new TestEcopagesJsxRenderer({
-					appConfig: config,
-					assetProcessingService: {
-						processDependencies: vi.fn(async () => []),
-					} as never,
-					runtimeOrigin: 'http://localhost:3000',
-					resolvedIntegrationDependencies: [],
-				});
-
-				const Page = eco.component<{}, JsxRenderable>({
-					integration: 'ecopages-jsx',
-					dependencies: {
-						components: [
-							KitchenSinkIntegrationCounterGroup,
-							KitchenSinkKitaShell,
-							KitchenSinkLitShell,
-							KitchenSinkReactShell,
-							KitchenSinkEcopagesJsxShell,
-						],
+		it('renders the real kitchen-sink mixed shell stack without leaking foreign renderer objects', async () => {
+			const jsx = ecopagesJsxPlugin();
+			const kitajs = kitajsPlugin();
+			const lit = litPlugin();
+			const react = reactPlugin({
+				extensions: ['.react.tsx'],
+			});
+			const config = await new ConfigBuilder()
+				.setRootDir(KITCHEN_SINK_ROOT)
+				.setRobotsTxt({
+					preferences: {
+						'*': [],
 					},
-					render: () => (
-						<div>
-							<EcoEmbed component={KitchenSinkEcopagesJsxShell} props={{ id: 'host-shell' }}>
-								<EcoEmbed component={KitchenSinkKitaShell} props={{ id: 'kita-shell' }}>
-									<EcoEmbed component={KitchenSinkLitShell} props={{ id: 'lit-shell' }}>
-										<EcoEmbed component={KitchenSinkReactShell} props={{ id: 'react-shell' }}>
-											Leaf
-										</EcoEmbed>
+				})
+				.setIntegrations([jsx, kitajs, lit, react])
+				.setDefaultMetadata({
+					title: 'Ecopages',
+					description: 'Ecopages',
+				})
+				.setBaseUrl('http://localhost:3000')
+				.build();
+
+			jsx.setConfig(config);
+			jsx.setRuntimeOrigin('http://localhost:3000');
+			kitajs.setConfig(config);
+			kitajs.setRuntimeOrigin('http://localhost:3000');
+			lit.setConfig(config);
+			lit.setRuntimeOrigin('http://localhost:3000');
+			react.setConfig(config);
+			react.setRuntimeOrigin('http://localhost:3000');
+
+			const renderer = new TestEcopagesJsxRenderer({
+				appConfig: config,
+				assetProcessingService: {
+					processDependencies: vi.fn(async () => []),
+				} as never,
+				runtimeOrigin: 'http://localhost:3000',
+				resolvedIntegrationDependencies: [],
+			});
+
+			const Page = eco.component<{}, JsxRenderable>({
+				integration: 'ecopages-jsx',
+				dependencies: {
+					components: [
+						KitchenSinkIntegrationCounterGroup,
+						KitchenSinkKitaShell,
+						KitchenSinkLitShell,
+						KitchenSinkReactShell,
+						KitchenSinkEcopagesJsxShell,
+					],
+				},
+				render: () => (
+					<div>
+						<EcoEmbed component={KitchenSinkEcopagesJsxShell} props={{ id: 'host-shell' }}>
+							<EcoEmbed component={KitchenSinkKitaShell} props={{ id: 'kita-shell' }}>
+								<EcoEmbed component={KitchenSinkLitShell} props={{ id: 'lit-shell' }}>
+									<EcoEmbed component={KitchenSinkReactShell} props={{ id: 'react-shell' }}>
+										Leaf
 									</EcoEmbed>
 								</EcoEmbed>
 							</EcoEmbed>
-							<EcoEmbed
-								component={KitchenSinkIntegrationCounterGroup}
-								props={{ testId: 'kitchen-sink-counters', radiantId: 'kitchen-sink-radiant' }}
-							/>
-						</div>
-					),
-				});
+						</EcoEmbed>
+						<EcoEmbed
+							component={KitchenSinkIntegrationCounterGroup}
+							props={{ testId: 'kitchen-sink-counters', radiantId: 'kitchen-sink-radiant' }}
+						/>
+					</div>
+				),
+			});
 
-				const result = await renderer.renderComponentWithForeignChildren({
-					component: Page,
-					props: {},
-					integrationContext: {
-						componentInstanceId: 'kitchen-sink-host',
-					},
-				});
+			const result = await renderer.renderComponentWithForeignChildren({
+				component: Page,
+				props: {},
+				integrationContext: {
+					componentInstanceId: 'kitchen-sink-host',
+				},
+			});
 
-				expect(result.html).toContain('integration-shell__body');
-				expect(result.html).toContain('kitchen-sink-counters');
-				expect(result.html).not.toContain('[object Object]');
-			},
-			20_000,
-		);
+			expect(result.html).toContain('integration-shell__body');
+			expect(result.html).toContain('kitchen-sink-counters');
+			expect(result.html).not.toContain('[object Object]');
+		}, 20_000);
 
 		it('rejects opaque foreign children instead of coercing them to object text', () => {
 			const renderer = new TestEcopagesJsxRenderer({

--- a/packages/integrations/ecopages-jsx/src/test/ecopages-jsx-renderer.test.tsx
+++ b/packages/integrations/ecopages-jsx/src/test/ecopages-jsx-renderer.test.tsx
@@ -439,88 +439,98 @@ describe('EcopagesJsxRenderer', () => {
 			expect(result.html).not.toContain('[object Object]');
 		});
 
-		it('renders the real kitchen-sink mixed shell stack without leaking foreign renderer objects', async () => {
-			const jsx = ecopagesJsxPlugin();
-			const kitajs = kitajsPlugin();
-			const lit = litPlugin();
-			const react = reactPlugin({
-				extensions: ['.react.tsx'],
-			});
-			const config = await new ConfigBuilder()
-				.setRootDir(KITCHEN_SINK_ROOT)
-				.setRobotsTxt({
-					preferences: {
-						'*': [],
+		/**
+		 * @remarks
+		 * Boots four integrations plus real kitchen-sink shells. The 5s Vitest default
+		 * flakes under suite load; a timeout leaves the global JSX SSR scope stack
+		 * uncleared and pollutes later frame-depth probes.
+		 */
+		it(
+			'renders the real kitchen-sink mixed shell stack without leaking foreign renderer objects',
+			async () => {
+				const jsx = ecopagesJsxPlugin();
+				const kitajs = kitajsPlugin();
+				const lit = litPlugin();
+				const react = reactPlugin({
+					extensions: ['.react.tsx'],
+				});
+				const config = await new ConfigBuilder()
+					.setRootDir(KITCHEN_SINK_ROOT)
+					.setRobotsTxt({
+						preferences: {
+							'*': [],
+						},
+					})
+					.setIntegrations([jsx, kitajs, lit, react])
+					.setDefaultMetadata({
+						title: 'Ecopages',
+						description: 'Ecopages',
+					})
+					.setBaseUrl('http://localhost:3000')
+					.build();
+
+				jsx.setConfig(config);
+				jsx.setRuntimeOrigin('http://localhost:3000');
+				kitajs.setConfig(config);
+				kitajs.setRuntimeOrigin('http://localhost:3000');
+				lit.setConfig(config);
+				lit.setRuntimeOrigin('http://localhost:3000');
+				react.setConfig(config);
+				react.setRuntimeOrigin('http://localhost:3000');
+
+				const renderer = new TestEcopagesJsxRenderer({
+					appConfig: config,
+					assetProcessingService: {
+						processDependencies: vi.fn(async () => []),
+					} as never,
+					runtimeOrigin: 'http://localhost:3000',
+					resolvedIntegrationDependencies: [],
+				});
+
+				const Page = eco.component<{}, JsxRenderable>({
+					integration: 'ecopages-jsx',
+					dependencies: {
+						components: [
+							KitchenSinkIntegrationCounterGroup,
+							KitchenSinkKitaShell,
+							KitchenSinkLitShell,
+							KitchenSinkReactShell,
+							KitchenSinkEcopagesJsxShell,
+						],
 					},
-				})
-				.setIntegrations([jsx, kitajs, lit, react])
-				.setDefaultMetadata({
-					title: 'Ecopages',
-					description: 'Ecopages',
-				})
-				.setBaseUrl('http://localhost:3000')
-				.build();
-
-			jsx.setConfig(config);
-			jsx.setRuntimeOrigin('http://localhost:3000');
-			kitajs.setConfig(config);
-			kitajs.setRuntimeOrigin('http://localhost:3000');
-			lit.setConfig(config);
-			lit.setRuntimeOrigin('http://localhost:3000');
-			react.setConfig(config);
-			react.setRuntimeOrigin('http://localhost:3000');
-
-			const renderer = new TestEcopagesJsxRenderer({
-				appConfig: config,
-				assetProcessingService: {
-					processDependencies: vi.fn(async () => []),
-				} as never,
-				runtimeOrigin: 'http://localhost:3000',
-				resolvedIntegrationDependencies: [],
-			});
-
-			const Page = eco.component<{}, JsxRenderable>({
-				integration: 'ecopages-jsx',
-				dependencies: {
-					components: [
-						KitchenSinkIntegrationCounterGroup,
-						KitchenSinkKitaShell,
-						KitchenSinkLitShell,
-						KitchenSinkReactShell,
-						KitchenSinkEcopagesJsxShell,
-					],
-				},
-				render: () => (
-					<div>
-						<EcoEmbed component={KitchenSinkEcopagesJsxShell} props={{ id: 'host-shell' }}>
-							<EcoEmbed component={KitchenSinkKitaShell} props={{ id: 'kita-shell' }}>
-								<EcoEmbed component={KitchenSinkLitShell} props={{ id: 'lit-shell' }}>
-									<EcoEmbed component={KitchenSinkReactShell} props={{ id: 'react-shell' }}>
-										Leaf
+					render: () => (
+						<div>
+							<EcoEmbed component={KitchenSinkEcopagesJsxShell} props={{ id: 'host-shell' }}>
+								<EcoEmbed component={KitchenSinkKitaShell} props={{ id: 'kita-shell' }}>
+									<EcoEmbed component={KitchenSinkLitShell} props={{ id: 'lit-shell' }}>
+										<EcoEmbed component={KitchenSinkReactShell} props={{ id: 'react-shell' }}>
+											Leaf
+										</EcoEmbed>
 									</EcoEmbed>
 								</EcoEmbed>
 							</EcoEmbed>
-						</EcoEmbed>
-						<EcoEmbed
-							component={KitchenSinkIntegrationCounterGroup}
-							props={{ testId: 'kitchen-sink-counters', radiantId: 'kitchen-sink-radiant' }}
-						/>
-					</div>
-				),
-			});
+							<EcoEmbed
+								component={KitchenSinkIntegrationCounterGroup}
+								props={{ testId: 'kitchen-sink-counters', radiantId: 'kitchen-sink-radiant' }}
+							/>
+						</div>
+					),
+				});
 
-			const result = await renderer.renderComponentWithForeignChildren({
-				component: Page,
-				props: {},
-				integrationContext: {
-					componentInstanceId: 'kitchen-sink-host',
-				},
-			});
+				const result = await renderer.renderComponentWithForeignChildren({
+					component: Page,
+					props: {},
+					integrationContext: {
+						componentInstanceId: 'kitchen-sink-host',
+					},
+				});
 
-			expect(result.html).toContain('integration-shell__body');
-			expect(result.html).toContain('kitchen-sink-counters');
-			expect(result.html).not.toContain('[object Object]');
-		});
+				expect(result.html).toContain('integration-shell__body');
+				expect(result.html).toContain('kitchen-sink-counters');
+				expect(result.html).not.toContain('[object Object]');
+			},
+			20_000,
+		);
 
 		it('rejects opaque foreign children instead of coercing them to object text', () => {
 			const renderer = new TestEcopagesJsxRenderer({


### PR DESCRIPTION
## Summary
Adds first-class, opt-in `sitemap.xml` generation in `@ecopages/core` during static export — written after `afterStaticExport`, filtered by `noindex`, `exclude`, and successfully exported pathnames.

## What changed
- `setSitemap()` / `SitemapConfig` with safe defaults (`enabled: false`)
- `PageMetadataProps.robots` for page-level noindex (meta tag lands in follow-up PR)
- Pure `renderSitemap` + `resolveSitemapPathnames` with path-pattern exclude matching
- `StaticExportContext.routes` (unfiltered) for integration hooks
- `activeStaticPathnames` only tracks successfully written/reused pages

## How to verify
1. Enable `.setSitemap({ enabled: true, extraUrls: ['/rss.xml'], exclude: ['/admin/**'] })`
2. Run `ecopages build` and confirm `dist/sitemap.xml`
3. `pnpm exec vitest run --project shared-core packages/core/src/static-site-generator/`

## Notes
Stacks on `release/v0.2.0`. Follow-ups: robots meta contribution + `AppStartInfo.routes`, then docs.