### PR TITLE
perf(core): warm integration vendors off first-page path

### DIFF
--- a/packages/core/src/adapters/bun/server-adapter.ts
+++ b/packages/core/src/adapters/bun/server-adapter.ts
@@ -37,6 +37,7 @@ import {
 	disposeDevResources,
 	maybeInjectAdapterHmrHtmlResponse,
 	prepareRuntimePublicDir,
+	startConfiguredIntegrationRuntimePrewarm,
 } from '../shared/runtime-server-lifecycle.ts';
 import { ClientBridge } from './client-bridge.ts';
 import { setAppDevClientBridge } from '../../dev/client-bridge-registry.ts';
@@ -691,6 +692,10 @@ export class BunServerAdapter extends SharedServerAdapter<BunServerAdapterParams
 
 		if (this.options?.watch) {
 			await this.hmrManager.ensureRuntimeReady();
+			startConfiguredIntegrationRuntimePrewarm({
+				appConfig: this.appConfig,
+				runtimeOrigin: this.runtimeOrigin,
+			});
 		}
 
 		this.fullyInitialized = true;

--- a/packages/core/src/adapters/node/server-adapter.ts
+++ b/packages/core/src/adapters/node/server-adapter.ts
@@ -24,6 +24,7 @@ import {
 	disposeDevResources,
 	maybeInjectAdapterHmrHtmlResponse,
 	prepareRuntimePublicDir,
+	startConfiguredIntegrationRuntimePrewarm,
 } from '../shared/runtime-server-lifecycle.ts';
 import { resolveServeRuntimeOrigin } from '../shared/runtime-app-bootstrap.ts';
 import { NodeClientAbortError, NodeHttpRequestBridge } from './http-request-bridge.ts';
@@ -409,6 +410,10 @@ export class NodeServerAdapter extends SharedServerAdapter<NodeServerAdapterPara
 			}
 
 			attachHmrToIntegrations(this.appConfig, this.hmrManager);
+			startConfiguredIntegrationRuntimePrewarm({
+				appConfig: this.appConfig,
+				runtimeOrigin: this.runtimeOrigin,
+			});
 
 			this.configureSharedResponseHandlers(this.staticRoutes, this.hmrManager);
 

--- a/packages/core/src/adapters/shared/runtime-server-lifecycle.test.ts
+++ b/packages/core/src/adapters/shared/runtime-server-lifecycle.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { test, vi } from 'vitest';
+import { appLogger } from '../../global/app-logger.ts';
+import * as appBuildManifestRuntime from '../../build/app-build-manifest-runtime.ts';
+import { startConfiguredIntegrationRuntimePrewarm } from './runtime-server-lifecycle.ts';
+
+test('startConfiguredIntegrationRuntimePrewarm activates every configured integration', async () => {
+	const ensureSpy = vi.spyOn(appBuildManifestRuntime, 'ensureIntegrationRuntimeReady').mockResolvedValue(undefined);
+
+	const appConfig = {
+		integrations: [{ name: 'react' }, { name: 'lit' }],
+	} as any;
+
+	startConfiguredIntegrationRuntimePrewarm({
+		appConfig,
+		runtimeOrigin: 'http://localhost:3000',
+	});
+
+	await vi.waitFor(() => {
+		assert.equal(ensureSpy.mock.calls.length, 2);
+	});
+
+	assert.deepEqual(
+		ensureSpy.mock.calls.map(([options]) => options.integrationName),
+		['react', 'lit'],
+	);
+
+	ensureSpy.mockRestore();
+});
+
+test('startConfiguredIntegrationRuntimePrewarm logs failures without throwing', async () => {
+	const ensureSpy = vi
+		.spyOn(appBuildManifestRuntime, 'ensureIntegrationRuntimeReady')
+		.mockRejectedValue(new Error('prewarm failed'));
+	const errorSpy = vi.spyOn(appLogger, 'error').mockImplementation(() => appLogger);
+
+	const appConfig = {
+		integrations: [{ name: 'react' }],
+	} as any;
+
+	startConfiguredIntegrationRuntimePrewarm({
+		appConfig,
+		runtimeOrigin: 'http://localhost:3000',
+	});
+
+	await vi.waitFor(() => {
+		assert.equal(errorSpy.mock.calls.length, 1);
+	});
+
+	assert.match(String(errorSpy.mock.calls[0]?.[0]), /Failed to prewarm integration runtimes/);
+
+	ensureSpy.mockRestore();
+	errorSpy.mockRestore();
+});

--- a/packages/core/src/adapters/shared/runtime-server-lifecycle.ts
+++ b/packages/core/src/adapters/shared/runtime-server-lifecycle.ts
@@ -4,6 +4,8 @@ import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 import type { IHmrManager } from '../../types/public-types.ts';
 import { RESOLVED_ASSETS_DIR } from '../../config/constants.ts';
 import { disposeAppBuildRuntime } from '../../build/runtime/build-runtime.ts';
+import { ensureIntegrationRuntimeReady } from '../../build/app-build-manifest-runtime.ts';
+import { appLogger } from '../../global/app-logger.ts';
 import type { ProjectWatcher } from '../../watchers/project-watcher.ts';
 import { copyRuntimePublicDirIfChanged } from './copy-runtime-public-dir.ts';
 import { clearAppDevClientBridge } from '../../dev/client-bridge-registry.ts';
@@ -49,6 +51,35 @@ export function attachHmrToIntegrations(appConfig: EcoPagesAppConfig, hmrManager
  */
 export function wireIntegrationHmrManagers(appConfig: EcoPagesAppConfig, hmrManager: IHmrManager): void {
 	attachHmrToIntegrations(appConfig, hmrManager);
+}
+
+/**
+ * Starts background activation of every configured integration after watch-mode HMR is ready.
+ *
+ * @remarks
+ * Fire-and-forget: overlaps with watcher setup so first-page render can join the same
+ * coalesced {@link ensureIntegrationRuntimeReady} promise instead of paying a cold vendor build.
+ * Failures are logged and do not crash the server.
+ */
+export function startConfiguredIntegrationRuntimePrewarm(options: {
+	appConfig: EcoPagesAppConfig;
+	runtimeOrigin: string;
+}): void {
+	const { appConfig, runtimeOrigin } = options;
+
+	void Promise.all(
+		appConfig.integrations.map((integration) =>
+			ensureIntegrationRuntimeReady({
+				appConfig,
+				integrationName: integration.name,
+				runtimeOrigin,
+			}),
+		),
+	).catch((error) => {
+		appLogger.error(
+			`Failed to prewarm integration runtimes: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	});
 }
 
 /**

--- a/packages/core/src/build/app-build-manifest-runtime.ts
+++ b/packages/core/src/build/app-build-manifest-runtime.ts
@@ -142,6 +142,10 @@ export async function setupAppRuntimePlugins(options: {
 
 /**
  * Activates one integration's runtime setup on first use.
+ *
+ * @remarks
+ * Concurrent callers share a single in-flight promise per integration name.
+ * Failed activations are evicted so a later caller can retry.
  */
 export async function ensureIntegrationRuntimeReady(options: {
 	appConfig: EcoPagesAppConfig;
@@ -151,9 +155,11 @@ export async function ensureIntegrationRuntimeReady(options: {
 }): Promise<void> {
 	const runtime = options.appConfig.runtime ?? {};
 	options.appConfig.runtime = runtime;
-	runtime.activatedIntegrations ??= new Set<string>();
+	runtime.integrationActivations ??= new Map<string, Promise<void>>();
 
-	if (runtime.activatedIntegrations.has(options.integrationName)) {
+	const existing = runtime.integrationActivations.get(options.integrationName);
+	if (existing) {
+		await existing;
 		return;
 	}
 
@@ -162,14 +168,23 @@ export async function ensureIntegrationRuntimeReady(options: {
 		return;
 	}
 
-	integration.setConfig(options.appConfig);
-	integration.setRuntimeOrigin(options.runtimeOrigin);
-	await integration.setup();
+	const activation = (async () => {
+		integration.setConfig(options.appConfig);
+		integration.setRuntimeOrigin(options.runtimeOrigin);
+		await integration.setup();
 
-	const onRuntimePlugin = options.onRuntimePlugin ?? options.appConfig.runtime?.onRuntimePlugin;
-	for (const plugin of integration.plugins ?? []) {
-		onRuntimePlugin?.(plugin);
+		const onRuntimePlugin = options.onRuntimePlugin ?? options.appConfig.runtime?.onRuntimePlugin;
+		for (const plugin of integration.plugins ?? []) {
+			onRuntimePlugin?.(plugin);
+		}
+	})();
+
+	runtime.integrationActivations.set(options.integrationName, activation);
+
+	try {
+		await activation;
+	} catch (error) {
+		runtime.integrationActivations.delete(options.integrationName);
+		throw error;
 	}
-
-	runtime.activatedIntegrations.add(options.integrationName);
 }

--- a/packages/core/src/build/build-adapter.test.ts
+++ b/packages/core/src/build/build-adapter.test.ts
@@ -473,7 +473,78 @@ test('ensureIntegrationRuntimeReady activates one integration exactly once', asy
 	});
 
 	assert.equal(integration.setup.mock.calls.length, 1);
-	assert.equal(appConfig.runtime?.activatedIntegrations?.has('react'), true);
+	assert.ok(appConfig.runtime?.integrationActivations?.has('react'));
+});
+
+test('ensureIntegrationRuntimeReady coalesces concurrent callers to one setup', async () => {
+	let resolveSetup!: () => void;
+	const setupGate = new Promise<void>((resolve) => {
+		resolveSetup = resolve;
+	});
+	const integration = {
+		name: 'react',
+		plugins: [],
+		setConfig: vi.fn(),
+		setRuntimeOrigin: vi.fn(),
+		setup: vi.fn(async () => {
+			await setupGate;
+		}),
+	};
+
+	const appConfig = {
+		integrations: [integration],
+	} as any;
+
+	const first = ensureIntegrationRuntimeReady({
+		appConfig,
+		integrationName: 'react',
+		runtimeOrigin: 'http://localhost:3000',
+	});
+	const second = ensureIntegrationRuntimeReady({
+		appConfig,
+		integrationName: 'react',
+		runtimeOrigin: 'http://localhost:3000',
+	});
+
+	assert.equal(integration.setup.mock.calls.length, 1);
+	resolveSetup();
+	await Promise.all([first, second]);
+	assert.equal(integration.setup.mock.calls.length, 1);
+});
+
+test('ensureIntegrationRuntimeReady evicts failed activation so a later caller can retry', async () => {
+	const integration = {
+		name: 'react',
+		plugins: [],
+		setConfig: vi.fn(),
+		setRuntimeOrigin: vi.fn(),
+		setup: vi.fn().mockRejectedValueOnce(new Error('setup failed')).mockResolvedValueOnce(undefined),
+	};
+
+	const appConfig = {
+		integrations: [integration],
+	} as any;
+
+	await assert.rejects(
+		() =>
+			ensureIntegrationRuntimeReady({
+				appConfig,
+				integrationName: 'react',
+				runtimeOrigin: 'http://localhost:3000',
+			}),
+		/setup failed/,
+	);
+
+	assert.equal(appConfig.runtime?.integrationActivations?.has('react'), false);
+
+	await ensureIntegrationRuntimeReady({
+		appConfig,
+		integrationName: 'react',
+		runtimeOrigin: 'http://localhost:3000',
+	});
+
+	assert.equal(integration.setup.mock.calls.length, 2);
+	assert.ok(appConfig.runtime?.integrationActivations?.has('react'));
 });
 
 test('setupAppRuntimePlugins skips processor setup in Lit static-render worker threads', async () => {

--- a/packages/core/src/types/internal-types.ts
+++ b/packages/core/src/types/internal-types.ts
@@ -178,8 +178,14 @@ export type EcoPagesAppConfig = {
 		runtimeAssetsPrepared?: boolean;
 		/** Registers integration runtime plugins when lazy activation completes. */
 		onRuntimePlugin?: (plugin: import('../build/contracts/build-types.ts').EcoBuildPlugin) => void;
-		/** Integration names that completed lazy runtime activation. */
-		activatedIntegrations?: Set<string>;
+		/**
+		 * In-flight or completed lazy integration activation promises, keyed by integration name.
+		 *
+		 * @remarks
+		 * Concurrent callers (background prewarm + first render) share the same promise.
+		 * Failed activations are removed so a later caller can retry.
+		 */
+		integrationActivations?: Map<string, Promise<void>>;
 		/** When `'host'`, the embedded dev server owns browser dev-client bootstrap. */
 		devClientOwner?: 'core' | 'host';
 		/** Integration hooks run when a registered `dependencies.scripts` entrypoint changes. */

--- a/packages/integrations/react/src/bundling/bundle.test.ts
+++ b/packages/integrations/react/src/bundling/bundle.test.ts
@@ -2,8 +2,9 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { EcoPagesAppConfig } from '@ecopages/core';
+import type { AssetProcessingService } from '@ecopages/core/services/asset-processing-service';
 import type { EcoBuildOnLoadResult } from '@ecopages/core/build/build-types';
 import { BundleService } from './bundle.ts';
 import { resolveReactPluginRuntimeModules } from './runtime-modules.ts';
@@ -236,5 +237,43 @@ describe('BundleService', () => {
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
+	});
+
+	it('processes page-layout-normalization vendor once for concurrent MDX callers', async () => {
+		const service = new BundleService({
+			rootDir: '/app',
+			appConfig: testAppConfig,
+			hostIntegrationName: 'react',
+		});
+		let resolveProcess!: () => void;
+		const processGate = new Promise<void>((resolve) => {
+			resolveProcess = resolve;
+		});
+		const processDependencies = vi.fn(async () => {
+			await processGate;
+			return [];
+		});
+		const assetProcessingService = {
+			processDependencies,
+		} satisfies Pick<AssetProcessingService, 'processDependencies'>;
+
+		const first = service.ensurePageLayoutNormalizationVendorProcessed(assetProcessingService);
+		const second = service.ensurePageLayoutNormalizationVendorProcessed(assetProcessingService);
+
+		expect(processDependencies).toHaveBeenCalledTimes(1);
+		expect(processDependencies).toHaveBeenCalledWith(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: 'page-layout-normalization',
+				}),
+			]),
+			'react:page-layout-normalization',
+		);
+
+		resolveProcess();
+		await Promise.all([first, second]);
+
+		await service.ensurePageLayoutNormalizationVendorProcessed(assetProcessingService);
+		expect(processDependencies).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/integrations/react/src/bundling/bundle.ts
+++ b/packages/integrations/react/src/bundling/bundle.ts
@@ -12,6 +12,7 @@ import { getReactClientGraphAllowSpecifiers, getReactRuntimeExternalSpecifiers }
 import { createBrowserRuntimePlugin } from '@ecopages/core/build/browser-runtime-plugin';
 import { getHostScopedJsxOwnershipPlugins } from '@ecopages/core/build/jsx-ownership-plugins';
 import type { EcoPagesAppConfig } from '@ecopages/core';
+import type { AssetProcessingService } from '@ecopages/core/services/asset-processing-service';
 import type { ReactRouterAdapter } from '../contracts/router-adapter.ts';
 import type { CompileOptions } from '@mdx-js/mdx';
 import { RuntimeBundleService, type ReactRuntimeImports } from './runtime-bundle.ts';
@@ -52,6 +53,7 @@ export interface ReactClientBundleOptions {
 export class BundleService {
 	private readonly runtimeBundleService: RuntimeBundleService;
 	private readonly config: BundleServiceConfig;
+	private pageLayoutNormalizationVendorPromise: Promise<void> | undefined;
 
 	constructor(config: BundleServiceConfig) {
 		this.config = config;
@@ -67,6 +69,32 @@ export class BundleService {
 	 */
 	getRuntimeImports(): ReactRuntimeImports {
 		return this.runtimeBundleService.getRuntimeImports();
+	}
+
+	/**
+	 * Processes the MDX-only page-layout-normalization vendor once per BundleService instance.
+	 *
+	 * @remarks
+	 * Concurrent callers share the same in-flight promise. Asset processing itself caches
+	 * by dependency key, so repeats after success remain cheap.
+	 */
+	async ensurePageLayoutNormalizationVendorProcessed(
+		assetProcessingService: Pick<AssetProcessingService, 'processDependencies'>,
+	): Promise<void> {
+		if (!this.pageLayoutNormalizationVendorPromise) {
+			this.pageLayoutNormalizationVendorPromise = assetProcessingService
+				.processDependencies(
+					this.runtimeBundleService.getPageLayoutNormalizationDependencies(),
+					'react:page-layout-normalization',
+				)
+				.then(() => undefined)
+				.catch((error) => {
+					this.pageLayoutNormalizationVendorPromise = undefined;
+					throw error;
+				});
+		}
+
+		await this.pageLayoutNormalizationVendorPromise;
 	}
 
 	/**

--- a/packages/integrations/react/src/bundling/runtime-bundle.test.ts
+++ b/packages/integrations/react/src/bundling/runtime-bundle.test.ts
@@ -96,13 +96,6 @@ describe('RuntimeBundleService', () => {
 					}),
 				}),
 				expect.objectContaining({
-					name: 'page-layout-normalization',
-					importPath: '@ecopages/core/eco/page-layout-normalization',
-					bundleOptions: expect.objectContaining({
-						naming: 'page-layout-normalization.development.js',
-					}),
-				}),
-				expect.objectContaining({
 					name: 'layout-compose',
 					importPath: '@ecopages/react/layout-compose',
 					bundleOptions: expect.objectContaining({
@@ -125,6 +118,18 @@ describe('RuntimeBundleService', () => {
 				}),
 			]),
 		);
+		expect(
+			dependencies.some((dependency) => 'name' in dependency && dependency.name === 'page-layout-normalization'),
+		).toBe(false);
+		expect(service.getPageLayoutNormalizationDependencies()).toEqual([
+			expect.objectContaining({
+				name: 'page-layout-normalization',
+				importPath: '@ecopages/core/eco/page-layout-normalization',
+				bundleOptions: expect.objectContaining({
+					naming: 'page-layout-normalization.development.js',
+				}),
+			}),
+		]);
 		expect(
 			dependencies.some(
 				(dependency) =>

--- a/packages/integrations/react/src/bundling/runtime-bundle.ts
+++ b/packages/integrations/react/src/bundling/runtime-bundle.ts
@@ -259,15 +259,6 @@ export class RuntimeBundleService {
 					},
 				}),
 				createBrowserRuntimeScriptAsset({
-					importPath: PAGE_LAYOUT_NORMALIZATION_PACKAGE,
-					name: 'page-layout-normalization',
-					fileName: this.getPageLayoutNormalizationVendorFileName(mode),
-					bundleOptions: {
-						define: this.createRuntimeDefines(mode),
-						excludeAppBuildPlugins: [DEFAULT_BROWSER_RUNTIME_PLUGIN_NAME],
-					},
-				}),
-				createBrowserRuntimeScriptAsset({
 					importPath: LAYOUT_COMPOSE_PACKAGE,
 					name: 'layout-compose',
 					fileName: this.getLayoutComposeVendorFileName(mode),
@@ -316,6 +307,34 @@ export class RuntimeBundleService {
 					}),
 				);
 			}
+		}
+
+		return dependencies;
+	}
+
+	/**
+	 * Declares the MDX-only page-layout-normalization vendor for the current runtime mode.
+	 *
+	 * @remarks
+	 * Kept out of {@link getDependencies} so non-MDX pages do not pay for this vendor during
+	 * integration setup. Callers process these assets once when an MDX page graph is prepared.
+	 */
+	getPageLayoutNormalizationDependencies(options?: { modes?: RuntimeMode[] }): AssetDefinition[] {
+		const dependencies: AssetDefinition[] = [];
+		const modes = options?.modes ?? [this.getCurrentRuntimeMode()];
+
+		for (const mode of modes) {
+			dependencies.push(
+				createBrowserRuntimeScriptAsset({
+					importPath: PAGE_LAYOUT_NORMALIZATION_PACKAGE,
+					name: 'page-layout-normalization',
+					fileName: this.getPageLayoutNormalizationVendorFileName(mode),
+					bundleOptions: {
+						define: this.createRuntimeDefines(mode),
+						excludeAppBuildPlugins: [DEFAULT_BROWSER_RUNTIME_PLUGIN_NAME],
+					},
+				}),
+			);
 		}
 
 		return dependencies;

--- a/packages/integrations/react/src/render/react-renderer.ts
+++ b/packages/integrations/react/src/render/react-renderer.ts
@@ -341,22 +341,24 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 
 			const isMdx = this.pageModuleService.isMdxFile(pagePath);
 			const declaredModules = this.pageModuleService.collectPageDeclaredModules(pageModule);
+
+			if (isMdx) {
+				await this.bundleService.ensurePageLayoutNormalizationVendorProcessed(this.assetProcessingService);
+			}
+
 			const dependencies = await this.hydrationAssetService.createPageBrowserGraphDependencies(
 				pagePath,
 				isMdx,
 				declaredModules,
 			);
-			const assets: ProcessedAsset[] = [];
-
-			if (isMdx) {
-				const mdxConfigAssets = await this.mdxConfigDependencyService.processMdxConfigDependencies({
-					pagePath,
-					config: (pageModule as EcoPageFile & { config?: EcoComponentConfig }).config,
-					processComponentDependencies: async (components) =>
-						await this.processComponentDependencies(components),
-				});
-				assets.push(...mdxConfigAssets);
-			}
+			const assets: ProcessedAsset[] = isMdx
+				? await this.mdxConfigDependencyService.processMdxConfigDependencies({
+						pagePath,
+						config: (pageModule as EcoPageFile & { config?: EcoComponentConfig }).config,
+						processComponentDependencies: async (components) =>
+							await this.processComponentDependencies(components),
+					})
+				: [];
 
 			return { dependencies, assets };
 		} catch (error) {

--- a/packages/integrations/react/src/test/react-renderer.test.tsx
+++ b/packages/integrations/react/src/test/react-renderer.test.tsx
@@ -626,6 +626,44 @@ describe('ReactRenderer', () => {
 		expect(withForceSpy).toHaveBeenCalledWith(pageFilePath, false, []);
 	});
 
+	it('ensures page-layout-normalization vendor only for MDX page graphs', async () => {
+		const tsxRenderer = createRenderer({ forceBrowserGraph: true });
+		const mdxAssetProcessingService = createAssetProcessingServiceMock();
+		const mdxRenderer = new TestReactRenderer({
+			appConfig: Config,
+			assetProcessingService: mdxAssetProcessingService as any,
+			runtimeOrigin: 'http://localhost:3000',
+			resolvedIntegrationDependencies: [],
+			reactConfig: {
+				forceBrowserGraph: true,
+				mdxExtensions: ['.mdx'],
+			},
+		});
+		const pageModule = {
+			default: Page,
+			config: {},
+		} as EcoPageFile;
+
+		vi.spyOn(tsxRenderer.hydrationAssetService, 'createPageBrowserGraphDependencies').mockResolvedValue([]);
+		vi.spyOn(mdxRenderer.hydrationAssetService, 'createPageBrowserGraphDependencies').mockResolvedValue([]);
+		const tsxEnsureSpy = vi
+			.spyOn(tsxRenderer.bundleService, 'ensurePageLayoutNormalizationVendorProcessed')
+			.mockResolvedValue(undefined);
+		const mdxEnsureSpy = vi
+			.spyOn(mdxRenderer.bundleService, 'ensurePageLayoutNormalizationVendorProcessed')
+			.mockResolvedValue(undefined);
+
+		tsxRenderer.isMdxFileOverride = false;
+		mdxRenderer.isMdxFileOverride = true;
+
+		await tsxRenderer.testCollectPageBrowserGraphContribution(pageFilePath, pageModule);
+		await mdxRenderer.testCollectPageBrowserGraphContribution('/app/src/pages/guide.mdx', pageModule);
+
+		expect(tsxEnsureSpy).not.toHaveBeenCalled();
+		expect(mdxEnsureSpy).toHaveBeenCalledTimes(1);
+		expect(mdxEnsureSpy).toHaveBeenCalledWith(mdxAssetProcessingService);
+	});
+
 	it('should emit canonical page data for router-backed pages inside non-react html templates', async () => {
 		const testRenderer = createRenderer({ routerAdapter: mockRouterAdapter });
 		testRenderer.htmlTemplate = NonReactHtmlTemplate as unknown as EcoComponent<HtmlTemplateProps>;


### PR DESCRIPTION
## Summary

Move React integration vendor builds off the first-page critical path by coalescing lazy activation, background-prewarming after HMR is ready, and deferring `page-layout-normalization` to MDX page graphs only.

## What changed

- Replace `activatedIntegrations` with a coalesced `integrationActivations` promise map (prewarm + first render share one `setup()`).
- Add `startConfiguredIntegrationRuntimePrewarm` in shared runtime lifecycle; wire it from Node and Bun watch init after HMR is attached.
- Remove `page-layout-normalization` from default React runtime vendors; ensure it from `ReactRenderer` only when preparing MDX page browser graphs.

## How to verify

1. Run `pnpm --filter @ecopages/core test` and `pnpm --filter @ecopages/react typecheck`.
2. Start kitchen-sink with `ecopages dev` and open a TSX React page first — `page-layout-normalization` should not build during integration setup.
3. Open an MDX React page — normalization vendor builds once; HMR bootstraps stay unbundled.
4. Confirm a second open of either route stays fast (cached vendors).