### PR TITLE
docs: document setSitemap, robots metadata, and AppStartInfo.routes

### DIFF
--- a/apps/docs/eco.config.ts
+++ b/apps/docs/eco.config.ts
@@ -23,6 +23,9 @@ const config = await new ConfigBuilder()
 		image: 'public/assets/images/default-og.png',
 		keywords: ['typescript', 'framework', 'static'],
 	})
+	.setSitemap({
+		enabled: true,
+	})
 	.setAdditionalWatchPaths(['src/content', 'src/homepage', 'src/lib/plugins', 'src/data'])
 	.setProcessors([
 		contentProcessorPlugin({

--- a/apps/docs/src/content/docs/getting-started/configuration.mdx
+++ b/apps/docs/src/content/docs/getting-started/configuration.mdx
@@ -103,6 +103,55 @@ No template filename setter is required in `eco.config.ts`.
 	Configuration for the robots.txt file.
 </ApiField>
 
+<ApiField
+	name="sitemap"
+	type="SitemapConfig"
+	defaultValue={`{ enabled: false, fileName: "sitemap.xml", extraUrls: [], exclude: [] }`}
+	setter="setSitemap"
+>
+	Automatic `sitemap.xml` generation during static export. Disabled by default. When enabled, the file is written
+	**after** `afterStaticExport` so integration-generated URLs can be listed via `extraUrls`.
+</ApiField>
+
+## Sitemap and robots
+
+### Config-level sitemap
+
+```typescript
+await new ConfigBuilder()
+	// ...
+	.setSitemap({
+		enabled: true,
+		extraUrls: ['/rss.xml'],
+		exclude: ['/admin/**'],
+	})
+	.build();
+```
+
+| Option | Role |
+|---|---|
+| `enabled` | Emit `sitemap.xml` on `ecopages build` / preview |
+| `extraUrls` | Non-page URLs to include (e.g. feeds) |
+| `exclude` | Pathname patterns to omit (`/admin`, `/admin/**`) |
+
+### Page-level `robots`
+
+Use `getMetadata` (or `Page.metadata`) to set robots directives. When `index: false`, the page is omitted from the sitemap and a `<meta name="robots">` tag is injected:
+
+```typescript
+export const getMetadata = () => ({
+	title: 'Admin',
+	description: 'Internal tools',
+	robots: { index: false, follow: false },
+});
+```
+
+| Mechanism | Affects sitemap | Affects indexing signal |
+|---|---|---|
+| `metadata.robots.index: false` | Yes | Yes (`<meta name="robots">`) |
+| `sitemap.exclude` | Yes | No |
+| `extraUrls` | Includes URL | N/A |
+
 <ApiField name="integrations" type="IntegrationPlugin[]" defaultValue="[]" setter="setIntegrations">
 	An array of integration plugins to enhance Ecopages functionality.
 </ApiField>

--- a/apps/docs/src/content/docs/getting-started/configuration.mdx
+++ b/apps/docs/src/content/docs/getting-started/configuration.mdx
@@ -110,7 +110,8 @@ No template filename setter is required in `eco.config.ts`.
 	setter="setSitemap"
 >
 	Automatic `sitemap.xml` generation during static export. Disabled by default. When enabled, the file is written
-	**after** `afterStaticExport` so integration-generated URLs can be listed via `extraUrls`.
+	**after** `afterStaticExport` so integration-generated URLs can be listed via `extraUrls`. Page eligibility is
+	decided during successful export (see below).
 </ApiField>
 
 ## Sitemap and robots
@@ -131,12 +132,21 @@ await new ConfigBuilder()
 | Option | Role |
 |---|---|
 | `enabled` | Emit `sitemap.xml` on `ecopages build` / preview |
-| `extraUrls` | Non-page URLs to include (e.g. feeds) |
-| `exclude` | Pathname patterns to omit (`/admin`, `/admin/**`) |
+| `extraUrls` | Non-page URLs always appended after page URLs (not filtered by `exclude` or page robots) |
+| `exclude` | Exact paths (`/admin`) or prefix wildcards (`/admin/**`); not a full glob engine |
+
+### How sitemap URLs are chosen
+
+1. Successfully exported pathnames only (failed or skipped pages are omitted)
+2. Drop when `metadata.robots.index === false`, or when metadata resolution fails (fail-closed)
+3. Drop pathnames matching `sitemap.exclude`
+4. Append `extraUrls` (deduped; always included)
+
+`StaticExportContext.routes` and `AppStartInfo.routes` stay **unfiltered** — sitemap filtering is separate.
 
 ### Page-level `robots`
 
-Use `getMetadata` (or `Page.metadata`) to set robots directives. When `index: false`, the page is omitted from the sitemap and a `<meta name="robots">` tag is injected:
+Use `getMetadata` (or `Page.metadata` / `app.static()` view `metadata`) to set robots directives. When `index: false` and metadata is available during export, the page is omitted from the sitemap. A `<meta name="robots">` tag is injected when directives differ from the defaults (`index: true`, `follow: true`):
 
 ```typescript
 export const getMetadata = () => ({
@@ -148,9 +158,10 @@ export const getMetadata = () => ({
 
 | Mechanism | Affects sitemap | Affects indexing signal |
 |---|---|---|
-| `metadata.robots.index: false` | Yes | Yes (`<meta name="robots">`) |
+| `metadata.robots.index: false` | Yes, when metadata resolves during export | Yes (`<meta name="robots">`) |
+| Metadata resolution failure | Yes (URL omitted) | Unchanged |
 | `sitemap.exclude` | Yes | No |
-| `extraUrls` | Includes URL | N/A |
+| `extraUrls` | Always includes URL | N/A |
 
 <ApiField name="integrations" type="IntegrationPlugin[]" defaultValue="[]" setter="setIntegrations">
 	An array of integration plugins to enhance Ecopages functionality.

--- a/apps/docs/src/content/docs/server/server-api.mdx
+++ b/apps/docs/src/content/docs/server/server-api.mdx
@@ -29,15 +29,15 @@ await app.start();
 
 Call `app.start()` after you register routes. It boots the server for the current CLI mode (`dev`, `preview`, `build`, or `start`).
 
-Pass an optional callback to run logic once the server can accept traffic. The callback receives `{ origin }` — the resolved base URL with no trailing slash.
+Pass an optional callback to run logic once the server can accept traffic. The callback receives `{ origin, routes }` — the resolved base URL (no trailing slash) and the static-generation route list.
 
 ```typescript
-await app.start(({ origin }) => {
-	// readiness hook
+await app.start(({ origin, routes }) => {
+	console.log(`Ready at ${origin} with ${routes.length} routes`);
 });
 ```
 
-The `OnAppStartCallback` type is exported from `@ecopages/core/create-app`.
+The `OnAppStartCallback` type is exported from `@ecopages/core/create-app`. Route resolution failures never block startup — `routes` falls back to `[]`.
 
 > **Note:** In embedded mode (for example the [Vite plugin](/docs/ecosystem/vite-plugin)), `app.start()` registers the callback but does not bind a port — the host owns the listen socket and runs your callback when the app is ready. Pass `runtime: { embedded: true, devClientOwner: 'host' }` to `createApp()`. See [Build and Host](/docs/core/build-and-host#boot-vs-embed).
 

--- a/apps/docs/src/content/docs/server/server-api.mdx
+++ b/apps/docs/src/content/docs/server/server-api.mdx
@@ -29,7 +29,9 @@ await app.start();
 
 Call `app.start()` after you register routes. It boots the server for the current CLI mode (`dev`, `preview`, `build`, or `start`).
 
-Pass an optional callback to run logic once the server can accept traffic. The callback receives `{ origin, routes }` — the resolved base URL (no trailing slash) and the static-generation route list.
+Pass an optional callback to run logic once the server can accept traffic. The callback receives `{ origin, routes }` —
+the resolved base URL (no trailing slash) and the unfiltered static-generation route list. Route resolution finishes
+before the callback runs.
 
 ```typescript
 await app.start(({ origin, routes }) => {
@@ -37,7 +39,8 @@ await app.start(({ origin, routes }) => {
 });
 ```
 
-The `OnAppStartCallback` type is exported from `@ecopages/core/create-app`. Route resolution failures never block startup — `routes` falls back to `[]`.
+The `OnAppStartCallback` type is exported from `@ecopages/core/create-app`. Route resolution failures never block
+startup — `routes` falls back to `[]`. This list is not sitemap-filtered; use `setSitemap` / page `robots` for that.
 
 > **Note:** In embedded mode (for example the [Vite plugin](/docs/ecosystem/vite-plugin)), `app.start()` registers the callback but does not bind a port — the host owns the listen socket and runs your callback when the app is ready. Pass `runtime: { embedded: true, devClientOwner: 'host' }` to `createApp()`. See [Build and Host](/docs/core/build-and-host#boot-vs-embed).
 


### PR DESCRIPTION
## Summary
Documents automatic sitemap config, page-level robots metadata, and `AppStartInfo.routes`. Enables sitemap generation for the docs app.

## What changed
- `configuration.mdx`: `setSitemap`, exclude vs noindex guidance
- `server-api.mdx`: `app.start(({ origin, routes }) => …)`
- `apps/docs/eco.config.ts`: `.setSitemap({ enabled: true })`

## How to verify
1. Read `/docs/getting-started/configuration` locally after build
2. Confirm docs `eco.config.ts` includes `setSitemap`
3. Stacks on #221 → #220 → `release/v0.2.0`

## Notes
Audit artifacts under `.audit/` remain local (gitignored).