### PR TITLE
feat(hmr): prewarm React client graph in dev

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to `@ecopages/core` are documented here.
 
 ### Features
 
+- Added dev HMR entrypoint disk cache, in-flight registration coalescing, and integration hooks for cold client-graph prewarm (`ECOPAGES_DEV_COLD_CLIENT_GRAPH`, `ECOPAGES_DEV_COLD_CLIENT_GRAPH_BLOCKING`).
 - Added nested `layout` arrays on `eco.page()` with normalization to `config.layouts` / `config.layoutEntries`.
 - Added `composeChildren` hook on `composeDocumentShell` for integration-owned unified layout+page composition.
 - Added `EcoDeclaredComponent` validation for `dependencies.components` entries.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -216,6 +216,10 @@
 			"types": "./src/build/cache/production-build-cache.ts",
 			"default": "./src/build/cache/production-build-cache.ts"
 		},
+		"./build/dev-hmr-entrypoint-cache": {
+			"types": "./src/build/cache/dev-hmr-entrypoint-cache.ts",
+			"default": "./src/build/cache/dev-hmr-entrypoint-cache.ts"
+		},
 		"./build/server-entry-build-cache": {
 			"types": "./src/build/cache/server-entry-build-cache.ts",
 			"default": "./src/build/cache/server-entry-build-cache.ts"

--- a/packages/core/src/adapters/bun/server-adapter.ts
+++ b/packages/core/src/adapters/bun/server-adapter.ts
@@ -34,8 +34,10 @@ import { createEcopagesSocket } from '../shared/ws/websocket-lifecycle.ts';
 import { resolveServeRuntimeOrigin } from '../shared/runtime/runtime-app-bootstrap.ts';
 import {
 	attachHmrToIntegrations,
+	awaitConfiguredClientGraphPrewarm,
 	disposeDevResources,
 	prepareRuntimePublicDir,
+	startConfiguredClientGraphPrewarm,
 	startConfiguredIntegrationRuntimePrewarm,
 } from '../shared/runtime/runtime-server-lifecycle.ts';
 import { ClientBridge } from './client-bridge.ts';
@@ -643,6 +645,12 @@ export class BunServerAdapter extends SharedServerAdapter<BunServerAdapterParams
 				appConfig: this.appConfig,
 				runtimeOrigin: this.runtimeOrigin,
 			});
+			startConfiguredClientGraphPrewarm({
+				appConfig: this.appConfig,
+				templateRouteFilePaths: this.router.templateRoutes.map((route) => route.filePath),
+				hmrEnabled: true,
+			});
+			await awaitConfiguredClientGraphPrewarm(this.appConfig);
 		}
 
 		this.fullyInitialized = true;

--- a/packages/core/src/adapters/node/server-adapter.ts
+++ b/packages/core/src/adapters/node/server-adapter.ts
@@ -21,8 +21,10 @@ import { ServerStaticBuilder } from '../shared/runtime/server-static-builder.ts'
 import { DEFAULT_ECOPAGES_HOSTNAME, DEFAULT_ECOPAGES_PORT } from '../../config/constants.ts';
 import {
 	attachHmrToIntegrations,
+	awaitConfiguredClientGraphPrewarm,
 	disposeDevResources,
 	prepareRuntimePublicDir,
+	startConfiguredClientGraphPrewarm,
 	startConfiguredIntegrationRuntimePrewarm,
 } from '../shared/runtime/runtime-server-lifecycle.ts';
 import { resolveServeRuntimeOrigin } from '../shared/runtime/runtime-app-bootstrap.ts';
@@ -405,6 +407,12 @@ export class NodeServerAdapter extends SharedServerAdapter<NodeServerAdapterPara
 				appConfig: this.appConfig,
 				runtimeOrigin: this.runtimeOrigin,
 			});
+			startConfiguredClientGraphPrewarm({
+				appConfig: this.appConfig,
+				templateRouteFilePaths: this.router.templateRoutes.map((route) => route.filePath),
+				hmrEnabled: true,
+			});
+			await awaitConfiguredClientGraphPrewarm(this.appConfig);
 
 			this.configureSharedResponseHandlers(this.staticRoutes, this.hmrManager);
 

--- a/packages/core/src/adapters/shared/hmr/hmr-entrypoint-registrar.test.ts
+++ b/packages/core/src/adapters/shared/hmr/hmr-entrypoint-registrar.test.ts
@@ -140,3 +140,49 @@ test('seedResolvedEntrypoint registers without invoking emit', async () => {
 
 	assert.equal(emitCalls, 0);
 });
+
+test('trackInFlightEntrypoint coalesces concurrent registerEntrypoint callers', async () => {
+	const rootDir = createTempRoot('hmr-registrar-inflight');
+	const srcDir = path.join(rootDir, 'src');
+	const distDir = path.join(rootDir, '.eco', 'assets', '_hmr');
+	fs.mkdirSync(srcDir, { recursive: true });
+	fs.mkdirSync(distDir, { recursive: true });
+
+	const entrypointPath = path.join(srcDir, 'inflight.tsx');
+	fs.writeFileSync(entrypointPath, 'export {}', 'utf8');
+	const outputPath = path.join(distDir, 'pages', 'inflight.js');
+	fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+
+	const registrar = new HmrEntrypointRegistrar({ srcDir, distDir });
+	let emitCalls = 0;
+	const sharedPromise = (async () => {
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		fs.writeFileSync(outputPath, 'bundled', 'utf8');
+		return {
+			sourcePath: entrypointPath,
+			outputPath,
+			outputUrl: '/assets/_hmr/pages/inflight.js',
+		};
+	})();
+
+	registrar.trackInFlightEntrypoint(entrypointPath, sharedPromise);
+
+	const [first, second] = await Promise.all([
+		registrar.registerEntrypoint(entrypointPath, {
+			emit: async () => {
+				emitCalls += 1;
+			},
+			getMissingOutputError: (source, output) => new Error(`missing ${source} -> ${output}`),
+		}),
+		registrar.registerEntrypoint(entrypointPath, {
+			emit: async () => {
+				emitCalls += 1;
+			},
+			getMissingOutputError: (source, output) => new Error(`missing ${source} -> ${output}`),
+		}),
+	]);
+
+	assert.equal(emitCalls, 0);
+	assert.equal(first.outputUrl, '/assets/_hmr/pages/inflight.js');
+	assert.equal(second.outputUrl, first.outputUrl);
+});

--- a/packages/core/src/adapters/shared/hmr/hmr-entrypoint-registrar.test.ts
+++ b/packages/core/src/adapters/shared/hmr/hmr-entrypoint-registrar.test.ts
@@ -186,3 +186,34 @@ test('trackInFlightEntrypoint coalesces concurrent registerEntrypoint callers', 
 	assert.equal(first.outputUrl, '/assets/_hmr/pages/inflight.js');
 	assert.equal(second.outputUrl, first.outputUrl);
 });
+
+test('tryTrackInFlightEntrypoint returns false when on-demand registration already owns the slot', async () => {
+	const rootDir = createTempRoot('hmr-registrar-try-track');
+	const srcDir = path.join(rootDir, 'src');
+	const distDir = path.join(rootDir, '.eco', 'assets', '_hmr');
+	fs.mkdirSync(srcDir, { recursive: true });
+	fs.mkdirSync(distDir, { recursive: true });
+
+	const entrypointPath = path.join(srcDir, 'owned.tsx');
+	fs.writeFileSync(entrypointPath, 'export {}', 'utf8');
+
+	const registrar = new HmrEntrypointRegistrar({ srcDir, distDir });
+	const onDemandPromise = Promise.resolve({
+		sourcePath: entrypointPath,
+		outputPath: path.join(distDir, 'pages', 'owned.js'),
+		outputUrl: '/assets/_hmr/pages/owned.js',
+	});
+
+	registrar.trackInFlightEntrypoint(entrypointPath, onDemandPromise);
+
+	const reserved = registrar.tryTrackInFlightEntrypoint(
+		entrypointPath,
+		Promise.resolve({
+			sourcePath: entrypointPath,
+			outputPath: path.join(distDir, 'pages', 'owned.js'),
+			outputUrl: '/assets/_hmr/pages/owned.js',
+		}),
+	);
+
+	assert.equal(reserved, false);
+});

--- a/packages/core/src/adapters/shared/hmr/hmr-entrypoint-registrar.ts
+++ b/packages/core/src/adapters/shared/hmr/hmr-entrypoint-registrar.ts
@@ -63,15 +63,31 @@ export class HmrEntrypointRegistrar {
 		this.inFlight.delete(normalizedEntrypoint);
 	}
 
+	isEntrypointInFlight(entrypointPath: string): boolean {
+		return this.inFlight.has(path.resolve(entrypointPath));
+	}
+
 	/**
 	 * Registers an in-flight promise so concurrent {@link registerEntrypoint}
 	 * callers coalesce on the same cold client-graph build.
 	 */
 	trackInFlightEntrypoint(entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>): void {
+		this.tryTrackInFlightEntrypoint(entrypointPath, promise);
+	}
+
+	/**
+	 * Reserves the in-flight slot when it is still free.
+	 *
+	 * @returns `false` when another registration (for example on-demand SSR) already owns the slot.
+	 */
+	tryTrackInFlightEntrypoint(entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>): boolean {
 		const normalizedEntrypoint = path.resolve(entrypointPath);
-		if (!this.inFlight.has(normalizedEntrypoint)) {
-			this.inFlight.set(normalizedEntrypoint, promise);
+		if (this.inFlight.has(normalizedEntrypoint)) {
+			return false;
 		}
+
+		this.inFlight.set(normalizedEntrypoint, promise);
+		return true;
 	}
 
 	releaseInFlightEntrypoint(entrypointPath: string): void {

--- a/packages/core/src/adapters/shared/hmr/hmr-entrypoint-registrar.ts
+++ b/packages/core/src/adapters/shared/hmr/hmr-entrypoint-registrar.ts
@@ -58,7 +58,27 @@ export class HmrEntrypointRegistrar {
 	}
 
 	clearRegistration(entrypointPath: string): void {
-		this.registered.delete(path.resolve(entrypointPath));
+		const normalizedEntrypoint = path.resolve(entrypointPath);
+		this.registered.delete(normalizedEntrypoint);
+		this.inFlight.delete(normalizedEntrypoint);
+	}
+
+	/**
+	 * Registers an in-flight promise so concurrent {@link registerEntrypoint}
+	 * callers coalesce on the same cold client-graph build.
+	 */
+	trackInFlightEntrypoint(entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>): void {
+		const normalizedEntrypoint = path.resolve(entrypointPath);
+		if (!this.inFlight.has(normalizedEntrypoint)) {
+			this.inFlight.set(normalizedEntrypoint, promise);
+		}
+	}
+
+	releaseInFlightEntrypoint(entrypointPath: string): void {
+		const normalizedEntrypoint = path.resolve(entrypointPath);
+		if (this.inFlight.get(normalizedEntrypoint)) {
+			this.inFlight.delete(normalizedEntrypoint);
+		}
 	}
 
 	/**

--- a/packages/core/src/adapters/shared/hmr/shared-hmr-manager.ts
+++ b/packages/core/src/adapters/shared/hmr/shared-hmr-manager.ts
@@ -375,6 +375,14 @@ export abstract class SharedHmrManager implements IHmrManager {
 		this.entrypointRegistrar.seedResolvedEntrypoint(resolved);
 	}
 
+	public trackInFlightEntrypoint(entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>): void {
+		this.entrypointRegistrar.trackInFlightEntrypoint(entrypointPath, promise);
+	}
+
+	public releaseInFlightEntrypoint(entrypointPath: string): void {
+		this.entrypointRegistrar.releaseInFlightEntrypoint(entrypointPath);
+	}
+
 	/**
 	 * Returns the emitted HMR script output when the entrypoint is already registered
 	 * and its browser bundle exists on disk.

--- a/packages/core/src/adapters/shared/hmr/shared-hmr-manager.ts
+++ b/packages/core/src/adapters/shared/hmr/shared-hmr-manager.ts
@@ -379,6 +379,10 @@ export abstract class SharedHmrManager implements IHmrManager {
 		this.entrypointRegistrar.trackInFlightEntrypoint(entrypointPath, promise);
 	}
 
+	public tryTrackInFlightEntrypoint(entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>): boolean {
+		return this.entrypointRegistrar.tryTrackInFlightEntrypoint(entrypointPath, promise);
+	}
+
 	public releaseInFlightEntrypoint(entrypointPath: string): void {
 		this.entrypointRegistrar.releaseInFlightEntrypoint(entrypointPath);
 	}

--- a/packages/core/src/adapters/shared/runtime/runtime-server-lifecycle.test.ts
+++ b/packages/core/src/adapters/shared/runtime/runtime-server-lifecycle.test.ts
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict';
 import { test, vi } from 'vitest';
 import { appLogger } from '../../../global/app-logger.ts';
 import * as appBuildManifestRuntime from '../../../build/app-build-manifest-runtime.ts';
-import { startConfiguredIntegrationRuntimePrewarm } from './runtime-server-lifecycle.ts';
+import {
+	startConfiguredIntegrationRuntimePrewarm,
+	startConfiguredClientGraphPrewarm,
+} from './runtime-server-lifecycle.ts';
 
 test('startConfiguredIntegrationRuntimePrewarm activates every configured integration', async () => {
 	const ensureSpy = vi.spyOn(appBuildManifestRuntime, 'ensureIntegrationRuntimeReady').mockResolvedValue(undefined);
@@ -51,4 +54,47 @@ test('startConfiguredIntegrationRuntimePrewarm logs failures without throwing', 
 
 	ensureSpy.mockRestore();
 	errorSpy.mockRestore();
+});
+
+test('startConfiguredClientGraphPrewarm delegates to integrations when enabled', () => {
+	const startPrewarm = vi.fn();
+	const appConfig = {
+		integrations: [{ name: 'react', startDevClientGraphPrewarm: startPrewarm }],
+	} as any;
+
+	startConfiguredClientGraphPrewarm({
+		appConfig,
+		templateRouteFilePaths: ['/app/pages/index.tsx'],
+		hmrEnabled: true,
+	});
+
+	assert.equal(startPrewarm.mock.calls.length, 1);
+	assert.deepEqual(startPrewarm.mock.calls[0]?.[0], {
+		appConfig,
+		templateRouteFilePaths: ['/app/pages/index.tsx'],
+	});
+});
+
+test('startConfiguredClientGraphPrewarm is skipped when disabled', () => {
+	const startPrewarm = vi.fn();
+	const previous = process.env.ECOPAGES_DEV_COLD_CLIENT_GRAPH;
+	process.env.ECOPAGES_DEV_COLD_CLIENT_GRAPH = 'false';
+
+	try {
+		startConfiguredClientGraphPrewarm({
+			appConfig: {
+				integrations: [{ name: 'react', startDevClientGraphPrewarm: startPrewarm }],
+			} as any,
+			templateRouteFilePaths: ['/app/pages/index.tsx'],
+			hmrEnabled: true,
+		});
+
+		assert.equal(startPrewarm.mock.calls.length, 0);
+	} finally {
+		if (previous === undefined) {
+			delete process.env.ECOPAGES_DEV_COLD_CLIENT_GRAPH;
+		} else {
+			process.env.ECOPAGES_DEV_COLD_CLIENT_GRAPH = previous;
+		}
+	}
 });

--- a/packages/core/src/adapters/shared/runtime/runtime-server-lifecycle.ts
+++ b/packages/core/src/adapters/shared/runtime/runtime-server-lifecycle.ts
@@ -74,6 +74,42 @@ export function startConfiguredIntegrationRuntimePrewarm(options: {
 	});
 }
 
+/** Returns whether background cold client-graph prewarm is enabled. */
+export function isDevColdClientGraphEnabled(): boolean {
+	return process.env.ECOPAGES_DEV_COLD_CLIENT_GRAPH !== 'false';
+}
+
+/**
+ * Starts background cold client-graph prewarm for every integration that supports it.
+ */
+export function startConfiguredClientGraphPrewarm(options: {
+	appConfig: EcoPagesAppConfig;
+	templateRouteFilePaths: readonly string[];
+	hmrEnabled: boolean;
+}): void {
+	if (!options.hmrEnabled || !isDevColdClientGraphEnabled()) {
+		return;
+	}
+
+	for (const integration of options.appConfig.integrations) {
+		integration.startDevClientGraphPrewarm?.({
+			appConfig: options.appConfig,
+			templateRouteFilePaths: options.templateRouteFilePaths,
+		});
+	}
+}
+
+/**
+ * Waits for integration-owned cold client-graph batches when blocking mode is enabled.
+ */
+export async function awaitConfiguredClientGraphPrewarm(appConfig: EcoPagesAppConfig): Promise<void> {
+	if (!isDevColdClientGraphEnabled() || process.env.ECOPAGES_DEV_COLD_CLIENT_GRAPH_BLOCKING !== 'true') {
+		return;
+	}
+
+	await Promise.all(appConfig.integrations.map((integration) => integration.awaitDevClientGraphPrewarm()));
+}
+
 /**
  * Releases shared dev resources in a consistent order across server adapters.
  *

--- a/packages/core/src/build/cache/dev-hmr-entrypoint-cache.test.ts
+++ b/packages/core/src/build/cache/dev-hmr-entrypoint-cache.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeAll, afterAll, test } from 'vitest';
+import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
+import {
+	createDevHmrEntrypointCache,
+	getDevHmrEntrypointCacheEntry,
+	removeDevHmrEntrypointCacheEntry,
+	setDevHmrEntrypointCacheEntry,
+} from './dev-hmr-entrypoint-cache.ts';
+
+const tempRoots: string[] = [];
+const originalNodeEnv = process.env.NODE_ENV;
+
+function createTempRoot(prefix: string): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+	tempRoots.push(root);
+	return root;
+}
+
+function makeAppConfig(rootDir: string): EcoPagesAppConfig {
+	return { rootDir } as unknown as EcoPagesAppConfig;
+}
+
+beforeAll(() => {
+	process.env.NODE_ENV = 'development';
+});
+
+afterAll(() => {
+	process.env.NODE_ENV = originalNodeEnv;
+});
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test('persists and restores a cold-graph entry across cache instances', () => {
+	const rootDir = createTempRoot('dev-hmr-cache-persist');
+	const appConfig = makeAppConfig(rootDir);
+
+	const sourcePath = path.join(rootDir, 'widget.tsx');
+	const outputPath = path.join(rootDir, '.eco', 'assets', '_hmr', 'widget.js');
+	fs.writeFileSync(sourcePath, 'export {}', 'utf8');
+	fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+	fs.writeFileSync(outputPath, 'bundled', 'utf8');
+
+	let cache = createDevHmrEntrypointCache(appConfig);
+	assert.equal(getDevHmrEntrypointCacheEntry(cache, sourcePath), null);
+
+	setDevHmrEntrypointCacheEntry(cache, sourcePath, {
+		outputPath,
+		outputUrl: '/assets/_hmr/widget.js',
+		sourceMtimeMs: fs.statSync(sourcePath).mtimeMs,
+		builtAt: Date.now(),
+	});
+
+	cache = createDevHmrEntrypointCache(appConfig);
+	const hit = getDevHmrEntrypointCacheEntry(cache, sourcePath);
+	assert.ok(hit);
+	assert.equal(hit.outputUrl, '/assets/_hmr/widget.js');
+});
+
+test('cache hit is invalidated when the source mtime changes', () => {
+	const rootDir = createTempRoot('dev-hmr-cache-mtime');
+	const appConfig = makeAppConfig(rootDir);
+
+	const sourcePath = path.join(rootDir, 'widget.tsx');
+	const outputPath = path.join(rootDir, '.eco', 'assets', '_hmr', 'widget.js');
+	fs.writeFileSync(sourcePath, 'export {}', 'utf8');
+	fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+	fs.writeFileSync(outputPath, 'bundled', 'utf8');
+
+	const cache = createDevHmrEntrypointCache(appConfig);
+	setDevHmrEntrypointCacheEntry(cache, sourcePath, {
+		outputPath,
+		outputUrl: '/assets/_hmr/widget.js',
+		sourceMtimeMs: fs.statSync(sourcePath).mtimeMs,
+		builtAt: Date.now(),
+	});
+
+	assert.ok(getDevHmrEntrypointCacheEntry(cache, sourcePath));
+
+	fs.writeFileSync(sourcePath, 'export { changed }', 'utf8');
+
+	assert.equal(getDevHmrEntrypointCacheEntry(cache, sourcePath), null);
+});
+
+test('cache hit is dropped when the on-disk artifact is removed', () => {
+	const rootDir = createTempRoot('dev-hmr-cache-missing');
+	const appConfig = makeAppConfig(rootDir);
+
+	const sourcePath = path.join(rootDir, 'widget.tsx');
+	const outputPath = path.join(rootDir, '.eco', 'assets', '_hmr', 'widget.js');
+	fs.writeFileSync(sourcePath, 'export {}', 'utf8');
+	fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+	fs.writeFileSync(outputPath, 'bundled', 'utf8');
+
+	const cache = createDevHmrEntrypointCache(appConfig);
+	setDevHmrEntrypointCacheEntry(cache, sourcePath, {
+		outputPath,
+		outputUrl: '/assets/_hmr/widget.js',
+		sourceMtimeMs: fs.statSync(sourcePath).mtimeMs,
+		builtAt: Date.now(),
+	});
+
+	fs.rmSync(outputPath, { force: true });
+
+	assert.equal(getDevHmrEntrypointCacheEntry(cache, sourcePath), null);
+});
+
+test('removeDevHmrEntrypointCacheEntry drops persisted entries', () => {
+	const rootDir = createTempRoot('dev-hmr-cache-remove');
+	const appConfig = makeAppConfig(rootDir);
+
+	const sourcePath = path.join(rootDir, 'widget.tsx');
+	const outputPath = path.join(rootDir, '.eco', 'assets', '_hmr', 'widget.js');
+	fs.writeFileSync(sourcePath, 'export {}', 'utf8');
+	fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+	fs.writeFileSync(outputPath, 'bundled', 'utf8');
+
+	const cache = createDevHmrEntrypointCache(appConfig);
+	setDevHmrEntrypointCacheEntry(cache, sourcePath, {
+		outputPath,
+		outputUrl: '/assets/_hmr/widget.js',
+		sourceMtimeMs: fs.statSync(sourcePath).mtimeMs,
+		builtAt: Date.now(),
+	});
+
+	removeDevHmrEntrypointCacheEntry(cache, sourcePath);
+
+	const reloaded = createDevHmrEntrypointCache(appConfig);
+	assert.equal(getDevHmrEntrypointCacheEntry(reloaded, sourcePath), null);
+});

--- a/packages/core/src/build/cache/dev-hmr-entrypoint-cache.ts
+++ b/packages/core/src/build/cache/dev-hmr-entrypoint-cache.ts
@@ -1,0 +1,177 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileSystem } from '@ecopages/file-system';
+import { getAppBrowserBuildPlugins } from '../build-adapter.ts';
+import { createBuildInputsFingerprint, hashAppConfigFile } from './build-input-fingerprint.ts';
+import {
+	readProductionCacheManifest,
+	writeProductionCacheManifest,
+	isProductionCacheManifestCurrent,
+	matchesProductionCacheFingerprint,
+} from './production-build-cache.ts';
+import { getCorePackageVersion } from './cache-keys.ts';
+import { isDevelopmentRuntime } from '../../utils/runtime.ts';
+import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
+
+/**
+ * @remarks
+ * Unlike the dev browser-script cache (which lives under `.eco`), the HMR
+ * entrypoint cache is written under `node_modules/.cache/ecopages` so a
+ * `rm -rf apps/<app>/.eco` during iteration still keeps persistent
+ * cold-graph artifacts across dev sessions for unchanged sources.
+ */
+export const DEV_HMR_ENTRYPOINT_CACHE_DIR = '.cache/ecopages/hmr-entrypoints';
+export const DEV_HMR_ENTRYPOINT_CACHE_FILENAME = '.hmr-entrypoints.json';
+
+export interface DevHmrEntrypointCacheEntry {
+	outputPath: string;
+	outputUrl: string;
+	sourceMtimeMs: number;
+	builtAt: number;
+}
+
+export interface DevHmrEntrypointCacheManifest {
+	invalidationVersion: string;
+	buildInputsFingerprint: string;
+	entries: Record<string, DevHmrEntrypointCacheEntry>;
+}
+
+export type DevHmrEntrypointCache = {
+	appConfig: EcoPagesAppConfig;
+	manifest: DevHmrEntrypointCacheManifest;
+};
+
+function getDevHmrEntrypointCacheDir(appConfig: EcoPagesAppConfig): string {
+	return path.join(appConfig.rootDir, 'node_modules', DEV_HMR_ENTRYPOINT_CACHE_DIR);
+}
+
+function getDevHmrEntrypointCacheManifestPath(appConfig: EcoPagesAppConfig): string {
+	return path.join(getDevHmrEntrypointCacheDir(appConfig), DEV_HMR_ENTRYPOINT_CACHE_FILENAME);
+}
+
+function createBrowserBuildKey(appConfig: EcoPagesAppConfig): string {
+	try {
+		const pluginNames = getAppBrowserBuildPlugins(appConfig)
+			.map((plugin) => plugin.name)
+			.sort()
+			.join('|');
+		return pluginNames || 'default';
+	} catch {
+		return 'default';
+	}
+}
+
+function createDevHmrEntrypointInvalidationVersion(appConfig: EcoPagesAppConfig): string {
+	return [getCorePackageVersion(), hashAppConfigFile(appConfig), createBrowserBuildKey(appConfig)].join('::');
+}
+
+function readManifest(appConfig: EcoPagesAppConfig): DevHmrEntrypointCacheManifest | undefined {
+	const manifest = readProductionCacheManifest<DevHmrEntrypointCacheManifest>(
+		getDevHmrEntrypointCacheManifestPath(appConfig),
+	);
+
+	if (!manifest) {
+		return undefined;
+	}
+
+	const invalidationVersion = createDevHmrEntrypointInvalidationVersion(appConfig);
+	const buildInputsFingerprint = createBuildInputsFingerprint(appConfig);
+
+	if (
+		!isProductionCacheManifestCurrent(manifest, invalidationVersion) ||
+		!matchesProductionCacheFingerprint(manifest, buildInputsFingerprint)
+	) {
+		return undefined;
+	}
+
+	return manifest;
+}
+
+/** Returns whether the dev HMR entrypoint disk cache is active. */
+export function shouldUseDevHmrEntrypointCache(): boolean {
+	return isDevelopmentRuntime();
+}
+
+/** Loads (or initializes) the persistent HMR entrypoint cache for one app. */
+export function createDevHmrEntrypointCache(appConfig: EcoPagesAppConfig): DevHmrEntrypointCache {
+	const invalidationVersion = createDevHmrEntrypointInvalidationVersion(appConfig);
+	const buildInputsFingerprint = createBuildInputsFingerprint(appConfig);
+	const existing = readManifest(appConfig);
+	const manifest: DevHmrEntrypointCacheManifest = existing ?? {
+		invalidationVersion,
+		buildInputsFingerprint,
+		entries: {},
+	};
+
+	return { appConfig, manifest };
+}
+
+/**
+ * Looks up a persisted HMR entrypoint by source path.
+ *
+ * @remarks
+ * Returns the cached entry only when the on-disk artifact still exists and the
+ * recorded source mtime matches. A stale artifact (e.g. removed `.eco`) or a
+ * source edit invalidates the entry so the caller rebuilds it.
+ */
+export function getDevHmrEntrypointCacheEntry(
+	cache: DevHmrEntrypointCache,
+	sourcePath: string,
+): DevHmrEntrypointCacheEntry | null {
+	if (!shouldUseDevHmrEntrypointCache()) {
+		return null;
+	}
+
+	const entry = cache.manifest.entries[sourcePath];
+	if (!entry?.outputPath || !entry.outputUrl) {
+		return null;
+	}
+
+	if (!fileSystem.exists(entry.outputPath)) {
+		return null;
+	}
+
+	try {
+		if (fs.statSync(sourcePath).mtimeMs !== entry.sourceMtimeMs) {
+			return null;
+		}
+	} catch {
+		return null;
+	}
+
+	return entry;
+}
+
+/** Persists one HMR entrypoint output for cross-session cold-graph reuse. */
+export function setDevHmrEntrypointCacheEntry(
+	cache: DevHmrEntrypointCache,
+	sourcePath: string,
+	entry: DevHmrEntrypointCacheEntry,
+): void {
+	if (!shouldUseDevHmrEntrypointCache()) {
+		return;
+	}
+
+	const invalidationVersion = createDevHmrEntrypointInvalidationVersion(cache.appConfig);
+	const buildInputsFingerprint = createBuildInputsFingerprint(cache.appConfig);
+
+	cache.manifest.invalidationVersion = invalidationVersion;
+	cache.manifest.buildInputsFingerprint = buildInputsFingerprint;
+	cache.manifest.entries[sourcePath] = entry;
+
+	writeProductionCacheManifest(getDevHmrEntrypointCacheManifestPath(cache.appConfig), cache.manifest);
+}
+
+/** Drops one persisted cold-graph entry after a source change or HMR rebuild. */
+export function removeDevHmrEntrypointCacheEntry(cache: DevHmrEntrypointCache, sourcePath: string): void {
+	if (!shouldUseDevHmrEntrypointCache()) {
+		return;
+	}
+
+	if (!(sourcePath in cache.manifest.entries)) {
+		return;
+	}
+
+	delete cache.manifest.entries[sourcePath];
+	writeProductionCacheManifest(getDevHmrEntrypointCacheManifestPath(cache.appConfig), cache.manifest);
+}

--- a/packages/core/src/diagnostics/startup-trace.ts
+++ b/packages/core/src/diagnostics/startup-trace.ts
@@ -8,6 +8,7 @@ export type StartupTracePhase =
 	| 'setupAppRuntimePlugins'
 	| 'route-registry'
 	| 'server-listen'
+	| 'dev-cold-client-graph'
 	| 'first-byte'
 	| 'first-page-browser-graph'
 	| 'first-request-ssr'

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -5,6 +5,10 @@ interface EcopagesEnv {
 	ECOPAGES_LOGGER_DEBUG: 'true' | 'false';
 	/** When `true`, emits startup phase timings to stderr. Also enabled when `ECOPAGES_LOGGER_DEBUG=true`. */
 	ECOPAGES_STARTUP_TRACE?: 'true' | 'false';
+	/** When `false`, skips background React HMR client-graph prewarm in dev. Default: enabled. */
+	ECOPAGES_DEV_COLD_CLIENT_GRAPH?: 'true' | 'false';
+	/** When `true`, blocks server listen until client-graph prewarm finishes. Default: background-only. */
+	ECOPAGES_DEV_COLD_CLIENT_GRAPH_BLOCKING?: 'true' | 'false';
 }
 
 declare global {

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -7,7 +7,7 @@ interface EcopagesEnv {
 	ECOPAGES_STARTUP_TRACE?: 'true' | 'false';
 	/** When `false`, skips background React HMR client-graph prewarm in dev. Default: enabled. */
 	ECOPAGES_DEV_COLD_CLIENT_GRAPH?: 'true' | 'false';
-	/** When `true`, blocks server listen until client-graph prewarm finishes. Default: background-only. */
+	/** When `true`, delays startup completion until client-graph prewarm finishes. Default: background after listen. */
 	ECOPAGES_DEV_COLD_CLIENT_GRAPH_BLOCKING?: 'true' | 'false';
 }
 

--- a/packages/core/src/plugins/integration-plugin.ts
+++ b/packages/core/src/plugins/integration-plugin.ts
@@ -26,6 +26,13 @@ export type {
 } from '../build/contracts/build-types.ts';
 export type { PageBrowserGraphContribution, PageBrowserGraphContributionContext } from '../types/public-types.ts';
 export type { StaticExportContext } from '../static-site-generator/static-export-context.ts';
+
+/** Options passed to integration-owned dev client-graph prewarm kickoff. */
+export type DevClientGraphPrewarmOptions = {
+	appConfig: EcoPagesAppConfig;
+	templateRouteFilePaths: readonly string[];
+};
+
 export type {
 	HtmlDocumentContribution,
 	HtmlDocumentContributionContext,
@@ -241,6 +248,16 @@ export abstract class IntegrationPlugin<C = EcoPagesElement> {
 			this.assetProcessingService.setHmrManager(hmrManager);
 		}
 	}
+
+	/**
+	 * Starts background cold client-graph prewarm for this integration when supported.
+	 */
+	startDevClientGraphPrewarm?(_options: DevClientGraphPrewarmOptions): void {}
+
+	/**
+	 * Waits for integration-owned cold client-graph prewarm when blocking mode is enabled.
+	 */
+	async awaitDevClientGraphPrewarm(): Promise<void> {}
 
 	/**
 	 * Creates the asset-processing service used for global integration dependencies.

--- a/packages/core/src/plugins/integration-plugin.ts
+++ b/packages/core/src/plugins/integration-plugin.ts
@@ -30,6 +30,7 @@ export type { StaticExportContext } from '../static-site-generator/static-export
 /** Options passed to integration-owned dev client-graph prewarm kickoff. */
 export type DevClientGraphPrewarmOptions = {
 	appConfig: EcoPagesAppConfig;
+	/** Template-route source paths from the route registry at server startup. */
 	templateRouteFilePaths: readonly string[];
 };
 
@@ -250,12 +251,21 @@ export abstract class IntegrationPlugin<C = EcoPagesElement> {
 	}
 
 	/**
-	 * Starts background cold client-graph prewarm for this integration when supported.
+	 * Starts background cold HMR entrypoint prewarm for this integration when supported.
+	 *
+	 * @remarks
+	 * Core calls this from `completeInitialization` when dev HMR/watch is enabled.
+	 * Only `@ecopages/react` implements it today; other integrations keep the default no-op.
+	 * Pair with {@link awaitDevClientGraphPrewarm} when `ECOPAGES_DEV_COLD_CLIENT_GRAPH_BLOCKING=true`.
 	 */
 	startDevClientGraphPrewarm?(_options: DevClientGraphPrewarmOptions): void {}
 
 	/**
-	 * Waits for integration-owned cold client-graph prewarm when blocking mode is enabled.
+	 * Waits for integration-owned cold HMR entrypoint prewarm when blocking mode is enabled.
+	 *
+	 * @remarks
+	 * Blocking mode delays startup completion, not socket bind. The server may already be
+	 * listening while background prewarm runs unless blocking is enabled.
 	 */
 	async awaitDevClientGraphPrewarm(): Promise<void> {}
 

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -372,6 +372,17 @@ export interface IHmrManager {
 	seedResolvedEntrypoint?(resolved: ResolvedHmrEntrypoint): void;
 
 	/**
+	 * Registers an in-flight cold client-graph promise so concurrent
+	 * {@link registerEntrypoint} callers coalesce on the same build.
+	 */
+	trackInFlightEntrypoint?(entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>): void;
+
+	/**
+	 * Releases a cold client-graph in-flight promise after the grouped build completes.
+	 */
+	releaseInFlightEntrypoint?(entrypointPath: string): void;
+
+	/**
 	 * Gets the map of watched files.
 	 */
 	getWatchedFiles(): Map<string, string>;

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -376,6 +376,7 @@ export interface IHmrManager {
 	 * {@link registerEntrypoint} callers coalesce on the same build.
 	 */
 	trackInFlightEntrypoint?(entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>): void;
+	tryTrackInFlightEntrypoint?(entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>): boolean;
 
 	/**
 	 * Releases a cold client-graph in-flight promise after the grouped build completes.

--- a/packages/ecopages/README.md
+++ b/packages/ecopages/README.md
@@ -71,6 +71,8 @@ Set these in `.env` or on the command line when diagnosing slow dev startup or f
 | :---------------------------- | :--------------------- | :--------------------------------------------------------------------------------------------- |
 | `ECOPAGES_LOGGER_DEBUG=true`  | `ecopages dev --debug` | Verbose `[@ecopages/core]` logs across the stack, plus **startup phase trace** lines on stderr |
 | `ECOPAGES_STARTUP_TRACE=true` | —                      | **Only** the phase trace (no extra debug noise). Useful when measuring first-open latency      |
+| `ECOPAGES_DEV_COLD_CLIENT_GRAPH=false` | —              | Disable background React HMR page-graph prewarm (on by default in dev with HMR)                |
+| `ECOPAGES_DEV_COLD_CLIENT_GRAPH_BLOCKING=true` | —    | Wait for client-graph prewarm before accepting connections (default is background-only)          |
 
 Trace lines are prefixed with `[ecopages:startup-trace]` and look like:
 
@@ -83,7 +85,7 @@ Trace lines are prefixed with `[ecopages:startup-trace]` and look like:
 [ecopages:startup-trace] summary path=/docs/getting-started/introduction bundleCount=13 clientBundleBytes=858396 wallMs=12496
 ```
 
-Phases: config ready → runtime plugins → route registry → server listening → first request SSR. The summary includes bundle count and total client JS bytes for that first request.
+Phases: config ready → runtime plugins → route registry → server listening → **dev cold client graph** (React HMR prewarm) → first request SSR. The summary includes bundle count and total client JS bytes for that first request.
 
 ```bash
 # Focused perf trace only

--- a/packages/ecopages/README.md
+++ b/packages/ecopages/README.md
@@ -67,12 +67,12 @@ ecopages dev -r
 
 Set these in `.env` or on the command line when diagnosing slow dev startup or first page load.
 
-| Env var                       | CLI                    | What you get                                                                                   |
-| :---------------------------- | :--------------------- | :--------------------------------------------------------------------------------------------- |
-| `ECOPAGES_LOGGER_DEBUG=true`  | `ecopages dev --debug` | Verbose `[@ecopages/core]` logs across the stack, plus **startup phase trace** lines on stderr |
-| `ECOPAGES_STARTUP_TRACE=true` | —                      | **Only** the phase trace (no extra debug noise). Useful when measuring first-open latency      |
-| `ECOPAGES_DEV_COLD_CLIENT_GRAPH=false` | —              | Disable background React HMR page-graph prewarm (on by default in dev with HMR)                |
-| `ECOPAGES_DEV_COLD_CLIENT_GRAPH_BLOCKING=true` | —    | Wait for client-graph prewarm before accepting connections (default is background-only)          |
+| Env var                                        | CLI                    | What you get                                                                                   |
+| :--------------------------------------------- | :--------------------- | :--------------------------------------------------------------------------------------------- |
+| `ECOPAGES_LOGGER_DEBUG=true`                   | `ecopages dev --debug` | Verbose `[@ecopages/core]` logs across the stack, plus **startup phase trace** lines on stderr |
+| `ECOPAGES_STARTUP_TRACE=true`                  | —                      | **Only** the phase trace (no extra debug noise). Useful when measuring first-open latency      |
+| `ECOPAGES_DEV_COLD_CLIENT_GRAPH=false`         | —                      | Disable background React HMR page-graph prewarm (on by default in dev with HMR)                |
+| `ECOPAGES_DEV_COLD_CLIENT_GRAPH_BLOCKING=true` | —                      | Wait for client-graph prewarm before accepting connections (default is background-only)        |
 
 Trace lines are prefixed with `[ecopages:startup-trace]` and look like:
 

--- a/packages/ecopages/README.md
+++ b/packages/ecopages/README.md
@@ -71,8 +71,8 @@ Set these in `.env` or on the command line when diagnosing slow dev startup or f
 | :--------------------------------------------- | :--------------------- | :--------------------------------------------------------------------------------------------- |
 | `ECOPAGES_LOGGER_DEBUG=true`                   | `ecopages dev --debug` | Verbose `[@ecopages/core]` logs across the stack, plus **startup phase trace** lines on stderr |
 | `ECOPAGES_STARTUP_TRACE=true`                  | —                      | **Only** the phase trace (no extra debug noise). Useful when measuring first-open latency      |
-| `ECOPAGES_DEV_COLD_CLIENT_GRAPH=false`         | —                      | Disable background React HMR page-graph prewarm (on by default in dev with HMR)                |
-| `ECOPAGES_DEV_COLD_CLIENT_GRAPH_BLOCKING=true` | —                      | Wait for client-graph prewarm before accepting connections (default is background-only)        |
+| `ECOPAGES_DEV_COLD_CLIENT_GRAPH=false`         | —                      | Disable background React HMR entrypoint prewarm (on by default when HMR is enabled)            |
+| `ECOPAGES_DEV_COLD_CLIENT_GRAPH_BLOCKING=true` | —                      | Delay startup completion until prewarm finishes (default runs in background after listen)      |
 
 Trace lines are prefixed with `[ecopages:startup-trace]` and look like:
 
@@ -81,11 +81,12 @@ Trace lines are prefixed with `[ecopages:startup-trace]` and look like:
 [ecopages:startup-trace] phase=setupAppRuntimePlugins durationMs=714 wallMs=1999
 [ecopages:startup-trace] phase=route-registry durationMs=1 wallMs=2000
 [ecopages:startup-trace] phase=server-listen durationMs=45 wallMs=2046
+[ecopages:startup-trace] phase=dev-cold-client-graph durationMs=733 wallMs=2779
 [ecopages:startup-trace] phase=first-request-ssr durationMs=5296 wallMs=12495
 [ecopages:startup-trace] summary path=/docs/getting-started/introduction bundleCount=13 clientBundleBytes=858396 wallMs=12496
 ```
 
-Phases: config ready → runtime plugins → route registry → server listening → **dev cold client graph** (React HMR prewarm) → first request SSR. The summary includes bundle count and total client JS bytes for that first request.
+Phases: config ready → runtime plugins → route registry → server listening → **dev cold client graph** (React HMR entrypoint prewarm, usually in background after listen) → first request SSR. The summary includes bundle count and total client JS bytes for that first request.
 
 ```bash
 # Focused perf trace only

--- a/packages/integrations/react/CHANGELOG.md
+++ b/packages/integrations/react/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to `@ecopages/react` are documented here.
 
 ### Features
 
+- Added background React HMR entrypoint prewarm at dev startup with grouped Rolldown batches, registrar seeding, and cross-session disk cache reuse.
 - Auto-vendor npm packages reachable from `eco.layout()` client render graphs under configured `layouts/` and `components/` directories when `router` is enabled; optional `runtimeModules` overrides manual entries for the same specifier.
 - Added nested layout arrays on `eco.page()` with unified React SSR composition via `composeDocumentShell` `composeChildren`.
 - Added `composeLayoutPageTree` and `serializePageDataScript` exports for shared client/SSR layout and hydration payloads.

--- a/packages/integrations/react/src/hmr/hmr-strategy.test.ts
+++ b/packages/integrations/react/src/hmr/hmr-strategy.test.ts
@@ -1,8 +1,15 @@
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ReactHmrStrategy } from './hmr-strategy.ts';
+import type { HmrPageMetadataCache } from './page-metadata-cache.ts';
 import type { DefaultHmrContext } from '@ecopages/core';
 import { createBrowserRuntimeManifest } from '@ecopages/core/build/browser-runtime-manifest';
+import {
+	createDevHmrEntrypointCache,
+	setDevHmrEntrypointCacheEntry,
+} from '@ecopages/core/build/dev-hmr-entrypoint-cache';
 import { HmrStrategyType } from '@ecopages/core/hmr/hmr-strategy';
 import { fileSystem } from '@ecopages/file-system';
 
@@ -62,7 +69,7 @@ function createPageMetadataCache(
 			overrides.markOwnedEntrypoint?.(entrypointPath);
 		},
 		setDeclaredModules: overrides.setDeclaredModules ?? (() => undefined),
-	};
+	} as HmrPageMetadataCache;
 }
 
 function createImportServerModuleMock(result: {
@@ -1342,6 +1349,101 @@ describe('ReactHmrStrategy', () => {
 					},
 				],
 			});
+		});
+	});
+
+	describe('prepareColdClientGraph', () => {
+		const originalNodeEnv = process.env.NODE_ENV;
+
+		afterEach(() => {
+			if (originalNodeEnv === undefined) {
+				delete process.env.NODE_ENV;
+			} else {
+				process.env.NODE_ENV = originalNodeEnv;
+			}
+		});
+
+		it('seeds cache hits and builds uncached route entrypoints in grouped passes', async () => {
+			process.env.NODE_ENV = 'development';
+			const pagesDir = '/tmp/src/pages';
+			const entrypointPath = path.join(pagesDir, 'login.tsx');
+			const seededPaths: string[] = [];
+			const strategy = new ReactHmrStrategy({
+				context: createMockContext({
+					getPagesDir: () => pagesDir,
+					seedResolvedEntrypoint: (resolved) => {
+						seededPaths.push(resolved.sourcePath);
+					},
+				}),
+				pageMetadataCache: createPageMetadataCache(),
+				runtimeManifest: defaultRuntimeManifest,
+			});
+
+			(strategy as any).bundleReactBuildTargets = vi.fn(async () => ['/assets/_hmr/pages/login.js']);
+
+			const cache = {
+				appConfig: { rootDir: '/tmp' },
+				manifest: {
+					invalidationVersion: 'v1',
+					buildInputsFingerprint: 'stable',
+					entries: {},
+				},
+			} as any;
+
+			await strategy.prepareColdClientGraph(cache, {
+				templateRouteFilePaths: [entrypointPath],
+				trackInFlightEntrypoint: vi.fn(),
+				releaseInFlightEntrypoint: vi.fn(),
+			});
+
+			expect((strategy as any).bundleReactBuildTargets).toHaveBeenCalledTimes(1);
+			expect(seededPaths).toContain(entrypointPath);
+		});
+
+		it('seeds persisted cache hits without invoking grouped builds', async () => {
+			process.env.NODE_ENV = 'development';
+			const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cold-graph-cache-hit-'));
+			const pagesDir = path.join(rootDir, 'src', 'pages');
+			fs.mkdirSync(pagesDir, { recursive: true });
+
+			const entrypointPath = path.join(pagesDir, 'login.tsx');
+			const outputPath = path.join(rootDir, '.eco', 'assets', '_hmr', 'pages', 'login.js');
+			fs.writeFileSync(entrypointPath, 'export {}', 'utf8');
+			fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+			fs.writeFileSync(outputPath, 'bundled', 'utf8');
+
+			const seededPaths: string[] = [];
+			const strategy = new ReactHmrStrategy({
+				context: createMockContext({
+					getPagesDir: () => pagesDir,
+					seedResolvedEntrypoint: (resolved) => {
+						seededPaths.push(resolved.sourcePath);
+					},
+				}),
+				pageMetadataCache: createPageMetadataCache(),
+				runtimeManifest: defaultRuntimeManifest,
+			});
+
+			(strategy as any).bundleReactBuildTargets = vi.fn(async () => []);
+
+			const cache = createDevHmrEntrypointCache({ rootDir } as any);
+			setDevHmrEntrypointCacheEntry(cache, entrypointPath, {
+				outputPath,
+				outputUrl: '/assets/_hmr/pages/login.js',
+				sourceMtimeMs: fs.statSync(entrypointPath).mtimeMs,
+				builtAt: Date.now(),
+			});
+
+			await strategy.prepareColdClientGraph(cache, {
+				templateRouteFilePaths: [entrypointPath],
+				trackInFlightEntrypoint: vi.fn(),
+				releaseInFlightEntrypoint: vi.fn(),
+			});
+
+			expect((strategy as any).bundleReactBuildTargets).not.toHaveBeenCalled();
+			expect(seededPaths).toContain(entrypointPath);
+
+			fs.rmSync(rootDir, { recursive: true, force: true });
 		});
 	});
 });

--- a/packages/integrations/react/src/hmr/hmr-strategy.test.ts
+++ b/packages/integrations/react/src/hmr/hmr-strategy.test.ts
@@ -1379,7 +1379,12 @@ describe('ReactHmrStrategy', () => {
 				runtimeManifest: defaultRuntimeManifest,
 			});
 
-			(strategy as any).bundleReactBuildTargets = vi.fn(async () => ['/assets/_hmr/pages/login.js']);
+			const outputPath = '/tmp/.eco/assets/_hmr/pages/login.js';
+			(strategy as any).bundleReactBuildTargets = vi.fn(async () => {
+				fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+				fs.writeFileSync(outputPath, 'bundled', 'utf8');
+				return ['/assets/_hmr/pages/login.js'];
+			});
 
 			const cache = {
 				appConfig: { rootDir: '/tmp' },
@@ -1392,8 +1397,9 @@ describe('ReactHmrStrategy', () => {
 
 			await strategy.prepareColdClientGraph(cache, {
 				templateRouteFilePaths: [entrypointPath],
-				trackInFlightEntrypoint: vi.fn(),
+				tryTrackInFlightEntrypoint: vi.fn(() => true),
 				releaseInFlightEntrypoint: vi.fn(),
+				getMissingEntrypointError: (source, output) => new Error(`missing ${source} -> ${output}`),
 			});
 
 			expect((strategy as any).bundleReactBuildTargets).toHaveBeenCalledTimes(1);
@@ -1436,8 +1442,9 @@ describe('ReactHmrStrategy', () => {
 
 			await strategy.prepareColdClientGraph(cache, {
 				templateRouteFilePaths: [entrypointPath],
-				trackInFlightEntrypoint: vi.fn(),
+				tryTrackInFlightEntrypoint: vi.fn(() => true),
 				releaseInFlightEntrypoint: vi.fn(),
+				getMissingEntrypointError: (source, output) => new Error(`missing ${source} -> ${output}`),
 			});
 
 			expect((strategy as any).bundleReactBuildTargets).not.toHaveBeenCalled();

--- a/packages/integrations/react/src/hmr/hmr-strategy.ts
+++ b/packages/integrations/react/src/hmr/hmr-strategy.ts
@@ -43,8 +43,9 @@ const COLD_BATCH_CHUNK_SIZE = 25;
 
 export type ColdClientGraphDependencies = {
 	templateRouteFilePaths: readonly string[];
-	trackInFlightEntrypoint: (entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>) => void;
+	tryTrackInFlightEntrypoint: (entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>) => boolean;
 	releaseInFlightEntrypoint: (entrypointPath: string) => void;
+	getMissingEntrypointError: (entrypointPath: string, outputPath: string) => Error;
 };
 
 type ColdClientGraphTarget = {
@@ -1117,26 +1118,59 @@ export class ReactHmrStrategy extends HmrStrategy {
 		cache: DevHmrEntrypointCache,
 		dependencies: ColdClientGraphDependencies,
 	): Promise<void> {
-		const chunkPromise = (async () => {
+		type ChunkResult = Map<string, ResolvedHmrEntrypoint>;
+		let resolveChunk!: (value: ChunkResult) => void;
+		let rejectChunk!: (reason?: unknown) => void;
+		const chunkPromise = new Promise<ChunkResult>((resolve, reject) => {
+			resolveChunk = resolve;
+			rejectChunk = reject;
+		});
+
+		const targetsToBuild: ColdClientGraphTarget[] = [];
+		for (const target of uncachedTargets) {
+			const normalizedEntrypoint = path.resolve(target.entrypointPath);
+			const inFlightPromise = chunkPromise.then((built) => {
+				const resolved = built.get(normalizedEntrypoint);
+				if (!resolved) {
+					throw dependencies.getMissingEntrypointError(target.entrypointPath, target.outputPath);
+				}
+
+				return resolved;
+			});
+
+			if (dependencies.tryTrackInFlightEntrypoint(target.entrypointPath, inFlightPromise)) {
+				targetsToBuild.push(target);
+			}
+		}
+
+		if (targetsToBuild.length === 0) {
+			return;
+		}
+
+		try {
 			const builtUrls = await this.bundleReactBuildTargets(
-				uncachedTargets.map((target) => ({
+				targetsToBuild.map((target) => ({
 					entrypointPath: target.entrypointPath,
 					outputUrl: target.outputUrl,
 				})),
 				{ grouped: true },
 			);
 			const builtUrlSet = new Set(builtUrls);
+			const built = new Map<string, ResolvedHmrEntrypoint>();
 
-			for (const target of uncachedTargets) {
-				if (!builtUrlSet.has(target.outputUrl)) {
+			for (const target of targetsToBuild) {
+				if (!builtUrlSet.has(target.outputUrl) || !fileSystem.exists(target.outputPath)) {
 					continue;
 				}
 
-				this.context.seedResolvedEntrypoint({
+				const resolved: ResolvedHmrEntrypoint = {
 					sourcePath: target.entrypointPath,
 					outputPath: target.outputPath,
 					outputUrl: target.outputUrl,
-				});
+				};
+				built.set(path.resolve(target.entrypointPath), resolved);
+
+				this.context.seedResolvedEntrypoint(resolved);
 
 				let sourceMtimeMs = 0;
 				try {
@@ -1152,21 +1186,14 @@ export class ReactHmrStrategy extends HmrStrategy {
 					builtAt: Date.now(),
 				});
 			}
-		})();
 
-		for (const target of uncachedTargets) {
-			const inFlightPromise = chunkPromise.then(() => ({
-				sourcePath: target.entrypointPath,
-				outputPath: target.outputPath,
-				outputUrl: target.outputUrl,
-			}));
-			dependencies.trackInFlightEntrypoint(target.entrypointPath, inFlightPromise);
-		}
-
-		try {
+			resolveChunk(built);
 			await chunkPromise;
+		} catch (error) {
+			rejectChunk(error);
+			throw error;
 		} finally {
-			for (const target of uncachedTargets) {
+			for (const target of targetsToBuild) {
 				dependencies.releaseInFlightEntrypoint(target.entrypointPath);
 			}
 		}

--- a/packages/integrations/react/src/hmr/hmr-strategy.ts
+++ b/packages/integrations/react/src/hmr/hmr-strategy.ts
@@ -8,12 +8,20 @@
  */
 
 import path from 'node:path';
+import fs from 'node:fs';
 
 import { HmrStrategy, HmrStrategyType, type HmrAction } from '@ecopages/core/hmr/hmr-strategy';
 import { RESOLVED_ASSETS_DIR } from '@ecopages/core/constants';
 import type { EcoBuildPlugin } from '@ecopages/core/plugins/integration-plugin';
 import { createBrowserRuntimePlugin } from '@ecopages/core/build/browser-runtime-plugin';
 import type { BrowserRuntimeManifest } from '@ecopages/core/build/browser-runtime-manifest';
+import type { ResolvedHmrEntrypoint } from '@ecopages/core';
+import {
+	getDevHmrEntrypointCacheEntry,
+	removeDevHmrEntrypointCacheEntry,
+	setDevHmrEntrypointCacheEntry,
+	type DevHmrEntrypointCache,
+} from '@ecopages/core/build/dev-hmr-entrypoint-cache';
 import { FileNotFoundError, fileSystem } from '@ecopages/file-system';
 import { Logger } from '@ecopages/logger';
 import type { DefaultHmrContext } from '@ecopages/core';
@@ -29,6 +37,21 @@ import type { HmrPageMetadataCache } from './page-metadata-cache.ts';
 import type { EcoComponentConfig } from '@ecopages/core';
 
 const appLogger = new Logger('[ReactHmrStrategy]');
+
+/** Entrypoints emitted per grouped Rolldown pass during the cold client graph build. */
+const COLD_BATCH_CHUNK_SIZE = 25;
+
+export type ColdClientGraphDependencies = {
+	templateRouteFilePaths: readonly string[];
+	trackInFlightEntrypoint: (entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>) => void;
+	releaseInFlightEntrypoint: (entrypointPath: string) => void;
+};
+
+type ColdClientGraphTarget = {
+	entrypointPath: string;
+	outputPath: string;
+	outputUrl: string;
+};
 
 export interface ReactHmrStrategyOptions {
 	context: DefaultHmrContext;
@@ -124,6 +147,7 @@ export class ReactHmrStrategy extends HmrStrategy {
 	private pageMetadataCache: HmrPageMetadataCache;
 	private readonly runtimeManifest: BrowserRuntimeManifest;
 	private readonly clientGraphBoundaryCache: ClientGraphBoundaryCache;
+	private devHmrEntrypointCache?: DevHmrEntrypointCache;
 
 	constructor(options: ReactHmrStrategyOptions) {
 		super();
@@ -502,6 +526,11 @@ export class ReactHmrStrategy extends HmrStrategy {
 			hasLayoutOwnedRequestedTarget = await this.hasLayoutOwnedDependencyTarget(_filePath, requestedTargets);
 		}
 		const requiresLayoutRefresh = isLayout || hasOwnedLayoutDependencyHit || hasLayoutOwnedRequestedTarget;
+
+		this.invalidateColdGraphCacheForPaths([
+			...pageTargets.map((target) => target.entrypointPath),
+			...nonPageTargets.map((target) => target.entrypointPath),
+		]);
 
 		await this.clearOutdirsForTargets(pageTargets, nonPageTargets);
 
@@ -926,6 +955,230 @@ export class ReactHmrStrategy extends HmrStrategy {
 			appLogger.error(`Error processing output for ${url}:`, error as Error);
 			await fileSystem.removeAsync(tempPath).catch(() => {});
 			return false;
+		}
+	}
+
+	/**
+	 * Builds the full client HMR graph in grouped Rolldown passes during server startup.
+	 *
+	 * @remarks
+	 * Discovers React page entrypoints from the route registry (with a pages-dir
+	 * fallback), seeds cache hits immediately, and builds uncached chunks in the
+	 * background. In-flight promises are registered before each grouped build so
+	 * concurrent SSR callers coalesce on the same work.
+	 */
+	async prepareColdClientGraph(
+		cache: DevHmrEntrypointCache,
+		dependencies: ColdClientGraphDependencies,
+	): Promise<void> {
+		this.devHmrEntrypointCache = cache;
+		const entrypoints = await this.discoverColdClientGraphEntrypoints(dependencies.templateRouteFilePaths);
+		if (entrypoints.length === 0) {
+			return;
+		}
+
+		appLogger.debug(`Preparing cold client graph for ${entrypoints.length} React entrypoints`);
+
+		for (let index = 0; index < entrypoints.length; index += COLD_BATCH_CHUNK_SIZE) {
+			const chunk = entrypoints.slice(index, index + COLD_BATCH_CHUNK_SIZE);
+			const targets = chunk.map((entrypointPath) => {
+				const { outputPath, outputUrl } = this.getEntrypointOutput(entrypointPath);
+				return { entrypointPath, outputPath, outputUrl };
+			});
+
+			const cachedTargets: ColdClientGraphTarget[] = [];
+			const uncachedTargets: ColdClientGraphTarget[] = [];
+
+			for (const target of targets) {
+				const hit = getDevHmrEntrypointCacheEntry(cache, target.entrypointPath);
+				if (hit && fileSystem.exists(hit.outputPath)) {
+					cachedTargets.push({
+						entrypointPath: target.entrypointPath,
+						outputPath: hit.outputPath,
+						outputUrl: hit.outputUrl,
+					});
+				} else {
+					uncachedTargets.push(target);
+				}
+			}
+
+			for (const target of cachedTargets) {
+				this.context.seedResolvedEntrypoint({
+					sourcePath: target.entrypointPath,
+					outputPath: target.outputPath,
+					outputUrl: target.outputUrl,
+				});
+			}
+
+			if (uncachedTargets.length === 0) {
+				continue;
+			}
+
+			await this.materializeUncachedColdClientGraphChunk(uncachedTargets, cache, dependencies);
+		}
+	}
+
+	private async discoverColdClientGraphEntrypoints(templateRouteFilePaths: readonly string[]): Promise<string[]> {
+		const fromRoutes = this.collectReactEntrypointsFromRouteFiles(templateRouteFilePaths);
+		if (fromRoutes.length > 0) {
+			return fromRoutes;
+		}
+
+		return this.discoverReactEntrypointsFromPagesDir();
+	}
+
+	private collectReactEntrypointsFromRouteFiles(templateRouteFilePaths: readonly string[]): string[] {
+		const seen = new Set<string>();
+		const entrypoints: string[] = [];
+
+		for (const filePath of templateRouteFilePaths) {
+			if (!this.isReactEntrypoint(filePath) || !this.isPageEntrypoint(filePath)) {
+				continue;
+			}
+
+			const normalized = path.resolve(filePath);
+			if (seen.has(normalized)) {
+				continue;
+			}
+
+			seen.add(normalized);
+			this.pageMetadataCache.markOwnedEntrypoint(filePath);
+			entrypoints.push(filePath);
+		}
+
+		return entrypoints.sort((left, right) => left.localeCompare(right));
+	}
+
+	private discoverReactEntrypointsFromPagesDir(): string[] {
+		const pagesDir = this.context.getPagesDir();
+		const files: string[] = [];
+
+		const walk = (dir: string): void => {
+			if (!fileSystem.exists(dir)) {
+				return;
+			}
+
+			let entries: fs.Dirent[];
+			try {
+				entries = fs.readdirSync(dir, { withFileTypes: true });
+			} catch {
+				return;
+			}
+
+			for (const entry of entries) {
+				const entryPath = path.join(dir, entry.name);
+				if (entry.isDirectory()) {
+					walk(entryPath);
+					continue;
+				}
+
+				if (/\.(tsx?|jsx?|mdx)$/.test(entry.name)) {
+					files.push(entryPath);
+				}
+			}
+		};
+
+		walk(pagesDir);
+
+		const seen = new Set<string>();
+		const entrypoints: string[] = [];
+
+		for (const filePath of files) {
+			let source: string;
+			try {
+				source = fs.readFileSync(filePath, 'utf8');
+			} catch {
+				continue;
+			}
+
+			if (!/\beco\.page(?:<[^>]*>)?\s*\(/.test(source)) {
+				continue;
+			}
+
+			if (!this.isReactEntrypoint(filePath) || !this.isPageEntrypoint(filePath)) {
+				continue;
+			}
+
+			const normalized = path.resolve(filePath);
+			if (seen.has(normalized)) {
+				continue;
+			}
+
+			seen.add(normalized);
+			this.pageMetadataCache.markOwnedEntrypoint(filePath);
+			entrypoints.push(filePath);
+		}
+
+		return entrypoints.sort((left, right) => left.localeCompare(right));
+	}
+
+	private async materializeUncachedColdClientGraphChunk(
+		uncachedTargets: ColdClientGraphTarget[],
+		cache: DevHmrEntrypointCache,
+		dependencies: ColdClientGraphDependencies,
+	): Promise<void> {
+		const chunkPromise = (async () => {
+			const builtUrls = await this.bundleReactBuildTargets(
+				uncachedTargets.map((target) => ({
+					entrypointPath: target.entrypointPath,
+					outputUrl: target.outputUrl,
+				})),
+				{ grouped: true },
+			);
+			const builtUrlSet = new Set(builtUrls);
+
+			for (const target of uncachedTargets) {
+				if (!builtUrlSet.has(target.outputUrl)) {
+					continue;
+				}
+
+				this.context.seedResolvedEntrypoint({
+					sourcePath: target.entrypointPath,
+					outputPath: target.outputPath,
+					outputUrl: target.outputUrl,
+				});
+
+				let sourceMtimeMs = 0;
+				try {
+					sourceMtimeMs = fs.statSync(target.entrypointPath).mtimeMs;
+				} catch {
+					// leave mtime at 0; the next session will rebuild defensively
+				}
+
+				setDevHmrEntrypointCacheEntry(cache, target.entrypointPath, {
+					outputPath: target.outputPath,
+					outputUrl: target.outputUrl,
+					sourceMtimeMs,
+					builtAt: Date.now(),
+				});
+			}
+		})();
+
+		for (const target of uncachedTargets) {
+			const inFlightPromise = chunkPromise.then(() => ({
+				sourcePath: target.entrypointPath,
+				outputPath: target.outputPath,
+				outputUrl: target.outputUrl,
+			}));
+			dependencies.trackInFlightEntrypoint(target.entrypointPath, inFlightPromise);
+		}
+
+		try {
+			await chunkPromise;
+		} finally {
+			for (const target of uncachedTargets) {
+				dependencies.releaseInFlightEntrypoint(target.entrypointPath);
+			}
+		}
+	}
+
+	private invalidateColdGraphCacheForPaths(entrypointPaths: string[]): void {
+		if (!this.devHmrEntrypointCache) {
+			return;
+		}
+
+		for (const entrypointPath of entrypointPaths) {
+			removeDevHmrEntrypointCacheEntry(this.devHmrEntrypointCache, entrypointPath);
 		}
 	}
 }

--- a/packages/integrations/react/src/plugin/react.plugin.ts
+++ b/packages/integrations/react/src/plugin/react.plugin.ts
@@ -315,12 +315,13 @@ export class ReactPlugin extends IntegrationPlugin<React.ReactNode> {
 		this.devClientGraphPrewarmPromise = strategy
 			.prepareColdClientGraph(cache, {
 				templateRouteFilePaths: options.templateRouteFilePaths,
-				trackInFlightEntrypoint: (entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>) => {
-					this.hmrManager?.trackInFlightEntrypoint?.(entrypointPath, promise);
-				},
+				tryTrackInFlightEntrypoint: (entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>) =>
+					this.hmrManager?.tryTrackInFlightEntrypoint?.(entrypointPath, promise) ?? false,
 				releaseInFlightEntrypoint: (entrypointPath: string) => {
 					this.hmrManager?.releaseInFlightEntrypoint?.(entrypointPath);
 				},
+				getMissingEntrypointError: (entrypointPath: string, outputPath: string) =>
+					new Error(`Cold client graph did not materialize ${entrypointPath} -> ${outputPath}`),
 			})
 			.catch((error: unknown) => {
 				appLogger.warn(

--- a/packages/integrations/react/src/plugin/react.plugin.ts
+++ b/packages/integrations/react/src/plugin/react.plugin.ts
@@ -5,11 +5,15 @@
 import type { AssetDefinition } from '@ecopages/core/services/asset-processing-service';
 import {
 	IntegrationPlugin,
+	type DevClientGraphPrewarmOptions,
 	type EcoBuildPlugin,
 	type IntegrationPluginConfig,
 } from '@ecopages/core/plugins/integration-plugin';
 import type { BrowserRuntimeManifest } from '@ecopages/core/build/browser-runtime-manifest';
 import type { HmrStrategy } from '@ecopages/core/hmr/hmr-strategy';
+import type { ResolvedHmrEntrypoint } from '@ecopages/core';
+import { createDevHmrEntrypointCache } from '@ecopages/core/build/dev-hmr-entrypoint-cache';
+import { startupTrace } from '@ecopages/core/diagnostics/startup-trace';
 import { Logger } from '@ecopages/logger';
 import type { CompileOptions } from '@mdx-js/mdx';
 import path from 'node:path';
@@ -112,6 +116,7 @@ export class ReactPlugin extends IntegrationPlugin<React.ReactNode> {
 	private readonly hmrPageMetadataCache: HmrPageMetadataCache;
 	private readonly clientGraphBoundaryCache: ClientGraphBoundaryCache;
 	private hmrStrategy?: ReactHmrStrategy;
+	private devClientGraphPrewarmPromise?: Promise<void>;
 	private runtimeDependenciesInitialized = false;
 	/**
 	 * When true, always emit page browser graph / hydration assets.
@@ -293,6 +298,44 @@ export class ReactPlugin extends IntegrationPlugin<React.ReactNode> {
 		}
 
 		return this.hmrStrategy;
+	}
+
+	override startDevClientGraphPrewarm(options: DevClientGraphPrewarmOptions): void {
+		if (!this.hmrManager?.isEnabled()) {
+			return;
+		}
+
+		const strategy = this.getHmrStrategy() as ReactHmrStrategy | undefined;
+		if (!strategy) {
+			return;
+		}
+
+		const cache = createDevHmrEntrypointCache(options.appConfig);
+		startupTrace.markPhaseStart('dev-cold-client-graph');
+		this.devClientGraphPrewarmPromise = strategy
+			.prepareColdClientGraph(cache, {
+				templateRouteFilePaths: options.templateRouteFilePaths,
+				trackInFlightEntrypoint: (entrypointPath: string, promise: Promise<ResolvedHmrEntrypoint>) => {
+					this.hmrManager?.trackInFlightEntrypoint?.(entrypointPath, promise);
+				},
+				releaseInFlightEntrypoint: (entrypointPath: string) => {
+					this.hmrManager?.releaseInFlightEntrypoint?.(entrypointPath);
+				},
+			})
+			.catch((error: unknown) => {
+				appLogger.warn(
+					'Cold client graph build failed; first SSR will build entrypoints on demand.',
+					error as Error,
+				);
+			})
+			.finally(() => {
+				startupTrace.markPhaseEnd('dev-cold-client-graph');
+				startupTrace.resetFirstRequestCounters();
+			});
+	}
+
+	override async awaitDevClientGraphPrewarm(): Promise<void> {
+		await this.devClientGraphPrewarmPromise;
 	}
 }
 

--- a/scripts/agora-hmr-warmup-bench.mjs
+++ b/scripts/agora-hmr-warmup-bench.mjs
@@ -1,0 +1,298 @@
+/**
+ * Benchmark HMR cold client-graph warmup against the agora app using local dist packages.
+ *
+ * Usage (from ecopages repo root):
+ *   node scripts/agora-hmr-warmup-bench.mjs
+ *
+ * Requires agora at ../techn.es/apps/agora and docker postgres for /login SSR.
+ */
+
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+const agoraDir = path.resolve(repoRoot, '..', 'techn.es', 'apps', 'agora');
+const agoraPackageJsonPath = path.join(agoraDir, 'package.json');
+const workspaceYamlPath = path.resolve(agoraDir, '..', '..', 'pnpm-workspace.yaml');
+const loginUrl = `http://localhost:${process.env.AGORA_BENCH_PORT ?? '3012'}/login`;
+const port = Number(process.env.AGORA_BENCH_PORT ?? '3012');
+
+const localPackages = {
+	ecopages: path.join(repoRoot, 'packages', 'ecopages', 'dist'),
+	'@ecopages/browser-router': path.join(repoRoot, 'packages', 'browser-router', 'dist'),
+	'@ecopages/core': path.join(repoRoot, 'packages', 'core', 'dist'),
+	'@ecopages/file-system': path.join(repoRoot, 'packages', 'file-system', 'dist'),
+	'@ecopages/image-processor': path.join(repoRoot, 'packages', 'processors', 'image-processor', 'dist'),
+	'@ecopages/mdx': path.join(repoRoot, 'packages', 'integrations', 'mdx', 'dist'),
+	'@ecopages/postcss-processor': path.join(repoRoot, 'packages', 'processors', 'postcss-processor', 'dist'),
+	'@ecopages/react': path.join(repoRoot, 'packages', 'integrations', 'react', 'dist'),
+	'@ecopages/react-router': path.join(repoRoot, 'packages', 'react-router', 'dist'),
+};
+
+function toFileSpec(absolutePath) {
+	return `file:${absolutePath}`;
+}
+
+function readJson(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+	fs.writeFileSync(filePath, `${JSON.stringify(value, null, 4)}\n`, 'utf8');
+}
+
+function run(command, args, cwd, env = process.env) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			cwd,
+			env,
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+
+		let stdout = '';
+		let stderr = '';
+		child.stdout.on('data', (chunk) => {
+			const text = String(chunk);
+			stdout += text;
+			process.stdout.write(text);
+		});
+		child.stderr.on('data', (chunk) => {
+			const text = String(chunk);
+			stderr += text;
+			process.stderr.write(text);
+		});
+		child.on('error', reject);
+		child.on('close', (code) => {
+			if (code === 0) {
+				resolve({ stdout, stderr });
+			} else {
+				reject(new Error(`${command} ${args.join(' ')} failed with exit code ${code}`));
+			}
+		});
+	});
+}
+
+function parseTraceLines(output) {
+	const phases = {};
+	for (const line of output.split('\n')) {
+		const phaseMatch = line.match(/phase=([^\s]+)(?:\s+durationMs=(\d+))?/);
+		if (phaseMatch) {
+			phases[phaseMatch[1]] = {
+				durationMs: phaseMatch[2] ? Number(phaseMatch[2]) : undefined,
+				line,
+			};
+		}
+	}
+	return phases;
+}
+
+function startDevServer(clearArtifacts) {
+	return new Promise((resolve, reject) => {
+		if (clearArtifacts) {
+			fs.rmSync(path.join(agoraDir, '.eco', 'assets', '_hmr'), { recursive: true, force: true });
+			fs.rmSync(path.join(agoraDir, 'node_modules', '.cache', 'ecopages'), { recursive: true, force: true });
+		}
+
+		const child = spawn('pnpm', ['exec', 'ecopages', 'dev', '-r', '-p', String(port), '-n', '0.0.0.0'], {
+			cwd: agoraDir,
+			env: {
+				...process.env,
+				ECOPAGES_STARTUP_TRACE: 'true',
+				ECOPAGES_LOGGER_DEBUG: 'false',
+			},
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+
+		let output = '';
+		const append = (chunk) => {
+			const text = String(chunk);
+			output += text;
+			process.stdout.write(text);
+		};
+		child.stdout.on('data', append);
+		child.stderr.on('data', append);
+
+		const deadline = Date.now() + 180_000;
+		const interval = setInterval(() => {
+			if (output.includes('running at') || output.includes(`localhost:${port}`)) {
+				clearInterval(interval);
+				resolve({
+					child,
+					output: () => output,
+					waitFor: async (pattern, timeoutMs = 120_000) => {
+						const start = Date.now();
+						while (Date.now() - start < timeoutMs) {
+							if (pattern.test(output)) {
+								return output;
+							}
+							await new Promise((r) => setTimeout(r, 250));
+						}
+						throw new Error(`Timed out waiting for ${pattern}`);
+					},
+				});
+				return;
+			}
+
+			if (Date.now() > deadline) {
+				clearInterval(interval);
+				child.kill('SIGTERM');
+				reject(new Error('Dev server failed to start within 180s'));
+			}
+		}, 250);
+
+		child.on('exit', (code) => {
+			if (code !== null && code !== 0) {
+				clearInterval(interval);
+				reject(new Error(`Dev server exited early with code ${code}\n${output}`));
+			}
+		});
+	});
+}
+
+async function curlLogin() {
+	const start = Date.now();
+	const response = await fetch(loginUrl, { redirect: 'manual' });
+	const elapsed = Date.now() - start;
+	return { status: response.status, elapsed };
+}
+
+async function stopServer(session) {
+	if (!session?.child || session.child.killed) {
+		return;
+	}
+
+	const child = session.child;
+	child.kill('SIGTERM');
+
+	await new Promise((resolve) => {
+		const timer = setTimeout(() => {
+			try {
+				child.kill('SIGKILL');
+			} catch {
+				// already stopped
+			}
+			resolve();
+		}, 8000);
+
+		child.once('exit', () => {
+			clearTimeout(timer);
+			resolve();
+		});
+	});
+
+	await new Promise((r) => setTimeout(r, 1500));
+}
+
+async function main() {
+	if (!fs.existsSync(agoraPackageJsonPath)) {
+		throw new Error(`Agora not found at ${agoraDir}`);
+	}
+
+	for (const targetPath of Object.values(localPackages)) {
+		if (!fs.existsSync(targetPath)) {
+			throw new Error(`Missing local build output: ${targetPath}. Run pnpm build:npm first.`);
+		}
+	}
+
+	const packageJsonBackup = fs.readFileSync(agoraPackageJsonPath, 'utf8');
+	const workspaceBackup = fs.existsSync(workspaceYamlPath) ? fs.readFileSync(workspaceYamlPath, 'utf8') : null;
+
+	const packageJson = readJson(agoraPackageJsonPath);
+	for (const [name, targetPath] of Object.entries(localPackages)) {
+		if (packageJson.devDependencies?.[name]) {
+			packageJson.devDependencies[name] = toFileSpec(targetPath);
+		}
+	}
+	writeJson(agoraPackageJsonPath, packageJson);
+
+	if (workspaceBackup) {
+		const fileOverrides = Object.fromEntries(
+			Object.entries(localPackages).map(([name, targetPath]) => [name, toFileSpec(targetPath)]),
+		);
+		const lines = workspaceBackup.split('\n');
+		const overridesIndex = lines.findIndex((line) => line.trim() === 'overrides:');
+		if (overridesIndex === -1) {
+			throw new Error('Could not find overrides block in pnpm-workspace.yaml');
+		}
+
+		let endIndex = overridesIndex + 1;
+		while (endIndex < lines.length && /^\s{4}\S/.test(lines[endIndex] ?? '')) {
+			endIndex += 1;
+		}
+
+		const overrideLines = Object.entries(fileOverrides).map(
+			([name, spec]) => `    ${JSON.stringify(name)}: ${JSON.stringify(spec)}`,
+		);
+		const nextLines = [...lines.slice(0, endIndex), ...overrideLines, ...lines.slice(endIndex)];
+		fs.writeFileSync(workspaceYamlPath, `${nextLines.join('\n')}\n`, 'utf8');
+	}
+
+	console.log('Installing agora with local ecopages dist packages...');
+	await run('pnpm', ['update', ...Object.keys(localPackages)], agoraDir);
+
+	const results = {};
+
+	try {
+		console.log('\n=== Case A: immediate /login at listen ===');
+		let session = await startDevServer(true);
+		const caseAStart = Date.now();
+		const caseA = await curlLogin();
+		const caseAOutput = session.output();
+		results.caseA = {
+			httpStatus: caseA.status,
+			curlMs: caseA.elapsed,
+			msSinceListen: Date.now() - caseAStart,
+			phases: parseTraceLines(caseAOutput),
+		};
+		await stopServer(session);
+
+		console.log('\n=== Case B: /login after dev-cold-client-graph ===');
+		session = await startDevServer(true);
+		await session.waitFor(/phase=dev-cold-client-graph\s+durationMs=/);
+		await new Promise((r) => setTimeout(r, 500));
+		const caseB = await curlLogin();
+		const caseBOutput = session.output();
+		results.caseB = {
+			httpStatus: caseB.status,
+			curlMs: caseB.elapsed,
+			phases: parseTraceLines(caseBOutput),
+			firstPageBrowserGraphMs: parseTraceLines(caseBOutput)['first-page-browser-graph']?.durationMs,
+		};
+		await stopServer(session);
+
+		console.log('\n=== Case C: restart with disk cache ===');
+		session = await startDevServer(false);
+		await session.waitFor(/phase=dev-cold-client-graph\s+durationMs=/);
+		const caseC = await curlLogin();
+		const caseCOutput = session.output();
+		results.caseC = {
+			httpStatus: caseC.status,
+			curlMs: caseC.elapsed,
+			phases: parseTraceLines(caseCOutput),
+			devColdClientGraphMs: parseTraceLines(caseCOutput)['dev-cold-client-graph']?.durationMs,
+			firstPageBrowserGraphMs: parseTraceLines(caseCOutput)['first-page-browser-graph']?.durationMs,
+		};
+		await stopServer(session);
+
+		const benchPath = path.join(repoRoot, '.audit', 'agora-hmr-warmup-bench.json');
+		fs.mkdirSync(path.dirname(benchPath), { recursive: true });
+		fs.writeFileSync(benchPath, `${JSON.stringify(results, null, 2)}\n`, 'utf8');
+
+		console.log('\n=== Summary ===');
+		console.log(JSON.stringify(results, null, 2));
+		console.log(`\nWrote ${benchPath}`);
+	} finally {
+		fs.writeFileSync(agoraPackageJsonPath, packageJsonBackup, 'utf8');
+		if (workspaceBackup !== null) {
+			fs.writeFileSync(workspaceYamlPath, workspaceBackup, 'utf8');
+		}
+	}
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : error);
+	process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- Restore Vite-style background HMR client-graph warmup for React pages: discover routes at startup, build grouped Rolldown chunks in the background, seed the registrar, and persist outputs under `node_modules/.cache/ecopages`.
- Coalesce concurrent SSR and prewarm via in-flight entrypoint tracking so the same page never pays two Rolldown emits.
- On by default in HMR dev; opt out with `ECOPAGES_DEV_COLD_CLIENT_GRAPH=false`. Optional blocking with `ECOPAGES_DEV_COLD_CLIENT_GRAPH_BLOCKING=true`.

## Verification

**Unit:** 2024 vitest tests pass (including cache, coalesce, lifecycle, `prepareColdClientGraph`).

**kitchen-sink (workspace):**
- After warmup: first `/` request `graphBuildCount=0`
- Cache restart: `dev-cold-client-graph` ~16ms

**agora (local `file:` dist overrides):**
- Case A (immediate `/login`): `graphBuildCount=1` — coalesced with background prewarm (~15s, not double Rolldown)
- Case B (after `dev-cold-client-graph`): `first-page-browser-graph` ~2.3s (improved vs ~3.8s baseline; large app with many pages)
- Background prewarm phase: ~11.8s for full route set

**Scope:** React only today. Core exposes integration hooks (`startDevClientGraphPrewarm` / `awaitDevClientGraphPrewarm`); Lit/MDX/Kitajs keep no-op defaults.

## Test plan

- [x] `pnpm run test:vitest`
- [x] agora cases A/B with `ECOPAGES_STARTUP_TRACE=true` and local dist
- [x] kitchen-sink cold-graph + cache hit
- [ ] CI on PR