### PR TITLE
feat(core): render custom src/pages/500.* on page render failures

### DIFF
--- a/apps/docs/src/content/docs/core/concepts.mdx
+++ b/apps/docs/src/content/docs/core/concepts.mdx
@@ -23,7 +23,7 @@ For example, the KitaJS integration might set up template extensions like this:
   .setIntegrations([kitajsPlugin()])
 ```
 
-Those extensions are then used to resolve semantic files such as `html.*` and `404.*`.
+Those extensions are then used to resolve semantic files such as `html.*`, `404.*`, and `500.*`.
 
 ## CSS Processing
 

--- a/apps/docs/src/content/docs/core/concepts.mdx
+++ b/apps/docs/src/content/docs/core/concepts.mdx
@@ -19,7 +19,7 @@ Ecopages uses a flexible integration system to extend its functionality. Each in
 For example, the KitaJS integration might set up template extensions like this:
 
 ```typescript
-  // html.kita.tsx and 404.kita.tsx are discovered automatically
+  // html.kita.tsx, 404.kita.tsx, and 500.kita.tsx are discovered automatically
   .setIntegrations([kitajsPlugin()])
 ```
 

--- a/apps/docs/src/content/docs/core/routing.mdx
+++ b/apps/docs/src/content/docs/core/routing.mdx
@@ -87,11 +87,18 @@ const config = await new ConfigBuilder()
 
 ### 404 Page
 
-Create `404.tsx` (or your integration extension) under `src/pages`.
+Create `404.tsx` (or your integration extension) under `src/pages`. Unmatched page requests render this template with status 404.
 
 ### 500 Page
 
-Create `500.tsx` (or your integration extension) under `src/pages`. When a page render fails, Ecopages renders this template with status 500. If the template is missing or throws, the response falls back to plain-text `Internal Server Error`.
+Create `500.tsx` (or your integration extension) under `src/pages`. When a **page** render fails in the file-route pipeline, Ecopages renders this template with status 500.
+
+Important:
+
+- Applies to page rendering (matched routes and a failing custom 404). API handlers keep their own `errorHandler` / JSON response path.
+- If the `500.*` template is missing or throws, the response falls back to plain-text `Internal Server Error`. The custom page is never retried.
+- Same contract in development and production; the original error is logged server-side.
+- Like `404.*`, the file is also a normal route at `/500`, so you can open it directly to preview the design (that direct visit is a 200 unless you trigger a render failure).
 
 ---
 
@@ -101,4 +108,5 @@ Create `500.tsx` (or your integration extension) under `src/pages`. When a page 
 | :--- | :--- | :--- |
 | **Static pages** | `src/pages/*.{ext}` | Marketing, docs, blogs |
 | **Dynamic pages** | `src/pages/[slug].{ext}` | Posts, profiles |
+| **Error pages** | `src/pages/404.*`, `src/pages/500.*` | Not-found and server-error HTML |
 | **API endpoints** | `app.get('/api/...')` | Data, forms |

--- a/apps/docs/src/content/docs/core/routing.mdx
+++ b/apps/docs/src/content/docs/core/routing.mdx
@@ -89,6 +89,10 @@ const config = await new ConfigBuilder()
 
 Create `404.tsx` (or your integration extension) under `src/pages`.
 
+### 500 Page
+
+Create `500.tsx` (or your integration extension) under `src/pages`. When a page render fails, Ecopages renders this template with status 500. If the template is missing or throws, the response falls back to plain-text `Internal Server Error`.
+
 ---
 
 ## Summary

--- a/apps/docs/src/content/docs/core/routing.mdx
+++ b/apps/docs/src/content/docs/core/routing.mdx
@@ -97,8 +97,22 @@ Important:
 
 - Applies to page rendering (matched routes and a failing custom 404). API handlers keep their own `errorHandler` / JSON response path.
 - If the `500.*` template is missing or throws, the response falls back to plain-text `Internal Server Error`. The custom page is never retried.
-- Same contract in development and production; the original error is logged server-side.
-- Like `404.*`, the file is also a normal route at `/500`, so you can open it directly to preview the design (that direct visit is a 200 unless you trigger a render failure).
+- In **development**, the thrown error is passed as page props (`message`, `stack`) so the custom 500 page can show the real failure. In **production**, those props are omitted so stacks are not serialized into HTML. The original error is always logged server-side.
+- Like `404.*`, the file is also a normal route at `/500`, so you can open it directly to preview the design (that direct visit is a 200 and has no error props unless you trigger a render failure).
+
+```tsx
+import { eco, type Error500TemplateProps } from '@ecopages/core';
+
+export default eco.page<Error500TemplateProps>({
+	render: ({ message, stack }) => (
+		<div>
+			<h1>Something went wrong</h1>
+			{message ? <p>{message}</p> : null}
+			{stack ? <pre>{stack}</pre> : null}
+		</div>
+	),
+});
+```
 
 ---
 

--- a/apps/docs/src/content/docs/getting-started/configuration.mdx
+++ b/apps/docs/src/content/docs/getting-started/configuration.mdx
@@ -75,7 +75,7 @@ Ecopages now discovers the document shell and error pages semantically:
 - `src/pages/404.*` resolves the not-found page by basename and integration extension.
 - `src/pages/500.*` resolves the server-error page by basename and integration extension.
 
-No template filename setter is required in `eco.config.ts`.
+No template filename setter is required in `eco.config.ts`. If `500.*` is missing or fails while rendering, the page pipeline falls back to plain-text `Internal Server Error`.
 
 
 <ApiField name="distDir" type="string" defaultValue="dist" setter="setDistDir">

--- a/apps/docs/src/content/docs/getting-started/configuration.mdx
+++ b/apps/docs/src/content/docs/getting-started/configuration.mdx
@@ -75,7 +75,7 @@ Ecopages now discovers the document shell and error pages semantically:
 - `src/pages/404.*` resolves the not-found page by basename and integration extension.
 - `src/pages/500.*` resolves the server-error page by basename and integration extension.
 
-No template filename setter is required in `eco.config.ts`. If `500.*` is missing or fails while rendering, the page pipeline falls back to plain-text `Internal Server Error`.
+No template filename setter is required in `eco.config.ts`. If `500.*` is missing or fails while rendering, the page pipeline falls back to plain-text `Internal Server Error`. In development, the custom 500 page receives `message` and `stack` props from the thrown error.
 
 
 <ApiField name="distDir" type="string" defaultValue="dist" setter="setDistDir">

--- a/apps/docs/src/content/docs/getting-started/configuration.mdx
+++ b/apps/docs/src/content/docs/getting-started/configuration.mdx
@@ -69,10 +69,11 @@ export default config;
 	The directory for layout components, relative to the src directory.
 </ApiField>
 
-Ecopages now discovers the document shell and 404 page semantically:
+Ecopages now discovers the document shell and error pages semantically:
 
 - `src/includes/html.*` resolves the HTML shell by basename and integration extension.
 - `src/pages/404.*` resolves the not-found page by basename and integration extension.
+- `src/pages/500.*` resolves the server-error page by basename and integration extension.
 
 No template filename setter is required in `eco.config.ts`.
 

--- a/apps/docs/src/public/skill/reference/core.md
+++ b/apps/docs/src/public/skill/reference/core.md
@@ -28,7 +28,7 @@ project/
 └── package.json
 ```
 
-Semantic discovery: `src/includes/html.*` and `src/pages/404.*` resolve by basename and integration extension.
+Semantic discovery: `src/includes/html.*`, `src/pages/404.*`, and `src/pages/500.*` resolve by basename and integration extension.
 
 ## The eco namespace
 

--- a/packages/core/__fixtures__/app/src/pages/500.ghtml.ts
+++ b/packages/core/__fixtures__/app/src/pages/500.ghtml.ts
@@ -1,0 +1,19 @@
+import type { EcoComponent, Error500TemplateProps } from '@ecopages/core';
+import { html } from '@ecopages/core/html';
+import { BaseLayout } from '../layouts/base-layout';
+
+const Error500: EcoComponent<Error500TemplateProps> = () =>
+	html`!${BaseLayout({
+		children: html`<div class="error500">
+			<h1>500 - Internal Server Error</h1>
+			<p>Something went wrong while rendering this page.</p>
+		</div>`,
+	})}`;
+
+Error500.config = {
+	dependencies: {
+		components: [BaseLayout],
+	},
+};
+
+export default Error500;

--- a/packages/core/__fixtures__/app/src/pages/500.ghtml.ts
+++ b/packages/core/__fixtures__/app/src/pages/500.ghtml.ts
@@ -2,11 +2,12 @@ import type { EcoComponent, Error500TemplateProps } from '@ecopages/core';
 import { html } from '@ecopages/core/html';
 import { BaseLayout } from '../layouts/base-layout';
 
-const Error500: EcoComponent<Error500TemplateProps> = () =>
+const Error500: EcoComponent<Error500TemplateProps> = ({ message, stack }) =>
 	html`!${BaseLayout({
 		children: html`<div class="error500">
 			<h1>500 - Internal Server Error</h1>
-			<p>Something went wrong while rendering this page.</p>
+			<p>${message ?? 'Something went wrong while rendering this page.'}</p>
+			${stack ? html`<pre class="error500__stack">${stack}</pre>` : ''}
 		</div>`,
 	})}`;
 

--- a/packages/core/src/adapters/shared/fs-server-response-factory.test.ts
+++ b/packages/core/src/adapters/shared/fs-server-response-factory.test.ts
@@ -102,6 +102,28 @@ describe('FileSystemServerResponseFactory', () => {
 		});
 	});
 
+	describe('createDefaultServerErrorResponse', () => {
+		it('should create a response with status 500 and the default server error body', async () => {
+			const response = await responseFactory.createDefaultServerErrorResponse();
+			expect(response.status).toBe(500);
+			expect(response.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
+			expect(await response.text()).toBe(STATUS_MESSAGE[500]);
+		});
+	});
+
+	describe('createHtmlServerErrorResponse', () => {
+		it('should create an html 500 response from a rendered body', async () => {
+			const response = await responseFactory.createHtmlServerErrorResponse(
+				'<h1>500 - Internal Server Error</h1>',
+			);
+			const body = await response.text();
+			expect(body).toContain('<h1>500 - Internal Server Error</h1>');
+			expect(response.headers.get('Content-Type')).toBe('text/html');
+			expect(response.status).toBe(500);
+			expect(response.statusText).toBe(STATUS_MESSAGE[500]);
+		});
+	});
+
 	describe('createFileResponse', () => {
 		it('should create a response with the file content and content type', async () => {
 			const readFileAsBufferSpy = vi

--- a/packages/core/src/adapters/shared/fs-server-response-factory.ts
+++ b/packages/core/src/adapters/shared/fs-server-response-factory.ts
@@ -54,6 +54,28 @@ export class FileSystemServerResponseFactory {
 		});
 	}
 
+	async createDefaultServerErrorResponse() {
+		return new Response(STATUS_MESSAGE[500], {
+			status: 500,
+			headers: {
+				'Content-Type': 'text/plain; charset=utf-8',
+			},
+		});
+	}
+
+	/**
+	 * Wraps already-rendered HTML in a 500 response envelope.
+	 */
+	async createHtmlServerErrorResponse(body: RouteRendererBody) {
+		return await this.createResponseWithBody(body, {
+			status: 500,
+			statusText: STATUS_MESSAGE[500],
+			headers: {
+				'Content-Type': 'text/html',
+			},
+		});
+	}
+
 	/**
 	 * Reads a static file response, returning `null` when the file is missing.
 	 */

--- a/packages/core/src/adapters/shared/fs-server-response-matcher.test.ts
+++ b/packages/core/src/adapters/shared/fs-server-response-matcher.test.ts
@@ -70,27 +70,32 @@ function createRouteRendererFactoryWithStub500(
 	realFactory: PageRendererResolver,
 	error500TemplatePath: string,
 	options?: { executeError?: Error },
-): PageRendererResolver {
+): { factory: PageRendererResolver; execute: ReturnType<typeof vi.fn> } {
+	const execute = options?.executeError
+		? vi.fn(async () => {
+				throw options.executeError;
+			})
+		: vi.fn(async () => ({
+				body: '<h1>500 - Internal Server Error</h1>',
+			}));
+
 	const stub500Renderer = {
-		execute: options?.executeError
-			? vi.fn(async () => {
-					throw options.executeError;
-				})
-			: vi.fn(async () => ({
-					body: '<h1>500 - Internal Server Error</h1>',
-				})),
+		execute,
 		loadPageModule: vi.fn(async () => ({
 			default: () => null,
 		})),
 	};
 
 	return {
-		getPageRenderer(filePath: string) {
-			if (filePath === error500TemplatePath) {
-				return stub500Renderer;
-			}
+		execute,
+		factory: {
+			getPageRenderer(filePath: string) {
+				if (filePath === error500TemplatePath) {
+					return stub500Renderer;
+				}
 
-			return realFactory.getPageRenderer(filePath);
+				return realFactory.getPageRenderer(filePath);
+			},
 		},
 	};
 }
@@ -405,7 +410,7 @@ describe('FileSystemResponseMatcher', () => {
 				INDEX_TEMPLATE_FILE,
 				renderError,
 			);
-			const factoryWithStub500 = createRouteRendererFactoryWithStub500(
+			const { factory: factoryWithStub500 } = createRouteRendererFactoryWithStub500(
 				throwingFactory,
 				appConfig.absolutePaths.error500TemplatePath,
 			);
@@ -432,6 +437,97 @@ describe('FileSystemResponseMatcher', () => {
 			expect(response.status).toBe(500);
 			expect(response.headers.get('Content-Type')).toBe('text/html');
 			expect(await response.text()).toContain('<h1>500 - Internal Server Error</h1>');
+		});
+
+		it('should pass message and stack to the custom 500 page in development', async () => {
+			const previousNodeEnv = process.env.NODE_ENV;
+			process.env.NODE_ENV = 'development';
+
+			try {
+				const renderError = new Error('page render failed');
+				const throwingFactory = createRouteRendererFactoryWithThrowingPage(
+					routeRendererFactory,
+					INDEX_TEMPLATE_FILE,
+					renderError,
+				);
+				const { factory: factoryWithStub500, execute } = createRouteRendererFactoryWithStub500(
+					throwingFactory,
+					appConfig.absolutePaths.error500TemplatePath,
+				);
+				const matcher = new FileSystemResponseMatcher({
+					appConfig,
+					assetPrefix: path.join(appConfig.rootDir, appConfig.distDir),
+					router,
+					routeRendererFactory: factoryWithStub500,
+					fileSystemResponseFactory,
+				});
+				const match: MatchResult = {
+					requestedPathname: APP_TEST_ROUTES.index,
+					templateRoute: {
+						kind: 'exact',
+						pathname: APP_TEST_ROUTES.index,
+						filePath: INDEX_TEMPLATE_FILE,
+					},
+					params: {},
+					query: {},
+				};
+
+				await matcher.handleMatch(match);
+
+				expect(execute).toHaveBeenCalledWith({
+					file: appConfig.absolutePaths.error500TemplatePath,
+					props: {
+						message: 'page render failed',
+						stack: renderError.stack,
+					},
+				});
+			} finally {
+				process.env.NODE_ENV = previousNodeEnv;
+			}
+		});
+
+		it('should omit error details from the custom 500 page in production', async () => {
+			const previousNodeEnv = process.env.NODE_ENV;
+			process.env.NODE_ENV = 'production';
+
+			try {
+				const renderError = new Error('page render failed');
+				const throwingFactory = createRouteRendererFactoryWithThrowingPage(
+					routeRendererFactory,
+					INDEX_TEMPLATE_FILE,
+					renderError,
+				);
+				const { factory: factoryWithStub500, execute } = createRouteRendererFactoryWithStub500(
+					throwingFactory,
+					appConfig.absolutePaths.error500TemplatePath,
+				);
+				const matcher = new FileSystemResponseMatcher({
+					appConfig,
+					assetPrefix: path.join(appConfig.rootDir, appConfig.distDir),
+					router,
+					routeRendererFactory: factoryWithStub500,
+					fileSystemResponseFactory,
+				});
+				const match: MatchResult = {
+					requestedPathname: APP_TEST_ROUTES.index,
+					templateRoute: {
+						kind: 'exact',
+						pathname: APP_TEST_ROUTES.index,
+						filePath: INDEX_TEMPLATE_FILE,
+					},
+					params: {},
+					query: {},
+				};
+
+				await matcher.handleMatch(match);
+
+				expect(execute).toHaveBeenCalledWith({
+					file: appConfig.absolutePaths.error500TemplatePath,
+					props: undefined,
+				});
+			} finally {
+				process.env.NODE_ENV = previousNodeEnv;
+			}
 		});
 
 		it('should return plain 500 when a matched route throws and the custom 500 template is missing', async () => {
@@ -478,7 +574,7 @@ describe('FileSystemResponseMatcher', () => {
 				INDEX_TEMPLATE_FILE,
 				renderError,
 			);
-			const factoryWithThrowing500 = createRouteRendererFactoryWithStub500(
+			const { factory: factoryWithThrowing500 } = createRouteRendererFactoryWithStub500(
 				throwingFactory,
 				appConfig.absolutePaths.error500TemplatePath,
 				{ executeError: templateError },
@@ -515,7 +611,7 @@ describe('FileSystemResponseMatcher', () => {
 				appConfig.absolutePaths.error404TemplatePath,
 				{ executeError: templateError },
 			);
-			const factoryWithStub500 = createRouteRendererFactoryWithStub500(
+			const { factory: factoryWithStub500 } = createRouteRendererFactoryWithStub500(
 				throwing404Factory,
 				appConfig.absolutePaths.error500TemplatePath,
 			);

--- a/packages/core/src/adapters/shared/fs-server-response-matcher.test.ts
+++ b/packages/core/src/adapters/shared/fs-server-response-matcher.test.ts
@@ -66,6 +66,35 @@ function createRouteRendererFactoryWithStub404(
 	};
 }
 
+function createRouteRendererFactoryWithStub500(
+	realFactory: PageRendererResolver,
+	error500TemplatePath: string,
+	options?: { executeError?: Error },
+): PageRendererResolver {
+	const stub500Renderer = {
+		execute: options?.executeError
+			? vi.fn(async () => {
+					throw options.executeError;
+				})
+			: vi.fn(async () => ({
+					body: '<h1>500 - Internal Server Error</h1>',
+				})),
+		loadPageModule: vi.fn(async () => ({
+			default: () => null,
+		})),
+	};
+
+	return {
+		getPageRenderer(filePath: string) {
+			if (filePath === error500TemplatePath) {
+				return stub500Renderer;
+			}
+
+			return realFactory.getPageRenderer(filePath);
+		},
+	};
+}
+
 function createRouteRendererFactoryWithThrowingPage(
 	realFactory: PageRendererResolver,
 	pageFilePath: string,
@@ -97,6 +126,21 @@ function createRouteRendererFactoryWithMissing404Template(error404TemplatePath: 
 			}
 
 			throw new Error(`Unexpected page renderer request: ${filePath}`);
+		},
+	};
+}
+
+function createRouteRendererFactoryWithMissing500Template(
+	realFactory: PageRendererResolver,
+	error500TemplatePath: string,
+): PageRendererResolver {
+	return {
+		getPageRenderer(filePath: string) {
+			if (filePath === error500TemplatePath) {
+				throw new Error('500 template not found');
+			}
+
+			return realFactory.getPageRenderer(filePath);
 		},
 	};
 }
@@ -354,18 +398,22 @@ describe('FileSystemResponseMatcher', () => {
 	});
 
 	describe('error taxonomy', () => {
-		it('should return 500 when a matched route render throws', async () => {
+		it('should return custom HTML 500 when a matched route render throws', async () => {
 			const renderError = new Error('page render failed');
 			const throwingFactory = createRouteRendererFactoryWithThrowingPage(
 				routeRendererFactory,
 				INDEX_TEMPLATE_FILE,
 				renderError,
 			);
+			const factoryWithStub500 = createRouteRendererFactoryWithStub500(
+				throwingFactory,
+				appConfig.absolutePaths.error500TemplatePath,
+			);
 			const matcher = new FileSystemResponseMatcher({
 				appConfig,
 				assetPrefix: path.join(appConfig.rootDir, appConfig.distDir),
 				router,
-				routeRendererFactory: throwingFactory,
+				routeRendererFactory: factoryWithStub500,
 				fileSystemResponseFactory,
 			});
 			const match: MatchResult = {
@@ -382,28 +430,108 @@ describe('FileSystemResponseMatcher', () => {
 			const response = await matcher.handleMatch(match);
 
 			expect(response.status).toBe(500);
+			expect(response.headers.get('Content-Type')).toBe('text/html');
+			expect(await response.text()).toContain('<h1>500 - Internal Server Error</h1>');
+		});
+
+		it('should return plain 500 when a matched route throws and the custom 500 template is missing', async () => {
+			const renderError = new Error('page render failed');
+			const throwingFactory = createRouteRendererFactoryWithThrowingPage(
+				routeRendererFactory,
+				INDEX_TEMPLATE_FILE,
+				renderError,
+			);
+			const factoryWithout500 = createRouteRendererFactoryWithMissing500Template(
+				throwingFactory,
+				appConfig.absolutePaths.error500TemplatePath,
+			);
+			const matcher = new FileSystemResponseMatcher({
+				appConfig,
+				assetPrefix: path.join(appConfig.rootDir, appConfig.distDir),
+				router,
+				routeRendererFactory: factoryWithout500,
+				fileSystemResponseFactory,
+			});
+			const match: MatchResult = {
+				requestedPathname: APP_TEST_ROUTES.index,
+				templateRoute: {
+					kind: 'exact',
+					pathname: APP_TEST_ROUTES.index,
+					filePath: INDEX_TEMPLATE_FILE,
+				},
+				params: {},
+				query: {},
+			};
+
+			const response = await matcher.handleMatch(match);
+
+			expect(response.status).toBe(500);
+			expect(response.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
 			expect(await response.text()).toBe('Internal Server Error');
 		});
 
-		it('should return 500 when the custom 404 template render throws', async () => {
-			const templateError = new Error('404 template render failed');
-			const throwing404Factory = createRouteRendererFactoryWithStub404(
+		it('should fall back to plain 500 when the custom 500 template render throws', async () => {
+			const renderError = new Error('page render failed');
+			const templateError = new Error('500 template render failed');
+			const throwingFactory = createRouteRendererFactoryWithThrowingPage(
 				routeRendererFactory,
-				appConfig.absolutePaths.error404TemplatePath,
+				INDEX_TEMPLATE_FILE,
+				renderError,
+			);
+			const factoryWithThrowing500 = createRouteRendererFactoryWithStub500(
+				throwingFactory,
+				appConfig.absolutePaths.error500TemplatePath,
 				{ executeError: templateError },
 			);
 			const matcher = new FileSystemResponseMatcher({
 				appConfig,
 				assetPrefix: path.join(appConfig.rootDir, appConfig.distDir),
 				router,
-				routeRendererFactory: throwing404Factory,
+				routeRendererFactory: factoryWithThrowing500,
+				fileSystemResponseFactory,
+			});
+			const match: MatchResult = {
+				requestedPathname: APP_TEST_ROUTES.index,
+				templateRoute: {
+					kind: 'exact',
+					pathname: APP_TEST_ROUTES.index,
+					filePath: INDEX_TEMPLATE_FILE,
+				},
+				params: {},
+				query: {},
+			};
+
+			const response = await matcher.handleMatch(match);
+
+			expect(response.status).toBe(500);
+			expect(response.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
+			expect(await response.text()).toBe('Internal Server Error');
+		});
+
+		it('should return custom HTML 500 when the custom 404 template render throws', async () => {
+			const templateError = new Error('404 template render failed');
+			const throwing404Factory = createRouteRendererFactoryWithStub404(
+				routeRendererFactory,
+				appConfig.absolutePaths.error404TemplatePath,
+				{ executeError: templateError },
+			);
+			const factoryWithStub500 = createRouteRendererFactoryWithStub500(
+				throwing404Factory,
+				appConfig.absolutePaths.error500TemplatePath,
+			);
+			const matcher = new FileSystemResponseMatcher({
+				appConfig,
+				assetPrefix: path.join(appConfig.rootDir, appConfig.distDir),
+				router,
+				routeRendererFactory: factoryWithStub500,
 				fileSystemResponseFactory,
 			});
 
 			const response = await matcher.handleNoMatch('/missing-page');
 
 			expect(response.status).toBe(500);
-			expect(await response.text()).toBe('Internal Server Error');
+			expect(response.headers.get('Content-Type')).toBe('text/html');
+			expect(await response.text()).toContain('<h1>500 - Internal Server Error</h1>');
 		});
 
 		it('should fall back to default 404 when the custom 404 template cannot be resolved', async () => {

--- a/packages/core/src/adapters/shared/fs-server-response-matcher.ts
+++ b/packages/core/src/adapters/shared/fs-server-response-matcher.ts
@@ -7,7 +7,7 @@ import type { PageCacheService } from '../../services/cache/page-cache-service.t
 import type { CacheStrategy, RenderResult } from '../../services/cache/cache.types.ts';
 import { PageRequestCacheCoordinator } from '../../services/cache/page-request-cache-coordinator.service.ts';
 import { ServerUtils } from '../../utils/server-utils.module.ts';
-import type { FileRouteMiddleware, RequestLocals } from '../../types/public-types.ts';
+import type { FileRouteMiddleware, RequestLocals, RouteRendererBody } from '../../types/public-types.ts';
 import { FileRouteMiddlewarePipeline } from './file-route-middleware-pipeline.ts';
 import { LocalsAccessError } from '../../errors/locals-access-error.ts';
 import { isDevelopmentRuntime } from '../../utils/runtime.ts';
@@ -147,9 +147,9 @@ export class FileSystemResponseMatcher {
 				return error;
 			}
 			if (error instanceof LocalsAccessError) {
-				return this.createInternalServerErrorResponse(error.message, match.requestedPathname, error);
+				return await this.createInternalServerErrorResponse(error.message, match.requestedPathname, error);
 			}
-			return this.createInternalServerErrorResponse(
+			return await this.createInternalServerErrorResponse(
 				error instanceof Error ? error.message : 'Internal Server Error',
 				match.requestedPathname,
 				error,
@@ -162,24 +162,54 @@ export class FileSystemResponseMatcher {
 	 * when the page template cannot be resolved.
 	 */
 	private async renderCustomNotFoundResponse(): Promise<Response> {
-		const error404TemplatePath = this.appConfig.absolutePaths.error404TemplatePath;
+		return this.renderCustomErrorPageResponse({
+			templatePath: this.appConfig.absolutePaths.error404TemplatePath,
+			label: '404',
+			createDefaultResponse: () => this.fileSystemResponseFactory.createDefaultNotFoundResponse(),
+			createHtmlResponse: (body) => this.fileSystemResponseFactory.createHtmlNotFoundResponse(body),
+		});
+	}
 
+	/**
+	 * Renders the app-owned custom 500 page, falling back to the default text 500
+	 * when the page template cannot be resolved.
+	 */
+	private async renderCustomServerErrorResponse(): Promise<Response> {
+		return this.renderCustomErrorPageResponse({
+			templatePath: this.appConfig.absolutePaths.error500TemplatePath,
+			label: '500',
+			createDefaultResponse: () => this.fileSystemResponseFactory.createDefaultServerErrorResponse(),
+			createHtmlResponse: (body) => this.fileSystemResponseFactory.createHtmlServerErrorResponse(body),
+		});
+	}
+
+	private async renderCustomErrorPageResponse({
+		templatePath,
+		label,
+		createDefaultResponse,
+		createHtmlResponse,
+	}: {
+		templatePath: string;
+		label: '404' | '500';
+		createDefaultResponse: () => Promise<Response>;
+		createHtmlResponse: (body: RouteRendererBody) => Promise<Response>;
+	}): Promise<Response> {
 		let routeRenderer;
 		try {
-			routeRenderer = this.routeRendererFactory.getPageRenderer(error404TemplatePath);
+			routeRenderer = this.routeRendererFactory.getPageRenderer(templatePath);
 		} catch {
 			appLogger.debug(
-				'Custom 404 template not found, falling back to default 404 response',
-				error404TemplatePath,
+				`Custom ${label} template not found, falling back to default ${label} response`,
+				templatePath,
 			);
-			return this.fileSystemResponseFactory.createDefaultNotFoundResponse();
+			return createDefaultResponse();
 		}
 
 		const result = await routeRenderer.execute({
-			file: error404TemplatePath,
+			file: templatePath,
 		});
 
-		return this.fileSystemResponseFactory.createHtmlNotFoundResponse(result.body);
+		return createHtmlResponse(result.body);
 	}
 
 	private async renderCustomNotFoundResponseOrServerError(pathname: string): Promise<Response> {
@@ -189,7 +219,7 @@ export class FileSystemResponseMatcher {
 			if (error instanceof Response) {
 				return error;
 			}
-			return this.createInternalServerErrorResponse(
+			return await this.createInternalServerErrorResponse(
 				error instanceof Error ? error.message : 'Internal Server Error',
 				pathname,
 				error,
@@ -197,17 +227,34 @@ export class FileSystemResponseMatcher {
 		}
 	}
 
-	private createInternalServerErrorResponse(message: string, pathname: string, error: unknown): Response {
+	/**
+	 * Logs the original render failure, then tries the custom 500 page once.
+	 * @remarks Any failure while rendering the custom 500 page falls back to the
+	 * default plain-text response and never re-enters the custom page path.
+	 */
+	private async createInternalServerErrorResponse(
+		message: string,
+		pathname: string,
+		error: unknown,
+	): Promise<Response> {
 		if (isDevelopmentRuntime() || appLogger.isDebugEnabled()) {
 			appLogger.error(`[FileSystemResponseMatcher] ${message} at ${pathname}`, error);
 		} else {
 			appLogger.error(`[FileSystemResponseMatcher] Render error at ${pathname}`, error);
 		}
 
-		return new Response('Internal Server Error', {
-			status: 500,
-			headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-		});
+		try {
+			return await this.renderCustomServerErrorResponse();
+		} catch (serverErrorPageError) {
+			if (serverErrorPageError instanceof Response) {
+				return serverErrorPageError;
+			}
+			appLogger.error(
+				`[FileSystemResponseMatcher] Custom 500 template failed at ${pathname}`,
+				serverErrorPageError,
+			);
+			return this.fileSystemResponseFactory.createDefaultServerErrorResponse();
+		}
 	}
 
 	private async createExecutionPlan(match: MatchResult, request?: Request): Promise<FileRouteExecutionPlan> {

--- a/packages/core/src/adapters/shared/fs-server-response-matcher.ts
+++ b/packages/core/src/adapters/shared/fs-server-response-matcher.ts
@@ -174,23 +174,47 @@ export class FileSystemResponseMatcher {
 	 * Renders the app-owned custom 500 page, falling back to the default text 500
 	 * when the page template cannot be resolved.
 	 */
-	private async renderCustomServerErrorResponse(): Promise<Response> {
+	private async renderCustomServerErrorResponse(error: unknown): Promise<Response> {
 		return this.renderCustomErrorPageResponse({
 			templatePath: this.appConfig.absolutePaths.error500TemplatePath,
 			label: '500',
+			props: this.buildServerErrorPageProps(error),
 			createDefaultResponse: () => this.fileSystemResponseFactory.createDefaultServerErrorResponse(),
 			createHtmlResponse: (body) => this.fileSystemResponseFactory.createHtmlServerErrorResponse(body),
 		});
 	}
 
+	/**
+	 * Builds development-only error details for the custom 500 page.
+	 * @remarks Production omits these fields so stacks are not serialized into HTML.
+	 */
+	private buildServerErrorPageProps(error: unknown): Record<string, unknown> | undefined {
+		if (!isDevelopmentRuntime()) {
+			return undefined;
+		}
+
+		if (error instanceof Error) {
+			return {
+				message: error.message,
+				stack: error.stack,
+			};
+		}
+
+		return {
+			message: String(error),
+		};
+	}
+
 	private async renderCustomErrorPageResponse({
 		templatePath,
 		label,
+		props,
 		createDefaultResponse,
 		createHtmlResponse,
 	}: {
 		templatePath: string;
 		label: '404' | '500';
+		props?: Record<string, unknown>;
 		createDefaultResponse: () => Promise<Response>;
 		createHtmlResponse: (body: RouteRendererBody) => Promise<Response>;
 	}): Promise<Response> {
@@ -207,6 +231,7 @@ export class FileSystemResponseMatcher {
 
 		const result = await routeRenderer.execute({
 			file: templatePath,
+			props,
 		});
 
 		return createHtmlResponse(result.body);
@@ -231,6 +256,8 @@ export class FileSystemResponseMatcher {
 	 * Logs the original render failure, then tries the custom 500 page once.
 	 * @remarks Any failure while rendering the custom 500 page falls back to the
 	 * default plain-text response and never re-enters the custom page path.
+	 * In development the thrown error's `message` and `stack` are passed into the
+	 * custom 500 page props.
 	 */
 	private async createInternalServerErrorResponse(
 		message: string,
@@ -244,7 +271,7 @@ export class FileSystemResponseMatcher {
 		}
 
 		try {
-			return await this.renderCustomServerErrorResponse();
+			return await this.renderCustomServerErrorResponse(error);
 		} catch (serverErrorPageError) {
 			if (serverErrorPageError instanceof Response) {
 				return serverErrorPageError;

--- a/packages/core/src/config/config-builder.test.ts
+++ b/packages/core/src/config/config-builder.test.ts
@@ -263,11 +263,12 @@ describe('EcoConfigBuilder', () => {
 		expect(config.absolutePaths.workDir).toBe(path.join('/project', 'custom-work'));
 	});
 
-	test('should derive semantic html and 404 template paths', async () => {
+	test('should derive semantic html, 404, and 500 template paths', async () => {
 		vi.spyOn(fileSystem, 'exists').mockImplementation((candidate) => {
 			return (
 				candidate === path.join('/project', 'src', 'includes', 'html.test1') ||
-				candidate === path.join('/project', 'src', 'pages', '404.test2')
+				candidate === path.join('/project', 'src', 'pages', '404.test2') ||
+				candidate === path.join('/project', 'src', 'pages', '500.test2')
 			);
 		});
 
@@ -280,6 +281,7 @@ describe('EcoConfigBuilder', () => {
 
 		expect(config.absolutePaths.htmlTemplatePath).toBe(path.join('/project', 'src', 'includes', 'html.test1'));
 		expect(config.absolutePaths.error404TemplatePath).toBe(path.join('/project', 'src', 'pages', '404.test2'));
+		expect(config.absolutePaths.error500TemplatePath).toBe(path.join('/project', 'src', 'pages', '500.test2'));
 	});
 
 	test('should throw for duplicate semantic html templates', async () => {

--- a/packages/core/src/config/config-builder.ts
+++ b/packages/core/src/config/config-builder.ts
@@ -48,7 +48,7 @@ export const CONFIG_BUILDER_ERRORS = {
 		'Both kitajs and react integrations are enabled. Use per-file JSX import source/pragma consistently (e.g. `/** @jsxImportSource react */` for React files and `/** @jsxImportSource @kitajs/html */` for Kita files).',
 	duplicateProcessorName: (name: string) => `Processor with name "${name}" already exists`,
 	duplicateLoaderName: (name: string) => `Loader with name "${name}" already exists`,
-	duplicateSemanticTemplate: (kind: 'html' | '404', matches: string[]) =>
+	duplicateSemanticTemplate: (kind: 'html' | '404' | '500', matches: string[]) =>
 		`Multiple ${kind} templates found: ${matches.join(', ')}`,
 	incompatibleRuntimeCapability: (
 		kind: 'integration' | 'processor',
@@ -147,6 +147,7 @@ export class ConfigBuilder {
 			srcDir: '',
 			htmlTemplatePath: '',
 			error404TemplatePath: '',
+			error500TemplatePath: '',
 		},
 		processors: new Map(),
 		loaders: new Map(),
@@ -508,12 +509,22 @@ export class ConfigBuilder {
 				dirPath: absolutePagesDir,
 				basename: '404',
 			}),
+			error500TemplatePath: this.resolveSemanticTemplatePath({
+				dirPath: absolutePagesDir,
+				basename: '500',
+			}),
 		};
 
 		return this;
 	}
 
-	private resolveSemanticTemplatePath({ dirPath, basename }: { dirPath: string; basename: 'html' | '404' }): string {
+	private resolveSemanticTemplatePath({
+		dirPath,
+		basename,
+	}: {
+		dirPath: string;
+		basename: 'html' | '404' | '500';
+	}): string {
 		const extensions = this.config.templatesExt.length > 0 ? this.config.templatesExt : ['.ghtml.ts'];
 		const matches = extensions
 			.map((extension) => path.join(dirPath, `${basename}${extension}`))

--- a/packages/core/src/config/constants.ts
+++ b/packages/core/src/config/constants.ts
@@ -8,6 +8,7 @@
  */
 export const STATUS_MESSAGE = {
 	404: '404 Not Found',
+	500: 'Internal Server Error',
 };
 
 /**

--- a/packages/core/src/route-renderer/orchestration/route-pipeline/route-prepared-options.builder.ts
+++ b/packages/core/src/route-renderer/orchestration/route-pipeline/route-prepared-options.builder.ts
@@ -43,8 +43,12 @@ export function buildPreparedRenderOptions<C = unknown>(input: {
 
 	const dedupedDependencies = dedupeProcessedAssets(allDependencies);
 	const pagePackage = createPagePackage(dedupedDependencies, { pageBrowserGraph });
-	const pageProps = {
+	const resolvedProps = {
 		...props,
+		...(routeOptions.props ?? {}),
+	};
+	const pageProps = {
+		...resolvedProps,
 		params: routeOptions.params || {},
 		query: routeOptions.query || {},
 	};
@@ -66,7 +70,7 @@ export function buildPreparedRenderOptions<C = unknown>(input: {
 		Layouts,
 		Layout,
 		layoutEntries,
-		props,
+		props: resolvedProps,
 		Page: Page as EcoComponent<PageProps, C>,
 		metadata,
 		params: routeOptions.params || {},

--- a/packages/core/src/router/server/route-registry.test.ts
+++ b/packages/core/src/router/server/route-registry.test.ts
@@ -32,6 +32,7 @@ describe('RouteRegistry', () => {
 		expect(registry.templateRoutes.map((route) => route.pathname)).toEqual([
 			'/',
 			'/404',
+			'/500',
 			'/postcss-hmr',
 			'/dynamic/[slug]',
 			'/catch-all/[...path]',

--- a/packages/core/src/services/assets/asset-processing-service/processors/script/content-script.processor.test.ts
+++ b/packages/core/src/services/assets/asset-processing-service/processors/script/content-script.processor.test.ts
@@ -37,6 +37,7 @@ function createMockConfig(): EcoPagesAppConfig {
 			srcDir: '/test/project/src',
 			htmlTemplatePath: '/test/project/src/html.tsx',
 			error404TemplatePath: '/test/project/src/404.tsx',
+			error500TemplatePath: '/test/project/src/500.tsx',
 		},
 		processors: new Map(),
 		loaders: new Map(),

--- a/packages/core/src/services/assets/asset-processing-service/processors/stylesheet/content-stylesheet.processor.test.ts
+++ b/packages/core/src/services/assets/asset-processing-service/processors/stylesheet/content-stylesheet.processor.test.ts
@@ -37,6 +37,7 @@ function createMockConfig(processors = new Map<string, Processor>()): EcoPagesAp
 			srcDir: '/test/project/src',
 			htmlTemplatePath: '/test/project/src/html.tsx',
 			error404TemplatePath: '/test/project/src/404.tsx',
+			error500TemplatePath: '/test/project/src/500.tsx',
 		},
 		processors,
 		loaders: new Map(),

--- a/packages/core/src/types/internal-types.ts
+++ b/packages/core/src/types/internal-types.ts
@@ -132,6 +132,7 @@ export type EcoPagesAppConfig = {
 		srcDir: string;
 		htmlTemplatePath: string;
 		error404TemplatePath: string;
+		error500TemplatePath: string;
 	};
 	/**
 	 * The processors to be used in the app

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -771,7 +771,9 @@ export type EcoLayoutComponent<T = EcoPagesElement> = EcoComponent<LayoutProps<T
 export type EcoHtmlComponent<T = EcoPagesElement> = EcoComponent<HtmlTemplateProps, T>;
 
 /**
- * Represents the props for the error 404 template.
+ * Props type for the semantic `404.*` page template.
+ * @remarks `message` and `stack` are declared for future error context. The
+ * runtime does not currently pass these props when rendering the custom 404 page.
  */
 export interface Error404TemplateProps extends Omit<HtmlTemplateProps, 'children'> {
 	message: string;
@@ -779,7 +781,10 @@ export interface Error404TemplateProps extends Omit<HtmlTemplateProps, 'children
 }
 
 /**
- * Represents the props for the error 500 template.
+ * Props type for the semantic `500.*` page template.
+ * @remarks `message` and `stack` are declared for future error context. The
+ * runtime does not currently pass these props when rendering the custom 500 page.
+ * Avoid rendering raw stacks in production if that wiring is added later.
  */
 export interface Error500TemplateProps extends Omit<HtmlTemplateProps, 'children'> {
 	message: string;

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -782,12 +782,13 @@ export interface Error404TemplateProps extends Omit<HtmlTemplateProps, 'children
 
 /**
  * Props type for the semantic `500.*` page template.
- * @remarks `message` and `stack` are declared for future error context. The
- * runtime does not currently pass these props when rendering the custom 500 page.
- * Avoid rendering raw stacks in production if that wiring is added later.
+ * @remarks In development, the page-pipeline passes `message` and `stack` from the
+ * thrown error when rendering this page after a failure. In production those
+ * fields are omitted so stacks are not serialized into HTML. Direct visits to
+ * `/500` also omit them.
  */
 export interface Error500TemplateProps extends Omit<HtmlTemplateProps, 'children'> {
-	message: string;
+	message?: string;
 	stack?: string;
 }
 
@@ -922,6 +923,12 @@ export type RouteRendererOptions = {
 	params?: PageParams;
 	query?: PageQuery;
 	locals?: RequestLocals;
+	/**
+	 * Extra props merged into the page props for this render.
+	 * @remarks Used by semantic error pages (for example development `message` /
+	 * `stack` on the custom 500 page).
+	 */
+	props?: Record<string, unknown>;
 };
 
 /**

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -779,6 +779,14 @@ export interface Error404TemplateProps extends Omit<HtmlTemplateProps, 'children
 }
 
 /**
+ * Represents the props for the error 500 template.
+ */
+export interface Error500TemplateProps extends Omit<HtmlTemplateProps, 'children'> {
+	message: string;
+	stack?: string;
+}
+
+/**
  * Represents the parameters for a page.
  * The keys are strings, and the values can be either a string or an array of strings.
  */


### PR DESCRIPTION
## Summary
Adds semantic `src/pages/500.*` discovery and HTML 500 responses for page-pipeline render failures, falling back to plain-text Internal Server Error when the template is missing or throws.

## What changed
- Discover `error500TemplatePath` beside `404` via `resolveSemanticTemplatePath`
- Factory helpers: `createDefaultServerErrorResponse` / `createHtmlServerErrorResponse`
- Matcher tries custom 500 once after logging the original error; no recursion
- Shared `renderCustomErrorPageResponse` for 404/500 resolve→render→envelope
- Tests for HTML success, missing template, throwing template, and 404→500 escalation
- Docs/fixture for the new semantic page

## How to verify
1. `cd packages/core && bun run typecheck`
2. `pnpm exec vitest run --project shared-core src/adapters/shared/fs-server-response-factory.test.ts src/adapters/shared/fs-server-response-matcher.test.ts src/config/config-builder.test.ts`
3. Add `src/pages/500.*` in an app, throw from a page render, confirm HTML 500; remove/break the template and confirm plain Internal Server Error

## Notes
- API / `errorHandler` paths unchanged
- Deferred: static/preview `500.html` serving; passing error details into the 500 template