### PR TITLE
feat(core): emit robots meta and expose AppStartInfo.routes

### DIFF
--- a/packages/core/src/adapters/abstract/application-adapter.test.ts
+++ b/packages/core/src/adapters/abstract/application-adapter.test.ts
@@ -247,12 +247,16 @@ describe('application adapter listening', () => {
 			} as ApplicationAdapterOptions['appConfig'],
 		});
 
-		await adapter.start(({ origin }) => {
+		let receivedRoutes: unknown;
+		await adapter.start(({ origin, routes }) => {
 			assert.equal(origin, 'http://localhost:3000');
+			receivedRoutes = routes;
 		});
 		adapter.handleListening('http://localhost:3000/');
+		await Promise.resolve();
 
 		assert.equal(infoSpy.mock.calls.length, 0);
+		assert.deepEqual(receivedRoutes, []);
 		infoSpy.mockRestore();
 	});
 });

--- a/packages/core/src/adapters/abstract/application-adapter.test.ts
+++ b/packages/core/src/adapters/abstract/application-adapter.test.ts
@@ -252,8 +252,7 @@ describe('application adapter listening', () => {
 			assert.equal(origin, 'http://localhost:3000');
 			receivedRoutes = routes;
 		});
-		adapter.handleListening('http://localhost:3000/');
-		await Promise.resolve();
+		await adapter.handleListening('http://localhost:3000/');
 
 		assert.equal(infoSpy.mock.calls.length, 0);
 		assert.deepEqual(receivedRoutes, []);

--- a/packages/core/src/adapters/abstract/application-adapter.ts
+++ b/packages/core/src/adapters/abstract/application-adapter.ts
@@ -81,7 +81,8 @@ export interface AppStartInfo {
 	 *
 	 * @remarks
 	 * Empty when the server adapter has no route registry yet, or when route
-	 * resolution fails (failures never block startup).
+	 * resolution fails (failures never block startup). Route resolution completes
+	 * before the `onAppStart` callback runs.
 	 */
 	routes: EcopagesRouteInfo[];
 }
@@ -121,7 +122,7 @@ export interface ApplicationAdapter<T = any> extends AsyncDisposable {
 	/** Boot the server. Pass a callback to run when the runtime is ready (optional). */
 	start(onAppStart?: OnAppStartCallback): Promise<T | void>;
 	/** Invoked by embedded hosts once the app can take traffic. */
-	handleListening(origin: string): void;
+	handleListening(origin: string): void | Promise<void>;
 	stop(force?: boolean): Promise<void>;
 }
 
@@ -535,11 +536,11 @@ export abstract class AbstractApplicationAdapter<
 	/**
 	 * Invoked by embedded hosts (for example Vite) once the app can take traffic.
 	 */
-	public handleListening(origin: string): void {
-		this.notifyListening(origin);
+	public async handleListening(origin: string): Promise<void> {
+		await this.notifyListening(origin);
 	}
 
-	protected notifyListening(origin: string): void {
+	protected async notifyListening(origin: string): Promise<void> {
 		const normalizedOrigin = origin.replace(/\/$/, '');
 
 		startupTrace.markServerListening();
@@ -549,7 +550,7 @@ export abstract class AbstractApplicationAdapter<
 			return;
 		}
 
-		void this.invokeAppStartCallback(normalizedOrigin);
+		await this.invokeAppStartCallback(normalizedOrigin);
 	}
 
 	/**

--- a/packages/core/src/adapters/abstract/application-adapter.ts
+++ b/packages/core/src/adapters/abstract/application-adapter.ts
@@ -24,6 +24,7 @@ import type {
 	RouteOptions,
 	StaticRoute,
 	ViewLoader,
+	EcopagesRouteInfo,
 } from '../../types/public-types.ts';
 import type { EcopagesWebSocketHandler } from '../../types/public-types.ts';
 import { fileSystem } from '@ecopages/file-system';
@@ -75,6 +76,14 @@ export interface ApplicationRuntimeOptions {
 
 export interface AppStartInfo {
 	origin: string;
+	/**
+	 * Static-generation routes available when the runtime becomes ready.
+	 *
+	 * @remarks
+	 * Empty when the server adapter has no route registry yet, or when route
+	 * resolution fails (failures never block startup).
+	 */
+	routes: EcopagesRouteInfo[];
 }
 
 export type OnAppStartCallback = (info: AppStartInfo) => void;
@@ -537,9 +546,35 @@ export abstract class AbstractApplicationAdapter<
 
 		if (!this.onAppStartCallback) {
 			this.logServerStarted(normalizedOrigin);
+			return;
 		}
 
-		this.onAppStartCallback?.({ origin: normalizedOrigin });
+		void this.invokeAppStartCallback(normalizedOrigin);
+	}
+
+	/**
+	 * Resolves routes exposed on {@link AppStartInfo}.
+	 *
+	 * @remarks
+	 * Default is empty. Runtime adapters override this to read from the
+	 * initialized server route registry.
+	 */
+	protected async resolveAppRoutes(): Promise<EcopagesRouteInfo[]> {
+		return [];
+	}
+
+	private async invokeAppStartCallback(origin: string): Promise<void> {
+		let routes: EcopagesRouteInfo[] = [];
+		try {
+			routes = await this.resolveAppRoutes();
+		} catch (error) {
+			appLogger.debug(
+				'Failed to resolve app start routes; continuing with empty routes',
+				error instanceof Error ? error.message : String(error),
+			);
+		}
+
+		this.onAppStartCallback?.({ origin, routes });
 	}
 
 	/**

--- a/packages/core/src/adapters/abstract/server-adapter.ts
+++ b/packages/core/src/adapters/abstract/server-adapter.ts
@@ -9,6 +9,7 @@
 
 import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 import type { ApiHandler } from '../../types/public-types.ts';
+import type { StaticGenerationRoute } from '../../router/server/route-registry.ts';
 
 /**
  * Configuration options for all server adapters
@@ -33,6 +34,13 @@ export interface ServerAdapterResult {
 	buildStatic: (options?: { preview?: boolean; force?: boolean }) => Promise<string | undefined>;
 	servePreviewOnly: () => Promise<string | undefined>;
 	dispose(): Promise<void>;
+	/**
+	 * Lists static-generation routes for app-start consumers.
+	 *
+	 * @remarks
+	 * Optional so lightweight adapter stubs in tests need not implement routing.
+	 */
+	listStaticGenerationRoutes?: (input: { runtimeOrigin: string }) => Promise<readonly StaticGenerationRoute[]>;
 }
 
 /**

--- a/packages/core/src/adapters/bun/create-app.ts
+++ b/packages/core/src/adapters/bun/create-app.ts
@@ -10,7 +10,7 @@
 
 import type { Server } from 'bun';
 import { appLogger } from '../../global/app-logger.ts';
-import type { ApiHandlerContext, RouteGroupBuilder } from '../../types/public-types.ts';
+import type { ApiHandlerContext, RouteGroupBuilder, EcopagesRouteInfo } from '../../types/public-types.ts';
 import { SharedApplicationAdapter } from '../shared/application-adapter.ts';
 import { resolveRuntimeBinding, resolveStaticRuntimeMode } from '../shared/runtime-app-bootstrap.ts';
 import { startupTrace } from '../../diagnostics/startup-trace.ts';
@@ -226,6 +226,24 @@ export class BunEcopagesApp<WebSocketData = undefined> extends SharedApplication
 		}
 
 		this.stopped = true;
+	}
+
+	protected override async resolveAppRoutes(): Promise<EcopagesRouteInfo[]> {
+		const listRoutes = this.serverAdapter?.listStaticGenerationRoutes;
+		if (!listRoutes) {
+			return [];
+		}
+
+		const routes = await listRoutes({ runtimeOrigin: this.appConfig.baseUrl });
+		return routes.map((route) => ({
+			pathname: route.pathname,
+			params: Object.fromEntries(
+				Object.entries(route.params).map(([key, value]) => [
+					key,
+					Array.isArray(value) ? value.join('/') : value,
+				]),
+			),
+		}));
 	}
 }
 

--- a/packages/core/src/adapters/bun/create-app.ts
+++ b/packages/core/src/adapters/bun/create-app.ts
@@ -10,7 +10,7 @@
 
 import type { Server } from 'bun';
 import { appLogger } from '../../global/app-logger.ts';
-import type { ApiHandlerContext, RouteGroupBuilder, EcopagesRouteInfo } from '../../types/public-types.ts';
+import type { ApiHandlerContext, RouteGroupBuilder } from '../../types/public-types.ts';
 import { SharedApplicationAdapter } from '../shared/application-adapter.ts';
 import { resolveRuntimeBinding, resolveStaticRuntimeMode } from '../shared/runtime-app-bootstrap.ts';
 import { startupTrace } from '../../diagnostics/startup-trace.ts';
@@ -19,6 +19,7 @@ import type { EcopagesAppOptions } from '../create-app.ts';
 import { type BunServerAdapterResult, createBunServerAdapter } from './server-adapter.ts';
 import { BunRuntimeHost } from './runtime-host.ts';
 import { hostOwnsDevClient } from '../../dev/dev-client-ownership.ts';
+import { resolveAppStartRoutes } from '../../utils/ecopages-route-info.ts';
 
 /**
  * Bun-specific route group builder that properly infers route params from path patterns.
@@ -144,7 +145,7 @@ export class BunEcopagesApp<WebSocketData = undefined> extends SharedApplication
 		if (preview && serveOnly) {
 			const previewOrigin = await this.serverAdapter.servePreviewOnly();
 			if (previewOrigin) {
-				this.notifyListening(previewOrigin);
+				await this.notifyListening(previewOrigin);
 			}
 			return;
 		}
@@ -155,7 +156,7 @@ export class BunEcopagesApp<WebSocketData = undefined> extends SharedApplication
 			appLogger.debugTimeEnd('Building static pages');
 
 			if (preview && previewOrigin) {
-				this.notifyListening(previewOrigin);
+				await this.notifyListening(previewOrigin);
 			}
 
 			if (build) {
@@ -200,11 +201,11 @@ export class BunEcopagesApp<WebSocketData = undefined> extends SharedApplication
 				process.exit(0);
 			}
 		} else {
-			this.notifyListening(runtimeOrigin);
+			await this.notifyListening(runtimeOrigin);
 		}
 
 		if (preview && previewOrigin) {
-			this.notifyListening(previewOrigin);
+			await this.notifyListening(previewOrigin);
 		}
 
 		return this.server ?? undefined;
@@ -228,22 +229,11 @@ export class BunEcopagesApp<WebSocketData = undefined> extends SharedApplication
 		this.stopped = true;
 	}
 
-	protected override async resolveAppRoutes(): Promise<EcopagesRouteInfo[]> {
-		const listRoutes = this.serverAdapter?.listStaticGenerationRoutes;
-		if (!listRoutes) {
-			return [];
-		}
-
-		const routes = await listRoutes({ runtimeOrigin: this.appConfig.baseUrl });
-		return routes.map((route) => ({
-			pathname: route.pathname,
-			params: Object.fromEntries(
-				Object.entries(route.params).map(([key, value]) => [
-					key,
-					Array.isArray(value) ? value.join('/') : value,
-				]),
-			),
-		}));
+	protected override async resolveAppRoutes() {
+		return resolveAppStartRoutes({
+			listStaticGenerationRoutes: this.serverAdapter?.listStaticGenerationRoutes,
+			runtimeOrigin: this.appConfig.baseUrl,
+		});
 	}
 }
 

--- a/packages/core/src/adapters/bun/server-adapter.ts
+++ b/packages/core/src/adapters/bun/server-adapter.ts
@@ -718,6 +718,7 @@ export class BunServerAdapter extends SharedServerAdapter<BunServerAdapterParams
 			completeInitialization: this.completeInitialization.bind(this),
 			handleRequest: this.handleRequest.bind(this),
 			attachUserWebSocketUpgrades: this.attachUserWebSocketUpgrades.bind(this),
+			listStaticGenerationRoutes: (input) => this.router.listStaticGenerationRoutes(input),
 			dispose: this.dispose.bind(this),
 		};
 	}

--- a/packages/core/src/adapters/node/create-app.ts
+++ b/packages/core/src/adapters/node/create-app.ts
@@ -1,5 +1,5 @@
 import { appLogger } from '../../global/app-logger.ts';
-import type { StaticRoute, EcopagesRouteInfo } from '../../types/public-types.ts';
+import type { StaticRoute } from '../../types/public-types.ts';
 import { SharedApplicationAdapter } from '../shared/application-adapter.ts';
 import { resolveRuntimeBinding, resolveStaticRuntimeMode } from '../shared/runtime-app-bootstrap.ts';
 import type { RuntimeHost } from '../shared/runtime-host.ts';
@@ -10,6 +10,7 @@ import type { NodeServerInstance } from './server-adapter.ts';
 import { NodeRuntimeHost } from './runtime-host.ts';
 import { hostOwnsDevClient } from '../../dev/dev-client-ownership.ts';
 import { startupTrace } from '../../diagnostics/startup-trace.ts';
+import { resolveAppStartRoutes } from '../../utils/ecopages-route-info.ts';
 
 export class NodeEcopagesApp extends SharedApplicationAdapter<EcopagesAppOptions, NodeServerInstance, Request> {
 	serverAdapter: NodeServerAdapterResult | undefined;
@@ -52,22 +53,11 @@ export class NodeEcopagesApp extends SharedApplicationAdapter<EcopagesAppOptions
 		this.stopped = true;
 	}
 
-	protected override async resolveAppRoutes(): Promise<EcopagesRouteInfo[]> {
-		const listRoutes = this.serverAdapter?.listStaticGenerationRoutes;
-		if (!listRoutes) {
-			return [];
-		}
-
-		const routes = await listRoutes({ runtimeOrigin: this.appConfig.baseUrl });
-		return routes.map((route) => ({
-			pathname: route.pathname,
-			params: Object.fromEntries(
-				Object.entries(route.params).map(([key, value]) => [
-					key,
-					Array.isArray(value) ? value.join('/') : value,
-				]),
-			),
-		}));
+	protected override async resolveAppRoutes() {
+		return resolveAppStartRoutes({
+			listStaticGenerationRoutes: this.serverAdapter?.listStaticGenerationRoutes,
+			runtimeOrigin: this.appConfig.baseUrl,
+		});
 	}
 
 	protected async initializeServerAdapter(): Promise<NodeServerAdapterResult> {
@@ -114,7 +104,7 @@ export class NodeEcopagesApp extends SharedApplicationAdapter<EcopagesAppOptions
 		if (preview && serveOnly) {
 			const previewOrigin = await this.serverAdapter.servePreviewOnly();
 			if (previewOrigin) {
-				this.notifyListening(previewOrigin);
+				await this.notifyListening(previewOrigin);
 			}
 			return;
 		}
@@ -125,7 +115,7 @@ export class NodeEcopagesApp extends SharedApplicationAdapter<EcopagesAppOptions
 			appLogger.debugTimeEnd('Building static pages');
 
 			if (preview && previewOrigin) {
-				this.notifyListening(previewOrigin);
+				await this.notifyListening(previewOrigin);
 			}
 
 			if (build) {
@@ -144,7 +134,7 @@ export class NodeEcopagesApp extends SharedApplicationAdapter<EcopagesAppOptions
 		this.runtimeOrigin = this.runtimeHost.getOrigin(this.server, serveOptions);
 
 		await this.serverAdapter.completeInitialization(this.server);
-		this.notifyListening(this.runtimeOrigin);
+		await this.notifyListening(this.runtimeOrigin);
 
 		return this.server;
 	}

--- a/packages/core/src/adapters/node/create-app.ts
+++ b/packages/core/src/adapters/node/create-app.ts
@@ -1,5 +1,5 @@
 import { appLogger } from '../../global/app-logger.ts';
-import type { StaticRoute } from '../../types/public-types.ts';
+import type { StaticRoute, EcopagesRouteInfo } from '../../types/public-types.ts';
 import { SharedApplicationAdapter } from '../shared/application-adapter.ts';
 import { resolveRuntimeBinding, resolveStaticRuntimeMode } from '../shared/runtime-app-bootstrap.ts';
 import type { RuntimeHost } from '../shared/runtime-host.ts';
@@ -50,6 +50,24 @@ export class NodeEcopagesApp extends SharedApplicationAdapter<EcopagesAppOptions
 		}
 
 		this.stopped = true;
+	}
+
+	protected override async resolveAppRoutes(): Promise<EcopagesRouteInfo[]> {
+		const listRoutes = this.serverAdapter?.listStaticGenerationRoutes;
+		if (!listRoutes) {
+			return [];
+		}
+
+		const routes = await listRoutes({ runtimeOrigin: this.appConfig.baseUrl });
+		return routes.map((route) => ({
+			pathname: route.pathname,
+			params: Object.fromEntries(
+				Object.entries(route.params).map(([key, value]) => [
+					key,
+					Array.isArray(value) ? value.join('/') : value,
+				]),
+			),
+		}));
 	}
 
 	protected async initializeServerAdapter(): Promise<NodeServerAdapterResult> {

--- a/packages/core/src/adapters/node/server-adapter.ts
+++ b/packages/core/src/adapters/node/server-adapter.ts
@@ -284,6 +284,7 @@ export class NodeServerAdapter extends SharedServerAdapter<NodeServerAdapterPara
 			completeInitialization: this.completeInitialization.bind(this),
 			handleRequest: this.handleRequest.bind(this),
 			attachUserWebSocketUpgrades: this.attachUserWebSocketUpgrades.bind(this),
+			listStaticGenerationRoutes: (input) => this.router.listStaticGenerationRoutes(input),
 			dispose: this.dispose.bind(this),
 		};
 	}

--- a/packages/core/src/route-renderer/orchestration/route-pipeline/robots-meta.contribution.test.ts
+++ b/packages/core/src/route-renderer/orchestration/route-pipeline/robots-meta.contribution.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+import { buildRobotsMetaContribution, formatRobotsMetaContent } from './robots-meta.contribution.ts';
+
+describe('formatRobotsMetaContent', () => {
+	test('returns undefined for omitted or default robots', () => {
+		expect(formatRobotsMetaContent(undefined)).toBeUndefined();
+		expect(formatRobotsMetaContent({})).toBeUndefined();
+		expect(formatRobotsMetaContent({ index: true, follow: true })).toBeUndefined();
+	});
+
+	test('formats noindex and nofollow overrides', () => {
+		expect(formatRobotsMetaContent({ index: false })).toBe('noindex');
+		expect(formatRobotsMetaContent({ follow: false })).toBe('nofollow');
+		expect(formatRobotsMetaContent({ index: false, follow: false })).toBe('noindex, nofollow');
+		expect(formatRobotsMetaContent({ index: false, follow: false, nocache: true })).toBe(
+			'noindex, nofollow, nocache',
+		);
+	});
+});
+
+describe('buildRobotsMetaContribution', () => {
+	test('returns undefined when no meta tag is needed', () => {
+		expect(buildRobotsMetaContribution({})).toBeUndefined();
+	});
+
+	test('returns a head-append contribution with escaped content', () => {
+		expect(buildRobotsMetaContribution({ robots: { index: false, follow: false } })).toEqual({
+			placement: 'head-append',
+			html: '<meta name="robots" content="noindex, nofollow">',
+		});
+	});
+});

--- a/packages/core/src/route-renderer/orchestration/route-pipeline/robots-meta.contribution.ts
+++ b/packages/core/src/route-renderer/orchestration/route-pipeline/robots-meta.contribution.ts
@@ -1,0 +1,54 @@
+import type { HtmlDocumentContribution } from '../../../services/html/html-transformer.service.ts';
+import type { PageMetadataProps, PageRobotsMetadata } from '../../../types/public-types.ts';
+import { escapeHtmlAttribute } from '../../../utils/html-escaping.ts';
+
+/**
+ * Builds a head contribution for non-default `metadata.robots` values.
+ *
+ * @remarks
+ * When `robots` is omitted or matches the default `index,follow` behaviour,
+ * no tag is emitted (Next.js parity). Otherwise a single
+ * `<meta name="robots" content="...">` contribution is returned.
+ */
+export function buildRobotsMetaContribution(
+	metadata: Pick<PageMetadataProps, 'robots'>,
+): HtmlDocumentContribution | undefined {
+	const content = formatRobotsMetaContent(metadata.robots);
+	if (!content) {
+		return undefined;
+	}
+
+	return {
+		placement: 'head-append',
+		html: `<meta name="robots" content="${escapeHtmlAttribute(content)}">`,
+	};
+}
+
+/**
+ * Formats robots directives for a meta tag, or `undefined` when defaults apply.
+ */
+export function formatRobotsMetaContent(robots: PageRobotsMetadata | undefined): string | undefined {
+	if (!robots) {
+		return undefined;
+	}
+
+	const index = robots.index !== false;
+	const follow = robots.follow !== false;
+	const directives: string[] = [];
+
+	if (!index) {
+		directives.push('noindex');
+	}
+	if (!follow) {
+		directives.push('nofollow');
+	}
+	if (robots.nocache) {
+		directives.push('nocache');
+	}
+
+	if (directives.length === 0) {
+		return undefined;
+	}
+
+	return directives.join(', ');
+}

--- a/packages/core/src/route-renderer/orchestration/route-pipeline/route-html-finalization.service.test.ts
+++ b/packages/core/src/route-renderer/orchestration/route-pipeline/route-html-finalization.service.test.ts
@@ -39,4 +39,20 @@ describe('route-html-finalization.service', () => {
 			'data-eco-document-owner': 'react-router',
 		});
 	});
+
+	it('prepends robots meta when metadata.robots differs from defaults', () => {
+		const plan = buildRouteHtmlFinalization({
+			renderOptions: {
+				metadata: { title: 'Admin', description: '', robots: { index: false, follow: false } },
+			} as IntegrationRendererRenderOptions,
+			getDocumentAttributes: () => undefined,
+			getHtmlDocumentContributions: () => [{ placement: 'head-append', html: '<meta name="test" />' }],
+			applyAttributesToHtmlElement: (html) => html,
+		});
+
+		expect(plan.htmlContributions).toEqual([
+			{ placement: 'head-append', html: '<meta name="robots" content="noindex, nofollow">' },
+			{ placement: 'head-append', html: '<meta name="test" />' },
+		]);
+	});
 });

--- a/packages/core/src/route-renderer/orchestration/route-pipeline/route-html-finalization.service.ts
+++ b/packages/core/src/route-renderer/orchestration/route-pipeline/route-html-finalization.service.ts
@@ -1,6 +1,7 @@
 import type { HtmlDocumentContribution } from '../../../services/html/html-transformer.service.ts';
 import type { IntegrationRendererRenderOptions } from '../../../types/public-types.ts';
 import type { RouteHtmlFinalization } from './route-render-orchestrator.ts';
+import { buildRobotsMetaContribution } from './robots-meta.contribution.ts';
 
 export type RouteHtmlFinalizationContext<C> = {
 	renderOptions: IntegrationRendererRenderOptions<C>;
@@ -14,14 +15,22 @@ export type RouteHtmlFinalizationContext<C> = {
 
 /**
  * Builds the structural HTML finalization plan for one prepared route render.
+ *
+ * @remarks
+ * Merges core robots meta contributions with integration-owned document
+ * contributions so page-level `metadata.robots` works across templates.
  */
 export function buildRouteHtmlFinalization<C>(context: RouteHtmlFinalizationContext<C>): RouteHtmlFinalization {
 	const { renderOptions } = context;
 	const documentAttributes = context.getDocumentAttributes(renderOptions);
-	const htmlContributions = context.getHtmlDocumentContributions({ renderOptions, partial: false });
+	const integrationContributions = context.getHtmlDocumentContributions({ renderOptions, partial: false }) ?? [];
+	const robotsContribution = buildRobotsMetaContribution(renderOptions.metadata ?? {});
+	const htmlContributions = robotsContribution
+		? [robotsContribution, ...integrationContributions]
+		: integrationContributions;
 	const hasStructuralFinalization = documentAttributes && Object.keys(documentAttributes).length > 0;
 
-	if (!hasStructuralFinalization && (!htmlContributions || htmlContributions.length === 0)) {
+	if (!hasStructuralFinalization && htmlContributions.length === 0) {
 		return {};
 	}
 

--- a/packages/core/src/utils/ecopages-route-info.ts
+++ b/packages/core/src/utils/ecopages-route-info.ts
@@ -24,3 +24,22 @@ export function normalizeRouteParams(params: Record<string, string | string[]>):
 	}
 	return normalized;
 }
+
+type StaticGenerationRouteLister = (input: {
+	runtimeOrigin: string;
+}) => Promise<readonly { pathname: string; params: Record<string, string | string[]> }[]>;
+
+/**
+ * Resolves {@link EcopagesRouteInfo} entries for app-start and similar consumers.
+ */
+export async function resolveAppStartRoutes(input: {
+	listStaticGenerationRoutes?: StaticGenerationRouteLister;
+	runtimeOrigin: string;
+}): Promise<EcopagesRouteInfo[]> {
+	if (!input.listStaticGenerationRoutes) {
+		return [];
+	}
+
+	const routes = await input.listStaticGenerationRoutes({ runtimeOrigin: input.runtimeOrigin });
+	return routes.map(toEcopagesRouteInfo);
+}


### PR DESCRIPTION
## Summary
Adds template-agnostic `<meta name=\"robots\">` injection from `metadata.robots`, and exposes static-generation routes on `AppStartInfo` when the runtime becomes ready.

## What changed
- `buildRobotsMetaContribution` merged into route HTML finalization (omit on default index/follow)
- `AppStartInfo.routes` required; `resolveAppRoutes()` on node/bun adapters via `listStaticGenerationRoutes`
- Route resolution failures never block startup

## How to verify
1. Page with `getMetadata: () => ({ ..., robots: { index: false } })` renders `<meta name=\"robots\" content=\"noindex\">`
2. `app.start(({ routes }) => ...)` receives pathnames in dev/preview
3. `pnpm exec vitest run --project shared-core packages/core/src/route-renderer/orchestration/route-pipeline/ packages/core/src/adapters/abstract/application-adapter.test.ts`

## Notes
Stacks on #220 (`feat/automatic-sitemap`). Follow-up: docs PR.