### PR TITLE
feat: add semantic 500 pages across docs, examples, and playgrounds

### DIFF
--- a/apps/docs/src/pages/500.css
+++ b/apps/docs/src/pages/500.css
@@ -1,0 +1,28 @@
+.error500 {
+	@apply min-h-[calc(100vh-64px)] flex items-center justify-center p-8 bg-background;
+
+	&__content {
+		@apply max-w-xl w-full text-center;
+	}
+
+	&__code {
+		@apply font-bold font-heading mb-4 select-none tracking-tighter text-on-background/30 text-8xl;
+		line-height: 0.85;
+	}
+
+	&__title {
+		@apply text-2xl md:text-3xl font-bold font-heading text-on-background mb-3 tracking-tight;
+	}
+
+	&__message {
+		@apply text-base md:text-lg text-on-background/60 mb-8 leading-relaxed font-sans max-w-sm mx-auto;
+	}
+
+	&__stack {
+		@apply mb-8 max-h-64 overflow-auto rounded-lg bg-on-background/5 p-4 text-left text-xs font-mono text-on-background/70 whitespace-pre-wrap;
+	}
+
+	&__actions {
+		@apply flex justify-center;
+	}
+}

--- a/apps/docs/src/pages/500.tsx
+++ b/apps/docs/src/pages/500.tsx
@@ -1,0 +1,34 @@
+import { eco } from '@ecopages/core';
+import { DocsLayout } from '@/layouts/docs-layout';
+import type { Error500TemplateProps } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+
+export default eco.page<Error500TemplateProps, JsxRenderable>({
+	layout: DocsLayout,
+	dependencies: {
+		stylesheets: ['./500.css'],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<div class="error500">
+				<div class="error500__content">
+					<div class="error500__code" aria-hidden="true">
+						500
+					</div>
+					<h1 class="error500__title">Something went wrong</h1>
+					<p class="error500__message">
+						{message ??
+							'We hit an unexpected error while rendering this page. Please try again in a moment.'}
+					</p>
+					{stack ? <pre class="error500__stack">{stack}</pre> : null}
+					<div class="error500__actions">
+						<a href="/" class="button button--outline">
+							Return Home
+						</a>
+					</div>
+				</div>
+			</div>
+		);
+	},
+});

--- a/e2e/fixtures/browser-router/src/pages/500.kita.tsx
+++ b/e2e/fixtures/browser-router/src/pages/500.kita.tsx
@@ -1,0 +1,22 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import type { ReactNode } from 'react';
+import { BaseLayout } from '../layouts/base-layout.kita';
+
+export default eco.page<Error500TemplateProps, ReactNode>({
+	dependencies: {
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<div class="error500">
+					<h1>500 - Internal Server Error</h1>
+					<p>{message ?? 'Something went wrong while rendering this page.'}</p>
+					{stack ? <pre class="error500__stack">{stack}</pre> : null}
+				</div>
+			</BaseLayout>
+		);
+	},
+});

--- a/e2e/fixtures/cache/src/pages/500.css
+++ b/e2e/fixtures/cache/src/pages/500.css
@@ -1,0 +1,4 @@
+.error500 {
+	text-align: center;
+	margin-top: 50px;
+}

--- a/e2e/fixtures/cache/src/pages/500.ghtml.ts
+++ b/e2e/fixtures/cache/src/pages/500.ghtml.ts
@@ -1,0 +1,20 @@
+import { eco, type Error500TemplateProps } from '@ecopages/core';
+import { html } from '@ecopages/core/html';
+import { BaseLayout } from '../layouts/base-layout';
+
+const Error500 = eco.component<Error500TemplateProps>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+	render: ({ message, stack }) =>
+		html`!${BaseLayout({
+			children: html`<div class="error500">
+				<h1>500 - Internal Server Error</h1>
+				<p>${message ?? 'Something went wrong while rendering this page.'}</p>
+				${stack ? html`<pre class="error500__stack">${stack}</pre>` : ''}
+			</div>`,
+		})}`,
+});
+
+export default Error500;

--- a/e2e/fixtures/core-hmr/src/pages/500.css
+++ b/e2e/fixtures/core-hmr/src/pages/500.css
@@ -1,0 +1,34 @@
+.error500 {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	align-items: center;
+	justify-content: center;
+	background-color: #e2e8f0;
+	border-radius: 0.375rem;
+	padding: 1rem;
+	margin-top: 5rem;
+	margin-bottom: 5rem;
+	max-width: fit-content;
+	margin-left: auto;
+	margin-right: auto;
+	box-shadow:
+		0 4px 6px -1px rgb(0 0 0 / 0.1),
+		0 2px 4px -2px rgb(0 0 0 / 0.1);
+}
+
+.error500 h1 {
+	font-size: 2.25rem;
+	line-height: 2.5rem;
+	font-weight: 700;
+	color: #0f172a;
+}
+
+.error500 p {
+	font-size: 1.125rem;
+	line-height: 1.75rem;
+	color: #334155;
+	padding: 2rem;
+	background-color: #f1f5f9;
+	border-radius: 0.375rem;
+}

--- a/e2e/fixtures/core-hmr/src/pages/500.ghtml.ts
+++ b/e2e/fixtures/core-hmr/src/pages/500.ghtml.ts
@@ -1,0 +1,21 @@
+import type { EcoComponent, Error500TemplateProps } from '@ecopages/core';
+import { html } from '@ecopages/core/html';
+import { BaseLayout } from '../layouts/base-layout';
+
+const Error500: EcoComponent<Error500TemplateProps> = ({ message, stack }) =>
+	html`!${BaseLayout({
+		children: html`<div class="error500">
+			<h1>500 - Internal Server Error</h1>
+			<p>${message ?? 'Something went wrong while rendering this page.'}</p>
+			${stack ? html`<pre class="error500__stack">${stack}</pre>` : ''}
+		</div>`,
+	})}`;
+
+Error500.config = {
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+};
+
+export default Error500;

--- a/e2e/fixtures/react-router/src/pages/500.tsx
+++ b/e2e/fixtures/react-router/src/pages/500.tsx
@@ -1,0 +1,23 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import type { ReactNode } from 'react';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps, ReactNode>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<div className="error500">
+					<h1>500 - Internal Server Error</h1>
+					<p>{message ?? 'Something went wrong while rendering this page.'}</p>
+					{stack ? <pre className="error500__stack">{stack}</pre> : null}
+				</div>
+			</BaseLayout>
+		);
+	},
+});

--- a/examples/blog-jsx/src/pages/500.css
+++ b/examples/blog-jsx/src/pages/500.css
@@ -1,0 +1,27 @@
+.error500 {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--space);
+	padding: var(--space-lg);
+	margin: var(--space-lg) auto;
+	max-width: fit-content;
+	background: var(--color-surface-elevated);
+	border: 1px solid var(--color-border);
+	border-radius: 0.5rem;
+	transition:
+		background-color 0.2s ease,
+		border-color 0.2s ease;
+}
+
+.error500 h1 {
+	margin-bottom: 0;
+}
+
+.error500 p {
+	margin-bottom: 0;
+	padding: var(--space);
+	background: var(--color-surface-muted);
+	border-radius: 0.375rem;
+}

--- a/examples/blog-jsx/src/pages/500.kita.tsx
+++ b/examples/blog-jsx/src/pages/500.kita.tsx
@@ -1,0 +1,22 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<div class="error500">
+					<h1>500 - Internal Server Error</h1>
+					<p>{message ?? 'Something went wrong while rendering this page.'}</p>
+					{stack ? <pre class="error500__stack">{stack}</pre> : null}
+				</div>
+			</BaseLayout>
+		);
+	},
+});

--- a/examples/blog-react/src/pages/500.css
+++ b/examples/blog-react/src/pages/500.css
@@ -1,0 +1,27 @@
+.error500 {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--space);
+	padding: var(--space-lg);
+	margin: var(--space-lg) auto;
+	max-width: fit-content;
+	background: var(--color-surface-elevated);
+	border: 1px solid var(--color-border);
+	border-radius: 0.5rem;
+	transition:
+		background-color 0.2s ease,
+		border-color 0.2s ease;
+}
+
+.error500 h1 {
+	margin-bottom: 0;
+}
+
+.error500 p {
+	margin-bottom: 0;
+	padding: var(--space);
+	background: var(--color-surface-muted);
+	border-radius: 0.375rem;
+}

--- a/examples/blog-react/src/pages/500.tsx
+++ b/examples/blog-react/src/pages/500.tsx
@@ -1,0 +1,23 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import type { ReactNode } from 'react';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps, ReactNode>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<div className="error500">
+					<h1>500 - Internal Server Error</h1>
+					<p>{message ?? 'Something went wrong while rendering this page.'}</p>
+					{stack ? <pre className="error500__stack">{stack}</pre> : null}
+				</div>
+			</BaseLayout>
+		);
+	},
+});

--- a/examples/starter-ghtml/src/pages/500.css
+++ b/examples/starter-ghtml/src/pages/500.css
@@ -1,0 +1,9 @@
+.error500 {
+	@apply flex flex-col gap-4 items-center justify-center bg-slate-200 rounded-md p-4 my-20 max-w-fit mx-auto shadow-md;
+	h1 {
+		@apply text-4xl font-bold text-slate-900;
+	}
+	p {
+		@apply text-lg text-slate-700 p-8 bg-slate-100 rounded-md;
+	}
+}

--- a/examples/starter-ghtml/src/pages/500.ts
+++ b/examples/starter-ghtml/src/pages/500.ts
@@ -1,0 +1,19 @@
+import { eco, type Error500TemplateProps } from '@ecopages/core';
+import { html } from '@ecopages/core/html';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) =>
+		html`!${BaseLayout({
+			children: html`<div class="error500">
+				<h1>500 - Internal Server Error</h1>
+				<p>${message ?? 'Something went wrong while rendering this page.'}</p>
+				${stack ? html`<pre class="error500__stack">${stack}</pre>` : ''}
+			</div>`,
+		})}`,
+});

--- a/examples/starter-jsx/src/pages/500.css
+++ b/examples/starter-jsx/src/pages/500.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/examples/starter-jsx/src/pages/500.kita.tsx
+++ b/examples/starter-jsx/src/pages/500.kita.tsx
@@ -1,0 +1,20 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<h1>500 - Internal Server Error</h1>
+				<p>{message ?? 'Something went wrong while rendering this page.'}</p>
+				{stack ? <pre>{stack}</pre> : null}
+			</BaseLayout>
+		);
+	},
+});

--- a/examples/starter-lit-jsx/src/pages/500.css
+++ b/examples/starter-lit-jsx/src/pages/500.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/examples/starter-lit-jsx/src/pages/500.kita.tsx
+++ b/examples/starter-lit-jsx/src/pages/500.kita.tsx
@@ -1,0 +1,22 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<div class="error500">
+					<h1>500 - Internal Server Error</h1>
+					<p>{message ?? 'Something went wrong while rendering this page.'}</p>
+					{stack ? <pre class="error500__stack">{stack}</pre> : null}
+				</div>
+			</BaseLayout>
+		);
+	},
+});

--- a/examples/starter-react/src/pages/500.css
+++ b/examples/starter-react/src/pages/500.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/examples/starter-react/src/pages/500.tsx
+++ b/examples/starter-react/src/pages/500.tsx
@@ -1,0 +1,23 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import type { ReactNode } from 'react';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps, ReactNode>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<div className="error500">
+					<h1>500 - Internal Server Error</h1>
+					<p>{message ?? 'Something went wrong while rendering this page.'}</p>
+					{stack ? <pre className="error500__stack">{stack}</pre> : null}
+				</div>
+			</BaseLayout>
+		);
+	},
+});

--- a/examples/with-react-better-auth/src/pages/500.tsx
+++ b/examples/with-react-better-auth/src/pages/500.tsx
@@ -1,0 +1,27 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps>({
+	layout: BaseLayout,
+	metadata: () => ({
+		title: 'Server error',
+		description: 'Something went wrong while rendering this page.',
+	}),
+	render: ({ message, stack }) => (
+		<div className="mx-auto max-w-2xl text-center">
+			<h1 className="text-4xl font-bold tracking-tight text-on-background">Server error</h1>
+			<p className="mt-4 text-muted">{message ?? 'Something went wrong while rendering this page.'}</p>
+			{stack ? (
+				<pre className="mt-6 overflow-auto rounded-lg bg-on-background/5 p-4 text-left text-xs font-mono text-on-background/70 whitespace-pre-wrap">
+					{stack}
+				</pre>
+			) : null}
+			<p className="mt-6">
+				<a href="/" className="btn btn-primary">
+					Back to home
+				</a>
+			</p>
+		</div>
+	),
+});

--- a/playground/browser-router/src/pages/500.css
+++ b/playground/browser-router/src/pages/500.css
@@ -1,0 +1,27 @@
+.error500 {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--space);
+	padding: var(--space-lg);
+	margin: var(--space-lg) auto;
+	max-width: fit-content;
+	background: var(--color-surface-elevated);
+	border: 1px solid var(--color-border);
+	border-radius: 0.5rem;
+	transition:
+		background-color 0.2s ease,
+		border-color 0.2s ease;
+}
+
+.error500 h1 {
+	margin-bottom: 0;
+}
+
+.error500 p {
+	margin-bottom: 0;
+	padding: var(--space);
+	background: var(--color-surface-muted);
+	border-radius: 0.375rem;
+}

--- a/playground/browser-router/src/pages/500.kita.tsx
+++ b/playground/browser-router/src/pages/500.kita.tsx
@@ -1,0 +1,22 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<div class="error500">
+					<h1>500 - Internal Server Error</h1>
+					<p>{message ?? 'Something went wrong while rendering this page.'}</p>
+					{stack ? <pre class="error500__stack">{stack}</pre> : null}
+				</div>
+			</BaseLayout>
+		);
+	},
+});

--- a/playground/eco-blog/src/pages/500.css
+++ b/playground/eco-blog/src/pages/500.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/playground/eco-blog/src/pages/500.kita.tsx
+++ b/playground/eco-blog/src/pages/500.kita.tsx
@@ -1,0 +1,22 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<div class="error500">
+					<h1>500 - Internal Server Error</h1>
+					<p>{message ?? 'Something went wrong while rendering this page.'}</p>
+					{stack ? <pre class="error500__stack">{stack}</pre> : null}
+				</div>
+			</BaseLayout>
+		);
+	},
+});

--- a/playground/global/src/pages/500.css
+++ b/playground/global/src/pages/500.css
@@ -1,0 +1,9 @@
+.error500 {
+	@apply flex flex-col gap-4 items-center justify-center bg-slate-200 rounded-md p-4 my-20 max-w-fit mx-auto shadow-md;
+	h1 {
+		@apply text-4xl font-bold text-slate-900;
+	}
+	p {
+		@apply text-lg text-slate-700 p-8 bg-slate-100 rounded-md;
+	}
+}

--- a/playground/global/src/pages/500.kita.tsx
+++ b/playground/global/src/pages/500.kita.tsx
@@ -1,0 +1,22 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<div class="error500">
+					<h1>500 - Internal Server Error</h1>
+					<p>{message ?? 'Something went wrong while rendering this page.'}</p>
+					{stack ? <pre class="error500__stack">{stack}</pre> : null}
+				</div>
+			</BaseLayout>
+		);
+	},
+});

--- a/playground/kitchen-sink/src/pages/500.kita.tsx
+++ b/playground/kitchen-sink/src/pages/500.kita.tsx
@@ -1,0 +1,43 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import { BaseLayout } from '@/layouts/base-layout';
+import { getPageTestId } from '@/data/primary-links';
+
+export default eco.page<Error500TemplateProps>({
+	dependencies: {
+		components: [BaseLayout],
+	},
+	layout: BaseLayout,
+	metadata: () => ({
+		title: 'Server Error',
+		description: 'Something went wrong while rendering this page.',
+	}),
+
+	render: ({ message, stack }) => {
+		return (
+			<section class="card text-center border-dashed" data-testid={getPageTestId('/server-error')}>
+				<p class="text-xs font-semibold uppercase tracking-[0.28em] text-sky-600">Custom 500</p>
+				<h1 class="font-display text-5xl font-semibold tracking-tight">
+					The render path failed, but the fallback page did not.
+				</h1>
+				<p class="mx-auto max-w-2xl text-lg leading-8 text-muted">
+					{message ??
+						'This is the semantic 500.kita.tsx page discovered automatically from the pages directory.'}
+				</p>
+				{stack ? (
+					<pre class="mx-auto mt-6 max-h-64 max-w-3xl overflow-auto rounded-lg bg-sky-950/5 p-4 text-left text-xs font-mono text-muted whitespace-pre-wrap">
+						{stack}
+					</pre>
+				) : null}
+				<div class="flex flex-wrap justify-center gap-3">
+					<a href="/" class="button button--primary">
+						Go back home
+					</a>
+					<a href="/explicit/team" class="button button--secondary">
+						Try an explicit route
+					</a>
+				</div>
+			</section>
+		);
+	},
+});

--- a/playground/namespace/src/pages/500.kita.tsx
+++ b/playground/namespace/src/pages/500.kita.tsx
@@ -1,0 +1,41 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import { BaseLayout } from '@/layouts/base-layout.kita';
+
+export default eco.page<Error500TemplateProps>({
+	dependencies: {
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<div class="max-w-2xl mx-auto text-center flex flex-col items-center justify-center min-h-[50vh] space-y-8">
+					<div class="space-y-4">
+						<h1 class="text-8xl md:text-9xl font-bold tracking-tight bg-clip-text text-transparent bg-linear-to-br from-white via-gray-200 to-gray-500">
+							500
+						</h1>
+						<h2 class="text-2xl md:text-3xl font-bold text-white">Server Error</h2>
+						<p class="text-gray-400 text-lg">
+							{message ?? 'Something went wrong while rendering this page.'}
+						</p>
+						{stack ? (
+							<pre class="max-h-64 overflow-auto rounded-lg bg-white/5 p-4 text-left text-xs font-mono text-gray-300 whitespace-pre-wrap">
+								{stack}
+							</pre>
+						) : null}
+					</div>
+
+					<div class="pt-8">
+						<a
+							href="/"
+							class="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-white text-black font-semibold hover:bg-gray-200 transition-colors"
+						>
+							Return Home
+						</a>
+					</div>
+				</div>
+			</BaseLayout>
+		);
+	},
+});

--- a/playground/react-router/src/pages/500.css
+++ b/playground/react-router/src/pages/500.css
@@ -1,0 +1,27 @@
+.error500 {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--space);
+	padding: var(--space-lg);
+	margin: var(--space-lg) auto;
+	max-width: fit-content;
+	background: var(--color-surface-elevated);
+	border: 1px solid var(--color-border);
+	border-radius: 0.5rem;
+	transition:
+		background-color 0.2s ease,
+		border-color 0.2s ease;
+}
+
+.error500 h1 {
+	margin-bottom: 0;
+}
+
+.error500 p {
+	margin-bottom: 0;
+	padding: var(--space);
+	background: var(--color-surface-muted);
+	border-radius: 0.375rem;
+}

--- a/playground/react-router/src/pages/500.tsx
+++ b/playground/react-router/src/pages/500.tsx
@@ -1,0 +1,23 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import type { ReactNode } from 'react';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps, ReactNode>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<div className="error500">
+					<h1>500 - Internal Server Error</h1>
+					<p>{message ?? 'Something went wrong while rendering this page.'}</p>
+					{stack ? <pre className="error500__stack">{stack}</pre> : null}
+				</div>
+			</BaseLayout>
+		);
+	},
+});

--- a/playground/react/src/pages/500.css
+++ b/playground/react/src/pages/500.css
@@ -1,0 +1,9 @@
+.error500 {
+	@apply flex flex-col gap-4 items-center justify-center bg-slate-200 rounded-md p-4 my-20 max-w-fit mx-auto shadow-md;
+	h1 {
+		@apply text-4xl font-bold text-slate-900;
+	}
+	p {
+		@apply text-lg text-slate-700 p-8 bg-slate-100 rounded-md;
+	}
+}

--- a/playground/react/src/pages/500.tsx
+++ b/playground/react/src/pages/500.tsx
@@ -1,0 +1,23 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import type { ReactNode } from 'react';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps, ReactNode>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<div className="error500">
+					<h1>500 - Internal Server Error</h1>
+					<p>{message ?? 'Something went wrong while rendering this page.'}</p>
+					{stack ? <pre className="error500__stack">{stack}</pre> : null}
+				</div>
+			</BaseLayout>
+		);
+	},
+});

--- a/playground/tailwind-v4/src/pages/500.css
+++ b/playground/tailwind-v4/src/pages/500.css
@@ -1,0 +1,20 @@
+/* 
+ * 500 page styles using @apply
+ * The @reference directive is auto-injected by the postcss-processor
+ */
+
+.error500 {
+	@apply flex flex-col items-center justify-center min-h-[60vh] text-center;
+}
+
+.error500 h1 {
+	@apply text-8xl md:text-9xl font-black text-transparent bg-clip-text bg-gradient-to-r from-primary-400 via-accent-500 to-primary-500 mb-4;
+}
+
+.error500 p {
+	@apply text-xl text-surface-300 mb-8;
+}
+
+.error500 a {
+	@apply px-6 py-3 rounded-lg bg-surface-800 border border-surface-700 text-surface-200 hover:border-primary-500 hover:text-primary-400 transition-colors;
+}

--- a/playground/tailwind-v4/src/pages/500.tsx
+++ b/playground/tailwind-v4/src/pages/500.tsx
@@ -1,0 +1,23 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import type { ReactNode } from 'react';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps, ReactNode>({
+	dependencies: {
+		stylesheets: ['./500.css'],
+		components: [BaseLayout],
+	},
+
+	render: ({ message, stack }) => {
+		return (
+			<BaseLayout>
+				<div className="error500">
+					<h1>500 - Internal Server Error</h1>
+					<p>{message ?? 'Something went wrong while rendering this page.'}</p>
+					{stack ? <pre className="error500__stack">{stack}</pre> : null}
+				</div>
+			</BaseLayout>
+		);
+	},
+});

--- a/playground/with-react-better-auth/src/pages/500.tsx
+++ b/playground/with-react-better-auth/src/pages/500.tsx
@@ -1,0 +1,27 @@
+import { eco } from '@ecopages/core';
+import type { Error500TemplateProps } from '@ecopages/core';
+import { BaseLayout } from '@/layouts/base-layout';
+
+export default eco.page<Error500TemplateProps>({
+	layout: BaseLayout,
+	metadata: () => ({
+		title: 'Server error',
+		description: 'Something went wrong while rendering this page.',
+	}),
+	render: ({ message, stack }) => (
+		<div className="mx-auto max-w-2xl text-center">
+			<h1 className="text-4xl font-bold tracking-tight text-on-background">Server error</h1>
+			<p className="mt-4 text-muted">{message ?? 'Something went wrong while rendering this page.'}</p>
+			{stack ? (
+				<pre className="mt-6 overflow-auto rounded-lg bg-on-background/5 p-4 text-left text-xs font-mono text-on-background/70 whitespace-pre-wrap">
+					{stack}
+				</pre>
+			) : null}
+			<p className="mt-6">
+				<a href="/" className="btn btn-primary">
+					Back to home
+				</a>
+			</p>
+		</div>
+	),
+});


### PR DESCRIPTION
## Summary
Adds `src/pages/500.*` across docs, examples, playgrounds, and e2e fixtures, wired to the development `message`/`stack` props from #223.

## What changed
- `apps/docs` 500 page mirrors the 404 layout and shows the real error + stack in development
- Examples, playgrounds, and e2e fixtures that ship a 404 now ship a parallel 500 that renders `message`/`stack` when present
- Skipped `playground/explicit-routes` (orphaned `views/404`, no semantic `pages/` discovery)

## How to verify
1. Open `/500` in `apps/docs` to preview the static design
2. Force a page render throw in development and confirm the custom 500 shows the real message/stack
3. In production mode, confirm those details are omitted from the HTML response

## Notes
- Stacked on `feat/custom-500-page` (#223)