### PR TITLE
fix(react): restore unbundled HMR page bootstraps via shared vendors

### DIFF
--- a/packages/integrations/react/src/bundling/bootstrap-package-paths.ts
+++ b/packages/integrations/react/src/bundling/bootstrap-package-paths.ts
@@ -1,0 +1,6 @@
+/**
+ * Bare package specifiers for React page hydration bootstrap helpers.
+ */
+
+export const PAGE_LAYOUT_NORMALIZATION_PACKAGE = '@ecopages/core/eco/page-layout-normalization';
+export const LAYOUT_COMPOSE_PACKAGE = '@ecopages/react/layout-compose';

--- a/packages/integrations/react/src/bundling/runtime-alias-map.test.ts
+++ b/packages/integrations/react/src/bundling/runtime-alias-map.test.ts
@@ -31,6 +31,8 @@ describe('buildReactRuntimeAliasMap', () => {
 			reactJsxDevRuntime: '/assets/vendors/react.js',
 			reactDom: '/assets/vendors/react-dom.js',
 			useSyncExternalStoreWithSelector: '/assets/vendors/use-sync-external-store-with-selector.js',
+			pageLayoutNormalization: '/assets/vendors/page-layout-normalization.js',
+			layoutCompose: '/assets/vendors/layout-compose.js',
 		});
 
 		expect(Array.from(manifest.bySpecifier.entries())).toEqual([
@@ -136,6 +138,8 @@ describe('buildReactRuntimeAliasMap', () => {
 				reactJsxDevRuntime: '/assets/vendors/react.js',
 				reactDom: '/assets/vendors/react-dom.js',
 				useSyncExternalStoreWithSelector: '/assets/vendors/use-sync-external-store-with-selector.js',
+				pageLayoutNormalization: '/assets/vendors/page-layout-normalization.js',
+				layoutCompose: '/assets/vendors/layout-compose.js',
 			}),
 		).toEqual({
 			react: '/assets/vendors/react.js',
@@ -159,6 +163,8 @@ describe('buildReactRuntimeAliasMap', () => {
 				reactJsxDevRuntime: '/assets/vendors/react.js',
 				reactDom: '/assets/vendors/react-dom.js',
 				useSyncExternalStoreWithSelector: '/assets/vendors/use-sync-external-store-with-selector.js',
+				pageLayoutNormalization: '/assets/vendors/page-layout-normalization.js',
+				layoutCompose: '/assets/vendors/layout-compose.js',
 				router: '/assets/vendors/router.js',
 			}),
 		).not.toHaveProperty('/router.ts');

--- a/packages/integrations/react/src/bundling/runtime-bundle.test.ts
+++ b/packages/integrations/react/src/bundling/runtime-bundle.test.ts
@@ -22,6 +22,8 @@ describe('RuntimeBundleService', () => {
 			reactJsxDevRuntime: '/assets/vendors/react.js',
 			reactDom: '/assets/vendors/react-dom.js',
 			useSyncExternalStoreWithSelector: '/assets/vendors/use-sync-external-store-with-selector.js',
+			pageLayoutNormalization: '/assets/vendors/page-layout-normalization.js',
+			layoutCompose: '/assets/vendors/layout-compose.js',
 		});
 
 		const dependencies = service.getDependencies();
@@ -77,6 +79,8 @@ describe('RuntimeBundleService', () => {
 			reactJsxDevRuntime: '/assets/vendors/react.development.js',
 			reactDom: '/assets/vendors/react-dom.development.js',
 			useSyncExternalStoreWithSelector: '/assets/vendors/use-sync-external-store-with-selector.development.js',
+			pageLayoutNormalization: '/assets/vendors/page-layout-normalization.development.js',
+			layoutCompose: '/assets/vendors/layout-compose.development.js',
 			router: '/assets/vendors/react-router-esm.development.js',
 		});
 
@@ -89,6 +93,21 @@ describe('RuntimeBundleService', () => {
 					bundleOptions: expect.objectContaining({
 						naming: 'use-sync-external-store-with-selector.development.js',
 						define: expect.objectContaining({ 'process.env.NODE_ENV': '"development"' }),
+					}),
+				}),
+				expect.objectContaining({
+					name: 'page-layout-normalization',
+					importPath: '@ecopages/core/eco/page-layout-normalization',
+					bundleOptions: expect.objectContaining({
+						naming: 'page-layout-normalization.development.js',
+					}),
+				}),
+				expect.objectContaining({
+					name: 'layout-compose',
+					importPath: '@ecopages/react/layout-compose',
+					bundleOptions: expect.objectContaining({
+						naming: 'layout-compose.development.js',
+						plugins: expect.any(Array),
 					}),
 				}),
 				expect.objectContaining({

--- a/packages/integrations/react/src/bundling/runtime-bundle.ts
+++ b/packages/integrations/react/src/bundling/runtime-bundle.ts
@@ -28,6 +28,7 @@ import {
 	createBrowserRuntimeManifest,
 	type BrowserRuntimeManifest,
 } from '@ecopages/core/build/browser-runtime-manifest';
+import { LAYOUT_COMPOSE_PACKAGE, PAGE_LAYOUT_NORMALIZATION_PACKAGE } from './bootstrap-package-paths.ts';
 
 export type ReactRuntimeImports = {
 	react: string;
@@ -36,6 +37,8 @@ export type ReactRuntimeImports = {
 	reactJsxDevRuntime: string;
 	reactDom: string;
 	useSyncExternalStoreWithSelector: string;
+	pageLayoutNormalization: string;
+	layoutCompose: string;
 	router?: string;
 };
 
@@ -132,6 +135,14 @@ export class RuntimeBundleService {
 			: 'use-sync-external-store-with-selector.js';
 	}
 
+	private getPageLayoutNormalizationVendorFileName(mode: RuntimeMode): string {
+		return mode === 'development' ? 'page-layout-normalization.development.js' : 'page-layout-normalization.js';
+	}
+
+	private getLayoutComposeVendorFileName(mode: RuntimeMode): string {
+		return mode === 'development' ? 'layout-compose.development.js' : 'layout-compose.js';
+	}
+
 	private createReactVendorImportRewritePlugin(mode: RuntimeMode): EcoBuildPlugin {
 		return createBrowserRuntimePlugin({
 			name: `react-plugin-vendor-runtime-import-rewrite-${mode}`,
@@ -158,6 +169,8 @@ export class RuntimeBundleService {
 			useSyncExternalStoreWithSelector: buildBrowserRuntimeAssetUrl(
 				this.getUseSyncExternalStoreWithSelectorVendorFileName(mode),
 			),
+			pageLayoutNormalization: buildBrowserRuntimeAssetUrl(this.getPageLayoutNormalizationVendorFileName(mode)),
+			layoutCompose: buildBrowserRuntimeAssetUrl(this.getLayoutComposeVendorFileName(mode)),
 		};
 
 		if (this.config.routerAdapter) {
@@ -239,6 +252,25 @@ export class RuntimeBundleService {
 					importPath: '@ecopages/react/runtime/use-sync-external-store-with-selector',
 					name: 'use-sync-external-store-with-selector',
 					fileName: this.getUseSyncExternalStoreWithSelectorVendorFileName(mode),
+					bundleOptions: {
+						define: this.createRuntimeDefines(mode),
+						excludeAppBuildPlugins: [DEFAULT_BROWSER_RUNTIME_PLUGIN_NAME],
+						plugins: [reactVendorImportRewritePlugin],
+					},
+				}),
+				createBrowserRuntimeScriptAsset({
+					importPath: PAGE_LAYOUT_NORMALIZATION_PACKAGE,
+					name: 'page-layout-normalization',
+					fileName: this.getPageLayoutNormalizationVendorFileName(mode),
+					bundleOptions: {
+						define: this.createRuntimeDefines(mode),
+						excludeAppBuildPlugins: [DEFAULT_BROWSER_RUNTIME_PLUGIN_NAME],
+					},
+				}),
+				createBrowserRuntimeScriptAsset({
+					importPath: LAYOUT_COMPOSE_PACKAGE,
+					name: 'layout-compose',
+					fileName: this.getLayoutComposeVendorFileName(mode),
 					bundleOptions: {
 						define: this.createRuntimeDefines(mode),
 						excludeAppBuildPlugins: [DEFAULT_BROWSER_RUNTIME_PLUGIN_NAME],

--- a/packages/integrations/react/src/hydration/assert-no-bare-ecopages-imports.ts
+++ b/packages/integrations/react/src/hydration/assert-no-bare-ecopages-imports.ts
@@ -1,0 +1,8 @@
+import { expect } from 'vitest';
+
+/**
+ * Test helper: assert generated hydration bootstrap source has no bare `@ecopages/*` imports.
+ */
+export function assertNoBareEcopagesImports(source: string): void {
+	expect(source).not.toMatch(/from\s+["']@ecopages\//);
+}

--- a/packages/integrations/react/src/hydration/bootstrap-imports.test.ts
+++ b/packages/integrations/react/src/hydration/bootstrap-imports.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { resolveHydrationBootstrapImports } from './bootstrap-imports.ts';
+
+const vendorImports = {
+	react: '/assets/vendors/react.js',
+	reactDomClient: '/assets/vendors/react-dom.js',
+	reactJsxRuntime: '/assets/vendors/react.js',
+	reactJsxDevRuntime: '/assets/vendors/react.js',
+	reactDom: '/assets/vendors/react-dom.js',
+	useSyncExternalStoreWithSelector: '/assets/vendors/use-sync-external-store-with-selector.js',
+	pageLayoutNormalization: '/assets/vendors/page-layout-normalization.js',
+	layoutCompose: '/assets/vendors/layout-compose.js',
+	router: '/assets/vendors/react-router-esm.js',
+};
+
+describe('resolveHydrationBootstrapImports', () => {
+	it('returns vendor URLs when browser runtime imports are enabled', () => {
+		expect(
+			resolveHydrationBootstrapImports({
+				useBrowserRuntimeImports: true,
+				runtimeImports: vendorImports,
+				routerAdapterImportPath: '@ecopages/react-router/browser',
+			}),
+		).toEqual({
+			reactImportPath: '/assets/vendors/react.js',
+			reactDomClientImportPath: '/assets/vendors/react-dom.js',
+			routerImportPath: '/assets/vendors/react-router-esm.js',
+			layoutComposeImportPath: '/assets/vendors/layout-compose.js',
+			pageLayoutNormalizationImportPath: '/assets/vendors/page-layout-normalization.js',
+		});
+	});
+
+	it('returns bare package names when browser runtime imports are disabled', () => {
+		expect(
+			resolveHydrationBootstrapImports({
+				useBrowserRuntimeImports: false,
+				runtimeImports: vendorImports,
+				routerAdapterImportPath: '@ecopages/react-router/browser',
+			}),
+		).toEqual({
+			reactImportPath: 'react',
+			reactDomClientImportPath: 'react-dom/client',
+			routerImportPath: '@ecopages/react-router/browser',
+			layoutComposeImportPath: '@ecopages/react/layout-compose',
+			pageLayoutNormalizationImportPath: '@ecopages/core/eco/page-layout-normalization',
+		});
+	});
+});

--- a/packages/integrations/react/src/hydration/bootstrap-imports.ts
+++ b/packages/integrations/react/src/hydration/bootstrap-imports.ts
@@ -1,0 +1,54 @@
+/**
+ * Resolves browser import paths for React page hydration bootstraps.
+ *
+ * @remarks
+ * When `useBrowserRuntimeImports` is true, helpers and runtimes resolve to shared
+ * `/assets/vendors/*.js` URLs so unbundled HMR bootstraps evaluate as native ESM.
+ * When false, bare package names are emitted for the production page bundler.
+ */
+
+import { LAYOUT_COMPOSE_PACKAGE, PAGE_LAYOUT_NORMALIZATION_PACKAGE } from '../bundling/bootstrap-package-paths.ts';
+import type { ReactRuntimeImports } from '../bundling/runtime-bundle.ts';
+
+export type HydrationBootstrapImportPaths = {
+	reactImportPath: string;
+	reactDomClientImportPath: string;
+	routerImportPath?: string;
+	layoutComposeImportPath: string;
+	pageLayoutNormalizationImportPath: string;
+};
+
+export type ResolveHydrationBootstrapImportsOptions = {
+	useBrowserRuntimeImports: boolean;
+	runtimeImports: ReactRuntimeImports;
+	routerAdapterImportPath?: string;
+};
+
+/**
+ * Returns import paths for React page hydration scripts.
+ */
+export function resolveHydrationBootstrapImports(
+	options: ResolveHydrationBootstrapImportsOptions,
+): HydrationBootstrapImportPaths {
+	const { useBrowserRuntimeImports, runtimeImports, routerAdapterImportPath } = options;
+
+	if (useBrowserRuntimeImports) {
+		return {
+			reactImportPath: runtimeImports.react,
+			reactDomClientImportPath: runtimeImports.reactDomClient,
+			...(runtimeImports.router || routerAdapterImportPath
+				? { routerImportPath: runtimeImports.router ?? routerAdapterImportPath }
+				: {}),
+			layoutComposeImportPath: runtimeImports.layoutCompose,
+			pageLayoutNormalizationImportPath: runtimeImports.pageLayoutNormalization,
+		};
+	}
+
+	return {
+		reactImportPath: 'react',
+		reactDomClientImportPath: 'react-dom/client',
+		...(routerAdapterImportPath ? { routerImportPath: routerAdapterImportPath } : {}),
+		layoutComposeImportPath: LAYOUT_COMPOSE_PACKAGE,
+		pageLayoutNormalizationImportPath: PAGE_LAYOUT_NORMALIZATION_PACKAGE,
+	};
+}

--- a/packages/integrations/react/src/hydration/hydration-asset.test.ts
+++ b/packages/integrations/react/src/hydration/hydration-asset.test.ts
@@ -1,6 +1,31 @@
 import { rapidhash } from '@ecopages/core/hash';
 import { describe, expect, it, vi } from 'vitest';
+import { assertNoBareEcopagesImports } from './assert-no-bare-ecopages-imports.ts';
 import { getIslandComponentKey, HydrationAssetService } from './hydration-asset.ts';
+
+const productionRuntimeImports = {
+	react: 'react',
+	reactDomClient: 'react-dom/client',
+	reactJsxRuntime: 'react',
+	reactJsxDevRuntime: 'react',
+	reactDom: 'react-dom',
+	useSyncExternalStoreWithSelector: 'use-sync-external-store/shim/with-selector',
+	pageLayoutNormalization: '@ecopages/core/eco/page-layout-normalization',
+	layoutCompose: '@ecopages/react/layout-compose',
+	router: undefined as string | undefined,
+};
+
+const browserRuntimeImports = {
+	react: '/assets/vendors/react.js',
+	reactDomClient: '/assets/vendors/react-dom.js',
+	reactJsxRuntime: '/assets/vendors/react.js',
+	reactJsxDevRuntime: '/assets/vendors/react.js',
+	reactDom: '/assets/vendors/react-dom.js',
+	useSyncExternalStoreWithSelector: '/assets/vendors/use-sync-external-store-with-selector.js',
+	pageLayoutNormalization: '/assets/vendors/page-layout-normalization.js',
+	layoutCompose: '/assets/vendors/layout-compose.js',
+	router: '/assets/vendors/react-router-esm.js' as string | undefined,
+};
 
 describe('HydrationAssetService', () => {
 	it('creates one page-owned route entry asset', () => {
@@ -10,11 +35,7 @@ describe('HydrationAssetService', () => {
 				getHmrManager: () => undefined,
 			} as any,
 			bundleService: {
-				getRuntimeImports: () => ({
-					react: 'react',
-					reactDomClient: 'react-dom/client',
-					router: undefined,
-				}),
+				getRuntimeImports: () => productionRuntimeImports,
 			} as any,
 		});
 
@@ -66,11 +87,7 @@ describe('HydrationAssetService', () => {
 				getHmrManager: () => undefined,
 			} as any,
 			bundleService: {
-				getRuntimeImports: () => ({
-					react: 'react',
-					reactDomClient: 'react-dom/client',
-					router: '/assets/vendors/react-router-esm.js',
-				}),
+				getRuntimeImports: () => browserRuntimeImports,
 			} as any,
 		});
 
@@ -97,7 +114,7 @@ describe('HydrationAssetService', () => {
 		});
 	});
 
-	it('bundles router-managed page bootstraps in development while keeping the HMR page module external', () => {
+	it('keeps router-managed page bootstraps unbundled in development with vendor helper imports', () => {
 		const service = new HydrationAssetService({
 			srcDir: '/app/src',
 			routerAdapter: {
@@ -117,11 +134,7 @@ describe('HydrationAssetService', () => {
 				getHmrManager: () => ({ isEnabled: () => true }),
 			} as any,
 			bundleService: {
-				getRuntimeImports: () => ({
-					react: 'react',
-					reactDomClient: 'react-dom/client',
-					router: '/assets/vendors/react-router-esm.js',
-				}),
+				getRuntimeImports: () => browserRuntimeImports,
 			} as any,
 		});
 
@@ -138,25 +151,22 @@ describe('HydrationAssetService', () => {
 			isMdx: false,
 		});
 
+		const content = String((dependencies[0] as { content?: string }).content ?? '');
 		expect(dependencies[0]).toMatchObject({
-			bundle: true,
+			bundle: false,
 			groupedBundle: undefined,
 			bundleOptions: {
-				external: expect.arrayContaining([
-					'/assets/vendors/react-router-esm.js',
-					'/assets/_hmr/pages/docs/index.js',
-				]),
+				external: ['/assets/vendors/react-router-esm.js'],
 			},
 			attributes: {
 				'data-eco-page-bootstrap': 'react-router',
 			},
 		});
-		expect(String((dependencies[0] as { content?: string }).content ?? '')).toContain(
-			'from "/assets/_hmr/pages/docs/index.js"',
-		);
+		expect(content).toContain('from "/assets/_hmr/pages/docs/index.js"');
+		assertNoBareEcopagesImports(content);
 	});
 
-	it('bundles MDX page bootstraps that import layout normalization helpers', () => {
+	it('emits vendor URLs for MDX layout normalization in unbundled HMR bootstraps', () => {
 		const service = new HydrationAssetService({
 			srcDir: '/app/src',
 			routerAdapter: {
@@ -176,11 +186,7 @@ describe('HydrationAssetService', () => {
 				getHmrManager: () => ({ isEnabled: () => true }),
 			} as any,
 			bundleService: {
-				getRuntimeImports: () => ({
-					react: '/assets/vendors/react.js',
-					reactDomClient: '/assets/vendors/react-dom.js',
-					router: '/assets/vendors/react-router-esm.js',
-				}),
+				getRuntimeImports: () => browserRuntimeImports,
 			} as any,
 		});
 
@@ -197,13 +203,11 @@ describe('HydrationAssetService', () => {
 
 		const content = String((dependencies[0] as { content?: string }).content ?? '');
 		expect(dependencies[0]).toMatchObject({
-			bundle: true,
-			bundleOptions: {
-				external: ['/assets/_hmr/pages/react-content.js'],
-			},
+			bundle: false,
 		});
-		expect(content).toContain('@ecopages/core/eco/page-layout-normalization');
+		expect(content).toContain('from "/assets/vendors/page-layout-normalization.js"');
 		expect(content).toContain('from "/assets/_hmr/pages/react-content.js"');
+		assertNoBareEcopagesImports(content);
 	});
 
 	it('bundles the React runtime into production page browser graph entries', async () => {
@@ -219,11 +223,7 @@ describe('HydrationAssetService', () => {
 			} as any,
 			bundleService: {
 				createBundleOptions,
-				getRuntimeImports: () => ({
-					react: 'react',
-					reactDomClient: 'react-dom/client',
-					router: undefined,
-				}),
+				getRuntimeImports: () => ({ ...productionRuntimeImports, router: undefined }),
 			} as any,
 		});
 
@@ -270,11 +270,7 @@ describe('HydrationAssetService', () => {
 			} as any,
 			bundleService: {
 				createBundleOptions,
-				getRuntimeImports: () => ({
-					react: '/assets/vendors/react.js',
-					reactDomClient: '/assets/vendors/react-dom.js',
-					router: '/assets/vendors/react-router-esm.js',
-				}),
+				getRuntimeImports: () => browserRuntimeImports,
 			} as any,
 		});
 
@@ -306,11 +302,7 @@ describe('HydrationAssetService', () => {
 			} as any,
 			bundleService: {
 				createBundleOptions,
-				getRuntimeImports: () => ({
-					react: '/assets/vendors/react.js',
-					reactDomClient: '/assets/vendors/react-dom.js',
-					router: undefined,
-				}),
+				getRuntimeImports: () => ({ ...browserRuntimeImports, router: undefined }),
 			} as any,
 		});
 
@@ -335,6 +327,10 @@ describe('HydrationAssetService', () => {
 				content: expect.stringContaining('import { hydrateRoot } from "/assets/vendors/react-dom.js";'),
 			});
 			expect(String((dependencies[0] as { content?: string }).content ?? '')).not.toContain('hmrHandlers');
+			expect(String((dependencies[0] as { content?: string }).content ?? '')).toContain(
+				'from "/assets/vendors/layout-compose.js"',
+			);
+			assertNoBareEcopagesImports(String((dependencies[0] as { content?: string }).content ?? ''));
 		} finally {
 			process.env.NODE_ENV = originalNodeEnv;
 		}
@@ -353,11 +349,7 @@ describe('HydrationAssetService', () => {
 				}),
 			} as any,
 			bundleService: {
-				getRuntimeImports: () => ({
-					react: 'react',
-					reactDomClient: 'react-dom/client',
-					router: undefined,
-				}),
+				getRuntimeImports: () => ({ ...productionRuntimeImports, router: undefined }),
 			} as any,
 		});
 
@@ -380,19 +372,17 @@ describe('HydrationAssetService', () => {
 			} as any,
 			bundleService: {
 				createBundleOptions: async () => ({}),
-				getRuntimeImports: () => ({
-					react: 'react',
-					reactDomClient: 'react-dom/client',
-					router: undefined,
-				}),
+				getRuntimeImports: () => ({ ...browserRuntimeImports, router: undefined }),
 			} as any,
 		});
 
 		const dependencies = await service.createPageBrowserGraphDependencies('/app/src/pages/index.tsx', false, []);
 
 		expect(dependencies[0]).toMatchObject({
+			bundle: false,
 			content: expect.stringContaining('const pageModuleUrl = "/assets/_hmr/pages/index.js";'),
 		});
+		assertNoBareEcopagesImports(String((dependencies[0] as { content?: string }).content ?? ''));
 	});
 
 	it('reuses the same bundled island asset for different component instances', async () => {
@@ -406,11 +396,7 @@ describe('HydrationAssetService', () => {
 			} as unknown as ConstructorParameters<typeof HydrationAssetService>[0]['assetProcessingService'],
 			bundleService: {
 				createBundleOptions,
-				getRuntimeImports: () => ({
-					react: 'react',
-					reactDomClient: 'react-dom/client',
-					router: undefined,
-				}),
+				getRuntimeImports: () => ({ ...productionRuntimeImports, router: undefined }),
 			} as unknown as ConstructorParameters<typeof HydrationAssetService>[0]['bundleService'],
 		});
 

--- a/packages/integrations/react/src/hydration/hydration-asset.ts
+++ b/packages/integrations/react/src/hydration/hydration-asset.ts
@@ -19,6 +19,7 @@ import {
 } from '@ecopages/core/services/asset-processing-service';
 import type { AssetProcessingService } from '@ecopages/core/services/asset-processing-service';
 import { createHydrationScript, createIslandHydrationScript } from './hydration-scripts.ts';
+import { resolveHydrationBootstrapImports } from './bootstrap-imports.ts';
 import { collectDeclaredModulesInConfig } from '../client-graph/declared-modules.ts';
 import type { BundleService } from '../bundling/bundle.ts';
 import type { HmrPageMetadataCache } from '../hmr/page-metadata-cache.ts';
@@ -116,8 +117,7 @@ export class HydrationAssetService {
 		/**
 		 * @remarks
 		 * Production router pages share a grouped bundle. Development HMR keeps each
-		 * page bootstrap independent so the hot page module URL stays external while
-		 * bare `@ecopages/*` helpers resolve through the browser bundler.
+		 * page bootstrap independent and unbundled; shared helpers resolve via vendor URLs.
 		 */
 		const groupedBundle =
 			!hmrEnabled && this.config.routerAdapter
@@ -126,28 +126,22 @@ export class HydrationAssetService {
 						entryName: this.getRouterPageGroupedEntryName(pagePath),
 					}
 				: undefined;
-		const existingExternal = Array.isArray(bundleOptions.external)
-			? bundleOptions.external.filter((value): value is string => typeof value === 'string')
-			: [];
-		const pageBootstrapBundleOptions = hmrEnabled
-			? {
-					...bundleOptions,
-					external: [...new Set([...existingExternal, importPath])],
-				}
-			: bundleOptions;
+		const bootstrapImports = resolveHydrationBootstrapImports({
+			useBrowserRuntimeImports,
+			runtimeImports,
+			routerAdapterImportPath: this.config.routerAdapter?.bundle.importPath,
+		});
 		return [
 			AssetFactory.createContentScript({
 				position: 'head',
 				content: createHydrationScript({
 					importPath: hmrEnabled ? importPath : pagePath,
 					pageModuleUrlExpression,
-					reactImportPath: useBrowserRuntimeImports ? runtimeImports.react : 'react',
-					reactDomClientImportPath: useBrowserRuntimeImports
-						? runtimeImports.reactDomClient
-						: 'react-dom/client',
-					routerImportPath: useBrowserRuntimeImports
-						? runtimeImports.router
-						: this.config.routerAdapter?.bundle.importPath,
+					reactImportPath: bootstrapImports.reactImportPath,
+					reactDomClientImportPath: bootstrapImports.reactDomClientImportPath,
+					routerImportPath: bootstrapImports.routerImportPath,
+					layoutComposeImportPath: bootstrapImports.layoutComposeImportPath,
+					pageLayoutNormalizationImportPath: bootstrapImports.pageLayoutNormalizationImportPath,
 					hmrEnabled,
 					isMdx,
 					router: this.config.routerAdapter,
@@ -157,14 +151,13 @@ export class HydrationAssetService {
 				packageRole: 'page-script',
 				/**
 				 * @remarks
-				 * Always bundle page bootstraps. Unbundled HMR entries are evaluated as
-				 * native browser ESM and cannot resolve bare package imports such as
-				 * `@ecopages/core/eco/page-layout-normalization` or
-				 * `@ecopages/react/layout-compose`.
+				 * HMR bootstraps stay unbundled write-through ESM. Helper imports must
+				 * already be browser-resolvable vendor URLs from
+				 * {@link resolveHydrationBootstrapImports}.
 				 */
-				bundle: true,
+				bundle: !hmrEnabled,
 				groupedBundle,
-				bundleOptions: pageBootstrapBundleOptions,
+				bundleOptions,
 				attributes: {
 					type: 'module',
 					defer: '',

--- a/packages/integrations/react/src/hydration/hydration-scripts.test.browser.ts
+++ b/packages/integrations/react/src/hydration/hydration-scripts.test.browser.ts
@@ -114,6 +114,10 @@ export function PageContent() {
 		reactImportPath,
 		reactDomClientImportPath,
 		routerImportPath,
+		layoutComposeImportPath: createModuleUrl('export function composeLayoutPageTree() { return null; }'),
+		pageLayoutNormalizationImportPath: createModuleUrl(
+			'export function ensurePageConfigLayouts(config) { return config; }',
+		),
 	};
 }
 

--- a/packages/integrations/react/src/hydration/hydration-scripts.test.ts
+++ b/packages/integrations/react/src/hydration/hydration-scripts.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest';
+import { assertNoBareEcopagesImports } from './assert-no-bare-ecopages-imports.ts';
 import { createHydrationScript, createIslandHydrationScript } from './hydration-scripts.ts';
 
 describe('createHydrationScript', () => {
@@ -7,12 +8,20 @@ describe('createHydrationScript', () => {
 		scriptId: 'ecopages-react-page',
 		reactImportPath: '/assets/react.js',
 		reactDomClientImportPath: '/assets/react-dom-client.js',
+		layoutComposeImportPath: '@ecopages/react/layout-compose',
+		pageLayoutNormalizationImportPath: '@ecopages/core/eco/page-layout-normalization',
 		isMdx: false,
+	};
+
+	const browserHelperImports = {
+		layoutComposeImportPath: '/assets/vendors/layout-compose.js',
+		pageLayoutNormalizationImportPath: '/assets/vendors/page-layout-normalization.js',
 	};
 
 	test('development output passes serialized locals to layout hydration for non-router pages', () => {
 		const script = createHydrationScript({
 			...baseOptions,
+			...browserHelperImports,
 			hmrEnabled: true,
 		});
 
@@ -29,25 +38,28 @@ describe('createHydrationScript', () => {
 		expect(script).toContain('const props = initialPageData.props;');
 		expect(script).toContain('window.__ECO_PAGES__.page = {');
 		expect(script).toContain('root.render(createTree(Page, props));');
-		expect(script).toContain('import { composeLayoutPageTree } from "@ecopages/react/layout-compose";');
+		expect(script).toContain('import { composeLayoutPageTree } from "/assets/vendors/layout-compose.js";');
 		expect(script).toContain('const createTree = (Component, props) => composeLayoutPageTree(Component, props);');
 		expect(script).toContain('window.__ECO_PAGES__.hmrHandlers');
+		assertNoBareEcopagesImports(script);
 	});
 
-	test('development MDX output emits layout helpers for the browser bundler to resolve', () => {
+	test('development MDX output emits vendor layout normalization imports', () => {
 		const script = createHydrationScript({
 			...baseOptions,
+			...browserHelperImports,
 			hmrEnabled: true,
 			isMdx: true,
 		});
 
-		expect(script).toContain('import { composeLayoutPageTree } from "@ecopages/react/layout-compose";');
+		expect(script).toContain('import { composeLayoutPageTree } from "/assets/vendors/layout-compose.js";');
 		expect(script).toContain(
-			'import { ensurePageConfigLayouts } from "@ecopages/core/eco/page-layout-normalization";',
+			'import { ensurePageConfigLayouts } from "/assets/vendors/page-layout-normalization.js";',
 		);
 		expect(script).toContain('import * as MDXModule from "/assets/page.js";');
 		expect(script).toContain('ensurePageConfigLayouts(Page.config);');
 		expect(script).toContain('const createTree = (Component, props) => composeLayoutPageTree(Component, props);');
+		assertNoBareEcopagesImports(script);
 	});
 
 	test('non-HMR output is readable and omits HMR handlers for non-router pages', () => {
@@ -72,6 +84,7 @@ describe('createHydrationScript', () => {
 	test('router development output exposes page-root cleanup before reuse', () => {
 		const script = createHydrationScript({
 			...baseOptions,
+			...browserHelperImports,
 			hmrEnabled: true,
 			router: {
 				name: 'eco-router',
@@ -108,6 +121,7 @@ describe('createHydrationScript', () => {
 		expect(script).not.toContain('@ecopages/react/page-data-reader');
 		expect(script).toContain('module: initialPageData.moduleUrl || pageModuleUrl');
 		expect(script).not.toContain('__ECO_PAGE_DATA_FALLBACK__');
+		assertNoBareEcopagesImports(script);
 	});
 
 	test('non-HMR output passes serialized locals to layout hydration for non-router MDX pages', () => {

--- a/packages/integrations/react/src/hydration/hydration-scripts.ts
+++ b/packages/integrations/react/src/hydration/hydration-scripts.ts
@@ -7,18 +7,11 @@
 import type { ReactRouterAdapter } from '../contracts/router-adapter.ts';
 import { getDevPageDataReaderBootstrapSource } from './page-data-reader.ts';
 
-const DEFAULT_LAYOUT_COMPOSE_IMPORT_PATH = '@ecopages/react/layout-compose';
-const PAGE_LAYOUT_NORMALIZATION_IMPORT = '@ecopages/core/eco/page-layout-normalization';
-
 function getPageDataReaderSource(options: HydrationScriptOptions): string {
 	if (options.pageDataReaderImportPath) {
 		return `import { readPageDataDocument, getPageDataFromDocument as getPageData } from "${options.pageDataReaderImportPath}";`;
 	}
 	return getDevPageDataReaderBootstrapSource();
-}
-
-function resolveLayoutComposeImportPath(options: HydrationScriptOptions): string {
-	return options.layoutComposeImportPath ?? DEFAULT_LAYOUT_COMPOSE_IMPORT_PATH;
 }
 
 /**
@@ -41,17 +34,30 @@ export type HydrationScriptOptions = {
 	 * When true, emit HMR registration and hot-reload handlers.
 	 *
 	 * @remarks
-	 * Page bootstraps are always bundled so bare package imports resolve through
-	 * the browser build pipeline. When false, this generator emits the same
-	 * readable bootstrap without HMR hooks.
+	 * HMR page bootstraps stay unbundled and evaluate as native browser ESM.
+	 * Callers must supply browser-resolvable import paths (shared vendor URLs)
+	 * so generated source does not emit bare `@ecopages/*` imports. When false,
+	 * this generator emits the same readable bootstrap without HMR hooks.
 	 */
 	hmrEnabled: boolean;
 	/** Whether the source file is an MDX file */
 	isMdx: boolean;
 	/** Optional router adapter for SPA navigation */
 	router?: ReactRouterAdapter;
-	/** Import path for shared layout composition helper */
-	layoutComposeImportPath?: string;
+	/**
+	 * Import path for shared layout composition helper.
+	 *
+	 * @remarks
+	 * Required so callers (not this generator) decide vendor URL vs bare package.
+	 */
+	layoutComposeImportPath: string;
+	/**
+	 * Import path for MDX page layout normalization helper.
+	 *
+	 * @remarks
+	 * Required so callers (not this generator) decide vendor URL vs bare package.
+	 */
+	pageLayoutNormalizationImportPath: string;
 	/**
 	 * Optional import path for the page-data reader.
 	 *
@@ -95,10 +101,10 @@ export type IslandHydrationScriptOptions = {
  * MDX pages need a namespace import so `config` can be copied onto the default
  * export before layout normalization runs.
  */
-function getImportStatement(importPath: string, isMdx: boolean): string {
+function getImportStatement(importPath: string, isMdx: boolean, pageLayoutNormalizationImportPath: string): string {
 	return isMdx
 		? `import * as MDXModule from "${importPath}";
-import { ensurePageConfigLayouts } from "${PAGE_LAYOUT_NORMALIZATION_IMPORT}";
+import { ensurePageConfigLayouts } from "${pageLayoutNormalizationImportPath}";
 const Page = MDXModule.default;
 if (MDXModule.config) {
   Page.config = MDXModule.config;
@@ -273,6 +279,7 @@ function createScriptWithRouter(options: HydrationScriptOptions): string {
 		throw new Error('routerImportPath is required when router adapter is configured');
 	}
 
+	const pageLayoutNormalizationImportPath = options.pageLayoutNormalizationImportPath;
 	const hmrInit = hmrEnabled
 		? `window.__ECO_PAGES__.hmrHandlers = window.__ECO_PAGES__.hmrHandlers || {};
 `
@@ -284,7 +291,7 @@ import { hydrateRoot } from "${reactDomClientImportPath}";
 import { createElement } from "${reactImportPath}";
 import { ${components.router}, ${components.pageContent} } from "${routerImportPath}";
 ${getPageDataReaderSource(options)}
-${getImportStatement(importPath, isMdx)}
+${getImportStatement(importPath, isMdx, pageLayoutNormalizationImportPath)}
 const pageModuleUrl = ${pageModuleUrlExpression};
 export default Page;
 export const config = Page.config;
@@ -359,7 +366,8 @@ if (document.readyState === "loading") {
 function createScriptWithoutRouter(options: HydrationScriptOptions): string {
 	const { importPath, isMdx, reactImportPath, reactDomClientImportPath, scriptId, hmrEnabled } = options;
 	const pageModuleUrlExpression = options.pageModuleUrlExpression ?? 'import.meta.url';
-	const layoutComposeImportPath = resolveLayoutComposeImportPath(options);
+	const layoutComposeImportPath = options.layoutComposeImportPath;
+	const pageLayoutNormalizationImportPath = options.pageLayoutNormalizationImportPath;
 
 	const hmrInit = hmrEnabled
 		? `window.__ECO_PAGES__.hmrHandlers = window.__ECO_PAGES__.hmrHandlers || {};
@@ -372,7 +380,7 @@ import { hydrateRoot } from "${reactDomClientImportPath}";
 import { createElement } from "${reactImportPath}";
 import { composeLayoutPageTree } from "${layoutComposeImportPath}";
 ${getPageDataReaderSource(options)}
-${getImportStatement(importPath, isMdx)}
+${getImportStatement(importPath, isMdx, pageLayoutNormalizationImportPath)}
 const pageModuleUrl = ${pageModuleUrlExpression};
 export default Page;
 export const config = Page.config;

--- a/packages/processors/postcss-processor/src/test/presets.test.ts
+++ b/packages/processors/postcss-processor/src/test/presets.test.ts
@@ -129,7 +129,7 @@ describe('Presets Verification', () => {
 
 		expect(result.length).toBeGreaterThan(0);
 		expect(result).toContain('--tw-');
-	});
+	}, 30_000);
 });
 
 test('Tailwind v4 preset should support nesting', async () => {
@@ -214,7 +214,7 @@ test('Tailwind v4 preset should preserve nested BEM selectors with @apply in pro
 			process.env.NODE_ENV = originalNodeEnv;
 		}
 	}
-});
+}, 30_000);
 
 describe('Tailwind v4 transformInput', () => {
 	const referencePath = '/abs/path/src/styles/tailwind.css';


### PR DESCRIPTION
## Summary
- Restore `bundle: !hmrEnabled` for React page bootstraps so dev page opens stay write-through ESM instead of per-page `Bun.build`
- Ship `page-layout-normalization` and `layout-compose` as shared `/assets/vendors/*` runtime assets, resolved through `resolveHydrationBootstrapImports`
- Raise kitchen-sink Tailwind preset test timeouts so full-suite load no longer flakes at 5s

## Test plan
- [x] `pnpm test:vitest` (pre-commit)
- [x] Kitchen-sink React MDX cold-load (`/react-content`) — no bare `@ecopages/*` in bootstrap
- [x] Confirm first open of a React page in `ecopages dev` does not content-script-bundle the page bootstrap