### PR TITLE
refactor(hmr): dev transform as sole page entrypoint path

### DIFF
--- a/packages/core/src/adapters/bun/hmr-manager.test.ts
+++ b/packages/core/src/adapters/bun/hmr-manager.test.ts
@@ -44,8 +44,6 @@ test('HmrManager shares one in-flight entrypoint registration across concurrent 
 		} as any,
 	});
 
-	const emitIntegrationEntrypoint = vi.spyOn(manager, 'emitIntegrationEntrypoint');
-
 	const [firstUrl, secondUrl] = await Promise.all([
 		manager.registerEntrypoint(entrypointPath),
 		manager.registerEntrypoint(entrypointPath),
@@ -53,7 +51,6 @@ test('HmrManager shares one in-flight entrypoint registration across concurrent 
 
 	assert.equal(firstUrl, `${DEV_TRANSFORM_URL_PREFIX}/pages/react-lab.js`);
 	assert.equal(secondUrl, `${DEV_TRANSFORM_URL_PREFIX}/pages/react-lab.js`);
-	assert.equal(emitIntegrationEntrypoint.mock.calls.length, 0);
 });
 
 test('HmrManager registers unowned page entrypoints with dev transform URLs', async () => {

--- a/packages/core/src/adapters/node/node-hmr-manager.test.ts
+++ b/packages/core/src/adapters/node/node-hmr-manager.test.ts
@@ -43,8 +43,6 @@ test('NodeHmrManager shares one in-flight entrypoint registration across concurr
 		} as any,
 	});
 
-	const emitIntegrationEntrypoint = vi.spyOn(manager, 'emitIntegrationEntrypoint');
-
 	const [firstUrl, secondUrl] = await Promise.all([
 		manager.registerEntrypoint(entrypointPath),
 		manager.registerEntrypoint(entrypointPath),
@@ -52,7 +50,6 @@ test('NodeHmrManager shares one in-flight entrypoint registration across concurr
 
 	assert.equal(firstUrl, `${DEV_TRANSFORM_URL_PREFIX}/pages/react-lab.js`);
 	assert.equal(secondUrl, `${DEV_TRANSFORM_URL_PREFIX}/pages/react-lab.js`);
-	assert.equal(emitIntegrationEntrypoint.mock.calls.length, 0);
 });
 
 test('NodeHmrManager does not broadcast HMR events for initial entrypoint registration builds', async () => {

--- a/packages/core/src/adapters/shared/hmr/hmr-manager.contract.test.ts
+++ b/packages/core/src/adapters/shared/hmr/hmr-manager.contract.test.ts
@@ -68,8 +68,6 @@ describe.each(runtimes)('shared HMR manager contract: $name', ({ create }) => {
 
 		using manager = await create(rootDir);
 
-		const emitIntegrationEntrypoint = vi.spyOn(manager, 'emitIntegrationEntrypoint');
-
 		const [firstUrl, secondUrl] = await Promise.all([
 			manager.registerEntrypoint(entrypointPath),
 			manager.registerEntrypoint(entrypointPath),
@@ -77,7 +75,6 @@ describe.each(runtimes)('shared HMR manager contract: $name', ({ create }) => {
 
 		assert.equal(firstUrl, `${DEV_TRANSFORM_URL_PREFIX}/pages/react-lab.js`);
 		assert.equal(secondUrl, `${DEV_TRANSFORM_URL_PREFIX}/pages/react-lab.js`);
-		assert.equal(emitIntegrationEntrypoint.mock.calls.length, 0);
 	});
 
 	test('registers unowned page entrypoints with dev transform URLs', async () => {

--- a/packages/core/src/adapters/shared/hmr/hmr-manager.dispatch.test.ts
+++ b/packages/core/src/adapters/shared/hmr/hmr-manager.dispatch.test.ts
@@ -87,7 +87,7 @@ const runtimes = [
 ] as const;
 
 describe.each(runtimes)('handleFileChange dispatch: $name', ({ create }) => {
-	test('non-script file changes invalidate dev transform cache and broadcast reload', async () => {
+	test('CSS file change routes to DefaultHmrStrategy and broadcasts reload', async () => {
 		const rootDir = createTempRoot('ecopages-dispatch-css');
 		fs.mkdirSync(path.join(rootDir, 'src'), { recursive: true });
 		const spy = createBridgeSpy();
@@ -100,9 +100,10 @@ describe.each(runtimes)('handleFileChange dispatch: $name', ({ create }) => {
 
 		assert.equal(spy.broadcasts.length, 1);
 		assert.equal(spy.broadcasts[0].type, 'reload');
+		assert.equal(spy.broadcasts[0].path, cssFile);
 	});
 
-	test('broadcast:false suppresses reload for non-script changes', async () => {
+	test('broadcast:false suppresses events even when the strategy returns a broadcast action', async () => {
 		const rootDir = createTempRoot('ecopages-dispatch-no-broadcast');
 		fs.mkdirSync(path.join(rootDir, 'src'), { recursive: true });
 		const spy = createBridgeSpy();
@@ -115,16 +116,23 @@ describe.each(runtimes)('handleFileChange dispatch: $name', ({ create }) => {
 		assert.equal(spy.broadcasts.length, 0);
 	});
 
-	test('defers reload broadcasts when no subscribers are connected', async () => {
+	test('defers client rebuilds when no subscribers are connected', async () => {
 		const rootDir = createTempRoot('ecopages-dispatch-no-subscribers');
 		fs.mkdirSync(path.join(rootDir, 'src'), { recursive: true });
 		const spy = createBridgeSpy();
 		spy.bridge.subscriberCount = 0;
 		using manager = await create(rootDir, spy);
 
-		const tsFile = path.join(rootDir, 'src', 'component.ts');
-		fs.writeFileSync(tsFile, 'export const component = true;\n', 'utf8');
-		await manager.handleFileChange(tsFile);
+		const customFile = path.join(rootDir, 'src', 'deferred.ts');
+		fs.writeFileSync(customFile, 'export const deferred = true;\n', 'utf8');
+		manager.registerStrategy(
+			new FakeHmrStrategy(HmrStrategyType.INTEGRATION, (filePath) => filePath === customFile, {
+				type: 'broadcast',
+				events: [{ type: 'update', path: '/assets/_hmr/deferred.js', timestamp: 1 }],
+			}),
+		);
+
+		await manager.handleFileChange(customFile);
 
 		assert.equal(spy.broadcasts.length, 0);
 	});

--- a/packages/core/src/adapters/shared/hmr/shared-hmr-manager.ts
+++ b/packages/core/src/adapters/shared/hmr/shared-hmr-manager.ts
@@ -325,46 +325,6 @@ export abstract class SharedHmrManager implements IHmrManager {
 		});
 	}
 
-	private selectEntrypointEmitter(entrypointPath: string): HmrStrategy | undefined {
-		return this.getStrategiesByPriority().find((candidate) => {
-			if (candidate.type !== HmrStrategyType.INTEGRATION) {
-				return false;
-			}
-
-			try {
-				return candidate.canEmitEntrypoint(entrypointPath);
-			} catch (error) {
-				appLogger.error(error);
-				return false;
-			}
-		});
-	}
-
-	protected createUnownedEntrypointError(entrypointPath: string): Error {
-		return new Error(
-			`[HMR] No integration owns entrypoint ${entrypointPath}. Page entrypoints must be emitted by their owning integration.`,
-		);
-	}
-
-	/**
-	 * Materializes one integration-owned page entrypoint during cold registration.
-	 *
-	 * @remarks
-	 * Registration uses {@link HmrStrategy.canEmitEntrypoint} / {@link HmrStrategy.emitEntrypoint},
-	 * not {@link HmrStrategy.matches} / {@link HmrStrategy.process}. File-change handling stays
-	 * on `handleFileChange()`.
-	 */
-	public async emitIntegrationEntrypoint(entrypointPath: string, outputPath: string): Promise<void> {
-		const emitter = this.selectEntrypointEmitter(entrypointPath);
-
-		if (!emitter) {
-			throw this.createUnownedEntrypointError(entrypointPath);
-		}
-
-		appLogger.debug(`[${this.constructor.name}] Selected entrypoint emitter: ${emitter.constructor.name}`);
-		await emitter.emitEntrypoint(entrypointPath, outputPath);
-	}
-
 	/**
 	 * Runs server invalidation and integration hooks before rebuilding a registered script entrypoint.
 	 *

--- a/packages/core/src/adapters/shared/hmr/shared-hmr-manager.ts
+++ b/packages/core/src/adapters/shared/hmr/shared-hmr-manager.ts
@@ -268,7 +268,43 @@ export abstract class SharedHmrManager implements IHmrManager {
 		}
 
 		this.devTransformServer.invalidateAll();
+
+		if (this.shouldSkipMissingFileChange(filePath) && !fileSystem.exists(filePath)) {
+			appLogger.debug(`[${this.constructor.name}] Skipping missing file change: ${filePath}`);
+			this.clearFailedEntrypointRegistration(filePath);
+			return;
+		}
+
 		const shouldBroadcast = options.broadcast ?? true;
+		const strategy = this.selectChangeStrategy(filePath);
+
+		if (!strategy) {
+			appLogger.warn(`[HMR] No strategy found for ${filePath}`);
+			if (shouldBroadcast && this.bridge.subscriberCount > 0) {
+				this.broadcast({ type: 'reload' });
+			}
+			return;
+		}
+
+		appLogger.debug(`[${this.constructor.name}] Selected strategy: ${strategy.constructor.name}`);
+
+		const action = await strategy.process(filePath);
+
+		if (shouldBroadcast && action.type === 'broadcast' && action.events) {
+			if (this.bridge.subscriberCount === 0) {
+				appLogger.debug(
+					`[${this.constructor.name}] Deferring HMR client broadcast for ${filePath} until a subscriber connects`,
+				);
+				return;
+			}
+
+			for (const event of action.events) {
+				const graphIdentities = event.graphIdentities ?? options.graphIdentities;
+				this.broadcast(graphIdentities === undefined ? event : { ...event, graphIdentities });
+			}
+			return;
+		}
+
 		if (shouldBroadcast && this.bridge.subscriberCount > 0) {
 			this.broadcast({ type: 'reload' });
 		}

--- a/packages/core/src/hmr/client/hmr-runtime.ts
+++ b/packages/core/src/hmr/client/hmr-runtime.ts
@@ -109,7 +109,7 @@ interface HMRPayload {
 
 	function getActiveHmrModuleUrl(): string | undefined {
 		const pageModule = window.__ECO_PAGES__?.page?.module;
-		if (pageModule && pageModule.includes('/assets/_hmr/')) {
+		if (pageModule && (pageModule.includes('/assets/_hmr/') || pageModule.includes('/assets/__eco_dev__/'))) {
 			return pageModule.split('?')[0];
 		}
 

--- a/packages/core/src/hmr/hmr-strategy.ts
+++ b/packages/core/src/hmr/hmr-strategy.ts
@@ -160,16 +160,6 @@ export abstract class HmrStrategy {
 	}
 
 	/**
-	 * Materializes one integration-owned HMR entrypoint during registration.
-	 *
-	 * @remarks
-	 * Must write the canonical output path and must not broadcast client events.
-	 */
-	async emitEntrypoint(_entrypointPath: string, _outputPath: string): Promise<void> {
-		return;
-	}
-
-	/**
 	 * Processes a file change and returns the action to take.
 	 *
 	 * This method may perform side effects such as:

--- a/packages/integrations/react/src/hmr/hmr-strategy.test.ts
+++ b/packages/integrations/react/src/hmr/hmr-strategy.test.ts
@@ -46,6 +46,10 @@ const defaultRuntimeManifest = createBrowserRuntimeManifest([
 	},
 ]);
 
+function devTransformPageUrl(relativeJsPath: string): string {
+	return `/assets/__eco_dev__/pages/${relativeJsPath}`;
+}
+
 function createPageMetadataCache(
 	overrides: {
 		initialOwnedEntrypoints?: string[];
@@ -141,57 +145,6 @@ describe('ReactHmrStrategy', () => {
 		expect(strategy.canEmitEntrypoint(pagePath)).toBe(true);
 	});
 
-	it('emitEntrypoint bundles owned React entrypoints before they are registered in watched files', async () => {
-		const pagePath = '/tmp/src/pages/index.tsx';
-		const bundle = vi.fn(async () => ({
-			success: true,
-			logs: [],
-			outputs: [{ path: '/tmp/.eco/assets/_hmr/pages/index.js' }],
-		}));
-		const strategy = new ReactHmrStrategy({
-			context: createMockContext({
-				getBrowserBundleService: () => ({ bundle }),
-			}),
-			pageMetadataCache: createPageMetadataCache({
-				ownsEntrypoint: (entrypointPath) => entrypointPath === pagePath,
-			}) as any,
-			runtimeManifest: defaultRuntimeManifest,
-		});
-
-		await strategy.emitEntrypoint(pagePath, '/tmp/.eco/assets/_hmr/pages/index.js');
-		expect(bundle).toHaveBeenCalled();
-	});
-
-	it('emitEntrypoint bundles owned React entrypoints during registration when other pages are already watched', async () => {
-		const existingPagePath = '/tmp/src/pages/about.tsx';
-		const pendingPagePath = '/tmp/src/pages/index.tsx';
-		const watchedFiles = new Map<string, string>([[existingPagePath, '/assets/_hmr/pages/about.js']]);
-		const bundle = vi.fn(async () => ({
-			success: true,
-			logs: [],
-			outputs: [{ path: '/tmp/.eco/assets/_hmr/pages/index.123.tmp.js' }],
-		}));
-		const strategy = new ReactHmrStrategy({
-			context: createMockContext({
-				getWatchedFiles: () => watchedFiles,
-				getBrowserBundleService: () => ({ bundle }),
-			}),
-			pageMetadataCache: createPageMetadataCache({
-				ownsEntrypoint: (entrypointPath) =>
-					entrypointPath === existingPagePath || entrypointPath === pendingPagePath,
-			}) as any,
-			runtimeManifest: defaultRuntimeManifest,
-		});
-
-		await strategy.emitEntrypoint(pendingPagePath, '/tmp/.eco/assets/_hmr/pages/index.js');
-		expect(bundle).toHaveBeenCalledTimes(1);
-		expect(bundle).toHaveBeenCalledWith(
-			expect.objectContaining({
-				entrypoints: [pendingPagePath],
-			}),
-		);
-	});
-
 	it('process returns none when no entrypoints are registered yet', async () => {
 		const pagePath = '/tmp/src/pages/index.tsx';
 		const bundle = vi.fn(async () => ({
@@ -215,7 +168,7 @@ describe('ReactHmrStrategy', () => {
 
 	it('matches route templates only when their configured extension is owned by React', () => {
 		const watchedFiles = new Map<string, string>([
-			['/tmp/src/pages/react-lab.tsx', '/assets/_hmr/pages/react-lab.js'],
+			['/tmp/src/pages/react-lab.tsx', '/assets/__eco_dev__/pages/react-lab.js'],
 		]);
 		const strategy = new ReactHmrStrategy({
 			context: createMockContext({
@@ -456,8 +409,8 @@ describe('ReactHmrStrategy', () => {
 		const changedEntrypoint = '/tmp/src/pages/react-lab.react.tsx';
 		const otherEntrypoint = '/tmp/src/pages/react-content.mdx';
 		const watchedFiles = new Map<string, string>([
-			[changedEntrypoint, '/assets/_hmr/pages/react-lab.react.js'],
-			[otherEntrypoint, '/assets/_hmr/pages/react-content.js'],
+			[changedEntrypoint, '/assets/__eco_dev__/pages/react-lab.react.js'],
+			[otherEntrypoint, '/assets/__eco_dev__/pages/react-content.js'],
 		]);
 
 		const strategy = new ReactHmrStrategy({
@@ -478,17 +431,13 @@ describe('ReactHmrStrategy', () => {
 
 		const action = await strategy.process(changedEntrypoint);
 
-		expect((strategy as any).bundleReactEntrypoint).toHaveBeenCalledTimes(1);
-		expect((strategy as any).bundleReactEntrypoint).toHaveBeenCalledWith(
-			changedEntrypoint,
-			'/assets/_hmr/pages/react-lab.react.js',
-		);
+		expect((strategy as any).bundleReactEntrypoint).not.toHaveBeenCalled();
 		expect(action).toEqual({
 			type: 'broadcast',
 			events: [
 				{
 					type: 'update',
-					path: '/assets/_hmr/pages/react-lab.react.js',
+					path: '/assets/__eco_dev__/pages/react-lab.react.js',
 					timestamp: expect.any(Number),
 				},
 			],
@@ -500,8 +449,8 @@ describe('ReactHmrStrategy', () => {
 		const entrypointB = '/tmp/src/pages/react-content.mdx';
 		const changedDependency = '/tmp/src/components/theme-toggle.react.tsx';
 		const watchedFiles = new Map<string, string>([
-			[entrypointA, '/assets/_hmr/pages/react-lab.react.js'],
-			[entrypointB, '/assets/_hmr/pages/react-content.js'],
+			[entrypointA, '/assets/__eco_dev__/pages/react-lab.react.js'],
+			[entrypointB, '/assets/__eco_dev__/pages/react-content.js'],
 		]);
 
 		const strategy = new ReactHmrStrategy({
@@ -518,34 +467,32 @@ describe('ReactHmrStrategy', () => {
 			allTemplateExtensions: ['.react.tsx', '.mdx', '.kita.tsx'],
 		});
 
-		(strategy as any).bundleReactEntrypoints = vi.fn(async () => [
-			'/assets/_hmr/pages/react-lab.react.js',
-			'/assets/_hmr/pages/react-content.js',
-		]);
+		(strategy as any).bundleReactEntrypoints = vi.fn(async () => []);
 
 		const action = await strategy.process(changedDependency);
 
-		expect((strategy as any).bundleReactEntrypoints).toHaveBeenCalledTimes(1);
+		expect((strategy as any).bundleReactEntrypoints).not.toHaveBeenCalled();
 		expect(action).toEqual({
 			type: 'broadcast',
-			events: [
+			events: expect.arrayContaining([
 				{
 					type: 'update',
-					path: '/assets/_hmr/pages/react-lab.react.js',
+					path: '/assets/__eco_dev__/pages/react-lab.react.js',
 					timestamp: expect.any(Number),
 				},
 				{
 					type: 'update',
-					path: '/assets/_hmr/pages/react-content.js',
+					path: '/assets/__eco_dev__/pages/react-content.js',
 					timestamp: expect.any(Number),
 				},
-			],
+			]),
 		});
+		expect(action.events).toHaveLength(2);
 	});
 
-	it('process builds all React page entrypoints together for a watched page entrypoint while only broadcasting the requested page', async () => {
+	it('process broadcasts only the requested dev transform page when sibling pages are grouped', async () => {
 		const changedEntrypoint = '/tmp/src/pages/index.tsx';
-		const watchedFiles = new Map<string, string>([[changedEntrypoint, '/assets/_hmr/pages/index.js']]);
+		const watchedFiles = new Map<string, string>([[changedEntrypoint, devTransformPageUrl('index.js')]]);
 
 		const strategy = new ReactHmrStrategy({
 			context: createMockContext({
@@ -559,29 +506,19 @@ describe('ReactHmrStrategy', () => {
 			runtimeManifest: defaultRuntimeManifest,
 		});
 
-		(strategy as any).bundleReactEntrypoints = vi.fn(async () => [
-			'/assets/_hmr/pages/index.js',
-			'/assets/_hmr/pages/dashboard.js',
-		]);
+		(strategy as any).bundleReactEntrypoints = vi.fn(async () => []);
+		(strategy as any).bundleReactEntrypoint = vi.fn(async () => true);
 
 		const action = await strategy.process(changedEntrypoint);
 
-		expect((strategy as any).bundleReactEntrypoints).toHaveBeenCalledWith([
-			{
-				entrypointPath: '/tmp/src/pages/dashboard.tsx',
-				outputUrl: '/assets/_hmr/pages/dashboard.js',
-			},
-			{
-				entrypointPath: '/tmp/src/pages/index.tsx',
-				outputUrl: '/assets/_hmr/pages/index.js',
-			},
-		]);
+		expect((strategy as any).bundleReactEntrypoints).not.toHaveBeenCalled();
+		expect((strategy as any).bundleReactEntrypoint).not.toHaveBeenCalled();
 		expect(action).toEqual({
 			type: 'broadcast',
 			events: [
 				{
 					type: 'update',
-					path: '/assets/_hmr/pages/index.js',
+					path: devTransformPageUrl('index.js'),
 					timestamp: expect.any(Number),
 				},
 			],
@@ -628,7 +565,7 @@ describe('ReactHmrStrategy', () => {
 		const pageEntrypoint = '/tmp/src/pages/index.tsx';
 		const islandEntrypoint = '/tmp/src/components/counter.tsx';
 		const watchedFiles = new Map<string, string>([
-			[pageEntrypoint, '/assets/_hmr/pages/index.js'],
+			[pageEntrypoint, '/assets/__eco_dev__/pages/index.js'],
 			[islandEntrypoint, '/assets/_hmr/components/counter.js'],
 		]);
 
@@ -643,24 +580,12 @@ describe('ReactHmrStrategy', () => {
 			runtimeManifest: defaultRuntimeManifest,
 		});
 
-		(strategy as any).bundleReactEntrypoints = vi.fn(async () => [
-			'/assets/_hmr/pages/index.js',
-			'/assets/_hmr/pages/dashboard.js',
-		]);
+		(strategy as any).bundleReactEntrypoints = vi.fn(async () => []);
 		(strategy as any).bundleReactEntrypoint = vi.fn(async () => true);
 
 		const action = await strategy.process('/tmp/src/components/theme-toggle.tsx');
 
-		expect((strategy as any).bundleReactEntrypoints).toHaveBeenCalledWith([
-			{
-				entrypointPath: '/tmp/src/pages/dashboard.tsx',
-				outputUrl: '/assets/_hmr/pages/dashboard.js',
-			},
-			{
-				entrypointPath: '/tmp/src/pages/index.tsx',
-				outputUrl: '/assets/_hmr/pages/index.js',
-			},
-		]);
+		expect((strategy as any).bundleReactEntrypoints).not.toHaveBeenCalled();
 		expect((strategy as any).bundleReactEntrypoint).toHaveBeenCalledTimes(1);
 		expect((strategy as any).bundleReactEntrypoint).toHaveBeenCalledWith(
 			'/tmp/src/components/counter.tsx',
@@ -671,7 +596,7 @@ describe('ReactHmrStrategy', () => {
 			events: [
 				{
 					type: 'update',
-					path: '/assets/_hmr/pages/index.js',
+					path: '/assets/__eco_dev__/pages/index.js',
 					timestamp: expect.any(Number),
 				},
 				{
@@ -835,7 +760,9 @@ describe('ReactHmrStrategy', () => {
 
 	describe('dependency graph selective invalidation', () => {
 		it('matches returns true for dependency-hit files tied to owned entrypoints', () => {
-			const watchedFiles = new Map<string, string>([['/tmp/src/pages/index.tsx', '/assets/_hmr/pages/index.js']]);
+			const watchedFiles = new Map<string, string>([
+				['/tmp/src/pages/index.tsx', '/assets/__eco_dev__/pages/index.js'],
+			]);
 			const changedComponent = '/tmp/src/components/button.tsx';
 			const strategy = new ReactHmrStrategy({
 				context: createMockContext({
@@ -859,7 +786,9 @@ describe('ReactHmrStrategy', () => {
 		});
 
 		it('matches returns false for dependency-hit files not tied to owned entrypoints', () => {
-			const watchedFiles = new Map<string, string>([['/tmp/src/pages/index.tsx', '/assets/_hmr/pages/index.js']]);
+			const watchedFiles = new Map<string, string>([
+				['/tmp/src/pages/index.tsx', '/assets/__eco_dev__/pages/index.js'],
+			]);
 			const changedComponent = '/tmp/src/components/button.tsx';
 			const strategy = new ReactHmrStrategy({
 				context: createMockContext({
@@ -887,8 +816,8 @@ describe('ReactHmrStrategy', () => {
 			const entrypointB = '/tmp/src/pages/page-b.tsx';
 			const changedComponent = '/tmp/src/components/shared.tsx';
 			const watchedFiles = new Map<string, string>([
-				[entrypointA, '/assets/_hmr/pages/page-a.js'],
-				[entrypointB, '/assets/_hmr/pages/page-b.js'],
+				[entrypointA, '/assets/__eco_dev__/pages/page-a.js'],
+				[entrypointB, '/assets/__eco_dev__/pages/page-b.js'],
 			]);
 
 			const strategy = new ReactHmrStrategy({
@@ -915,17 +844,13 @@ describe('ReactHmrStrategy', () => {
 
 			const action = await strategy.process(changedComponent);
 
-			expect((strategy as any).bundleReactEntrypoint).toHaveBeenCalledTimes(1);
-			expect((strategy as any).bundleReactEntrypoint).toHaveBeenCalledWith(
-				entrypointA,
-				'/assets/_hmr/pages/page-a.js',
-			);
+			expect((strategy as any).bundleReactEntrypoint).not.toHaveBeenCalled();
 			expect(action).toEqual({
 				type: 'broadcast',
 				events: [
 					{
 						type: 'update',
-						path: '/assets/_hmr/pages/page-a.js',
+						path: '/assets/__eco_dev__/pages/page-a.js',
 						timestamp: expect.any(Number),
 					},
 				],
@@ -936,7 +861,7 @@ describe('ReactHmrStrategy', () => {
 			const entrypointA = '/tmp/src/pages/page-a.tsx';
 			const nonReactEntrypoint = '/tmp/src/pages/other.kita.tsx';
 			const changedComponent = '/tmp/src/components/shared.tsx';
-			const watchedFiles = new Map<string, string>([[entrypointA, '/assets/_hmr/pages/page-a.js']]);
+			const watchedFiles = new Map<string, string>([[entrypointA, '/assets/__eco_dev__/pages/page-a.js']]);
 
 			const strategy = new ReactHmrStrategy({
 				context: createMockContext({
@@ -971,8 +896,8 @@ describe('ReactHmrStrategy', () => {
 			const layoutEntrypoint = '/tmp/src/layouts/base-layout.tsx';
 			const changedComponent = '/tmp/src/components/app-shell.tsx';
 			const watchedFiles = new Map<string, string>([
-				[entrypointA, '/assets/_hmr/pages/page-a.js'],
-				[entrypointB, '/assets/_hmr/pages/page-b.js'],
+				[entrypointA, '/assets/__eco_dev__/pages/page-a.js'],
+				[entrypointB, '/assets/__eco_dev__/pages/page-b.js'],
 			]);
 
 			const strategy = new ReactHmrStrategy({
@@ -998,18 +923,11 @@ describe('ReactHmrStrategy', () => {
 				runtimeManifest: defaultRuntimeManifest,
 			});
 
-			(strategy as any).bundleReactEntrypoints = vi.fn(async () => [
-				'/assets/_hmr/pages/page-a.js',
-				'/assets/_hmr/pages/page-b.js',
-			]);
+			(strategy as any).bundleReactEntrypoints = vi.fn(async () => []);
 
 			const action = await strategy.process(changedComponent);
 
-			expect((strategy as any).bundleReactEntrypoints).toHaveBeenCalledTimes(1);
-			expect((strategy as any).bundleReactEntrypoints).toHaveBeenCalledWith([
-				{ entrypointPath: entrypointA, outputUrl: '/assets/_hmr/pages/page-a.js' },
-				{ entrypointPath: entrypointB, outputUrl: '/assets/_hmr/pages/page-b.js' },
-			]);
+			expect((strategy as any).bundleReactEntrypoints).not.toHaveBeenCalled();
 			expect(action).toEqual({
 				type: 'broadcast',
 				events: [
@@ -1025,8 +943,8 @@ describe('ReactHmrStrategy', () => {
 			const entrypointB = '/tmp/src/pages/page-b.tsx';
 			const changedComponent = '/tmp/src/components/app-shell.tsx';
 			const watchedFiles = new Map<string, string>([
-				[entrypointA, '/assets/_hmr/pages/page-a.js'],
-				[entrypointB, '/assets/_hmr/pages/page-b.js'],
+				[entrypointA, '/assets/__eco_dev__/pages/page-a.js'],
+				[entrypointB, '/assets/__eco_dev__/pages/page-b.js'],
 			]);
 
 			const strategy = new ReactHmrStrategy({
@@ -1078,14 +996,11 @@ describe('ReactHmrStrategy', () => {
 				runtimeManifest: defaultRuntimeManifest,
 			});
 
-			(strategy as any).bundleReactEntrypoints = vi.fn(async () => [
-				'/assets/_hmr/pages/page-a.js',
-				'/assets/_hmr/pages/page-b.js',
-			]);
+			(strategy as any).bundleReactEntrypoints = vi.fn(async () => []);
 
 			const action = await strategy.process(changedComponent);
 
-			expect((strategy as any).bundleReactEntrypoints).toHaveBeenCalledTimes(1);
+			expect((strategy as any).bundleReactEntrypoints).not.toHaveBeenCalled();
 			expect(action).toEqual({
 				type: 'broadcast',
 				events: [
@@ -1101,8 +1016,8 @@ describe('ReactHmrStrategy', () => {
 			const entrypointB = '/tmp/src/pages/page-b.tsx';
 			const changedComponent = '/tmp/src/components/shared.tsx';
 			const watchedFiles = new Map<string, string>([
-				[entrypointA, '/assets/_hmr/pages/page-a.js'],
-				[entrypointB, '/assets/_hmr/pages/page-b.js'],
+				[entrypointA, '/assets/__eco_dev__/pages/page-a.js'],
+				[entrypointB, '/assets/__eco_dev__/pages/page-b.js'],
 			]);
 
 			const strategy = new ReactHmrStrategy({
@@ -1125,25 +1040,22 @@ describe('ReactHmrStrategy', () => {
 				runtimeManifest: defaultRuntimeManifest,
 			});
 
-			(strategy as any).bundleReactEntrypoints = vi.fn(async () => [
-				'/assets/_hmr/pages/page-a.js',
-				'/assets/_hmr/pages/page-b.js',
-			]);
+			(strategy as any).bundleReactEntrypoints = vi.fn(async () => []);
 
 			const action = await strategy.process(changedComponent);
 
-			expect((strategy as any).bundleReactEntrypoints).toHaveBeenCalledTimes(1);
+			expect((strategy as any).bundleReactEntrypoints).not.toHaveBeenCalled();
 			expect(action).toEqual({
 				type: 'broadcast',
 				events: [
 					{
 						type: 'update',
-						path: '/assets/_hmr/pages/page-a.js',
+						path: '/assets/__eco_dev__/pages/page-a.js',
 						timestamp: expect.any(Number),
 					},
 					{
 						type: 'update',
-						path: '/assets/_hmr/pages/page-b.js',
+						path: '/assets/__eco_dev__/pages/page-b.js',
 						timestamp: expect.any(Number),
 					},
 				],
@@ -1155,8 +1067,8 @@ describe('ReactHmrStrategy', () => {
 			const entrypointB = '/tmp/src/pages/page-b.tsx';
 			const changedComponent = '/tmp/src/components/app-shell.tsx';
 			const watchedFiles = new Map<string, string>([
-				[entrypointA, '/assets/_hmr/pages/page-a.js'],
-				[entrypointB, '/assets/_hmr/pages/page-b.js'],
+				[entrypointA, '/assets/__eco_dev__/pages/page-a.js'],
+				[entrypointB, '/assets/__eco_dev__/pages/page-b.js'],
 			]);
 
 			const strategy = new ReactHmrStrategy({
@@ -1207,14 +1119,11 @@ describe('ReactHmrStrategy', () => {
 				runtimeManifest: defaultRuntimeManifest,
 			});
 
-			(strategy as any).bundleReactEntrypoints = vi.fn(async () => [
-				'/assets/_hmr/pages/page-a.js',
-				'/assets/_hmr/pages/page-b.js',
-			]);
+			(strategy as any).bundleReactEntrypoints = vi.fn(async () => []);
 
 			const action = await strategy.process(changedComponent);
 
-			expect((strategy as any).bundleReactEntrypoints).toHaveBeenCalledTimes(1);
+			expect((strategy as any).bundleReactEntrypoints).not.toHaveBeenCalled();
 			expect(action).toEqual({
 				type: 'broadcast',
 				events: [
@@ -1230,8 +1139,8 @@ describe('ReactHmrStrategy', () => {
 			const entrypointB = '/tmp/src/pages/page-b.tsx';
 			const changedComponent = '/tmp/src/components/app-shell.tsx';
 			const watchedFiles = new Map<string, string>([
-				[entrypointA, '/assets/_hmr/pages/page-a.js'],
-				[entrypointB, '/assets/_hmr/pages/page-b.js'],
+				[entrypointA, '/assets/__eco_dev__/pages/page-a.js'],
+				[entrypointB, '/assets/__eco_dev__/pages/page-b.js'],
 				[changedComponent, '/assets/_hmr/components/app-shell.js'],
 			]);
 
@@ -1285,19 +1194,12 @@ describe('ReactHmrStrategy', () => {
 				runtimeManifest: defaultRuntimeManifest,
 			});
 
-			(strategy as any).bundleReactEntrypoints = vi.fn(async () => [
-				'/assets/_hmr/pages/page-a.js',
-				'/assets/_hmr/pages/page-b.js',
-			]);
+			(strategy as any).bundleReactEntrypoints = vi.fn(async () => []);
 			(strategy as any).bundleReactEntrypoint = vi.fn(async () => true);
 
 			const action = await strategy.process(changedComponent);
 
-			expect((strategy as any).bundleReactEntrypoints).toHaveBeenCalledTimes(1);
-			expect((strategy as any).bundleReactEntrypoints).toHaveBeenCalledWith([
-				{ entrypointPath: entrypointA, outputUrl: '/assets/_hmr/pages/page-a.js' },
-				{ entrypointPath: entrypointB, outputUrl: '/assets/_hmr/pages/page-b.js' },
-			]);
+			expect((strategy as any).bundleReactEntrypoints).not.toHaveBeenCalled();
 			expect((strategy as any).bundleReactEntrypoint).toHaveBeenCalledTimes(1);
 			expect((strategy as any).bundleReactEntrypoint).toHaveBeenCalledWith(
 				changedComponent,
@@ -1315,7 +1217,7 @@ describe('ReactHmrStrategy', () => {
 
 		it('matches gives precedence to watched entrypoint check over dependency graph hits', () => {
 			const entrypointA = '/tmp/src/pages/page-a.tsx';
-			const watchedFiles = new Map<string, string>([[entrypointA, '/assets/_hmr/pages/page-a.js']]);
+			const watchedFiles = new Map<string, string>([[entrypointA, '/assets/__eco_dev__/pages/page-a.js']]);
 			const strategy = new ReactHmrStrategy({
 				context: createMockContext({
 					getWatchedFiles: () => watchedFiles,
@@ -1341,8 +1243,8 @@ describe('ReactHmrStrategy', () => {
 			const entrypointA = '/tmp/src/pages/page-a.tsx';
 			const entrypointB = '/tmp/src/pages/page-b.tsx';
 			const watchedFiles = new Map<string, string>([
-				[entrypointA, '/assets/_hmr/pages/page-a.js'],
-				[entrypointB, '/assets/_hmr/pages/page-b.js'],
+				[entrypointA, '/assets/__eco_dev__/pages/page-a.js'],
+				[entrypointB, '/assets/__eco_dev__/pages/page-b.js'],
 			]);
 
 			const strategy = new ReactHmrStrategy({
@@ -1369,17 +1271,13 @@ describe('ReactHmrStrategy', () => {
 
 			const action = await strategy.process(entrypointA);
 
-			expect((strategy as any).bundleReactEntrypoint).toHaveBeenCalledTimes(1);
-			expect((strategy as any).bundleReactEntrypoint).toHaveBeenCalledWith(
-				entrypointA,
-				'/assets/_hmr/pages/page-a.js',
-			);
+			expect((strategy as any).bundleReactEntrypoint).not.toHaveBeenCalled();
 			expect(action).toEqual({
 				type: 'broadcast',
 				events: [
 					{
 						type: 'update',
-						path: '/assets/_hmr/pages/page-a.js',
+						path: '/assets/__eco_dev__/pages/page-a.js',
 						timestamp: expect.any(Number),
 					},
 				],

--- a/packages/integrations/react/src/hmr/hmr-strategy.test.ts
+++ b/packages/integrations/react/src/hmr/hmr-strategy.test.ts
@@ -588,6 +588,42 @@ describe('ReactHmrStrategy', () => {
 		});
 	});
 
+	it('process broadcasts dev transform URLs without rebuilding disk page bundles', async () => {
+		const changedEntrypoint = '/tmp/src/pages/docs/index.tsx';
+		const devTransformUrl = '/assets/__eco_dev__/pages/docs/index.js';
+		const watchedFiles = new Map<string, string>([[changedEntrypoint, devTransformUrl]]);
+
+		const strategy = new ReactHmrStrategy({
+			context: createMockContext({
+				getWatchedFiles: () => watchedFiles,
+			}),
+			pageMetadataCache: createPageMetadataCache({
+				getDeclaredModules: () => [],
+				ownsEntrypoint: (entrypointPath) => entrypointPath === changedEntrypoint,
+				initialOwnedEntrypoints: [changedEntrypoint],
+			}) as any,
+			runtimeManifest: defaultRuntimeManifest,
+		});
+
+		(strategy as any).bundleReactEntrypoints = vi.fn(async () => []);
+		(strategy as any).bundleReactEntrypoint = vi.fn(async () => true);
+
+		const action = await strategy.process(changedEntrypoint);
+
+		expect((strategy as any).bundleReactEntrypoints).not.toHaveBeenCalled();
+		expect((strategy as any).bundleReactEntrypoint).not.toHaveBeenCalled();
+		expect(action).toEqual({
+			type: 'broadcast',
+			events: [
+				{
+					type: 'update',
+					path: devTransformUrl,
+					timestamp: expect.any(Number),
+				},
+			],
+		});
+	});
+
 	it('process keeps non-page entrypoints on the per-entrypoint path when page targets are grouped', async () => {
 		const pageEntrypoint = '/tmp/src/pages/index.tsx';
 		const islandEntrypoint = '/tmp/src/components/counter.tsx';

--- a/packages/integrations/react/src/hmr/hmr-strategy.ts
+++ b/packages/integrations/react/src/hmr/hmr-strategy.ts
@@ -12,6 +12,7 @@ import fs from 'node:fs';
 
 import { HmrStrategy, HmrStrategyType, type HmrAction } from '@ecopages/core/hmr/hmr-strategy';
 import { RESOLVED_ASSETS_DIR } from '@ecopages/core/constants';
+import { DEV_TRANSFORM_URL_PREFIX } from '@ecopages/core/dev/transform-server';
 import type { EcoBuildPlugin } from '@ecopages/core/plugins/integration-plugin';
 import { createBrowserRuntimePlugin } from '@ecopages/core/build/browser-runtime-plugin';
 import type { BrowserRuntimeManifest } from '@ecopages/core/build/browser-runtime-manifest';
@@ -235,6 +236,40 @@ export class ReactHmrStrategy extends HmrStrategy {
 		return this.allTemplateExtensions.find((extension) => filePath.endsWith(extension));
 	}
 
+	private isDevTransformOutputUrl(outputUrl: string): boolean {
+		return outputUrl.startsWith(`${DEV_TRANSFORM_URL_PREFIX}/`);
+	}
+
+	private queueDevTransformOutputUpdates(
+		targets: readonly ReactHmrBuildTarget[],
+		requestedOutputUrls: ReadonlySet<string>,
+		updates: string[],
+	): void {
+		for (const { outputUrl } of targets) {
+			if (requestedOutputUrls.has(outputUrl)) {
+				updates.push(outputUrl);
+			}
+		}
+	}
+
+	private partitionDevTransformBuildTargets(targets: readonly ReactHmrBuildTarget[]): {
+		transformTargets: ReactHmrBuildTarget[];
+		diskTargets: ReactHmrBuildTarget[];
+	} {
+		const transformTargets: ReactHmrBuildTarget[] = [];
+		const diskTargets: ReactHmrBuildTarget[] = [];
+
+		for (const target of targets) {
+			if (this.isDevTransformOutputUrl(target.outputUrl)) {
+				transformTargets.push(target);
+			} else {
+				diskTargets.push(target);
+			}
+		}
+
+		return { transformTargets, diskTargets };
+	}
+
 	private ownsWatchedEntrypoint(filePath: string): boolean {
 		return this.pageMetadataCache.ownsEntrypoint(filePath);
 	}
@@ -290,13 +325,23 @@ export class ReactHmrStrategy extends HmrStrategy {
 	 */
 	matches(filePath: string): boolean {
 		const watchedFiles = this.context.getWatchedFiles();
+		const resolvedFilePath = path.resolve(filePath);
 		appLogger.debug(`Checking ${filePath}. Watched: ${watchedFiles.size}`);
 
-		if (watchedFiles.has(filePath)) {
-			return this.ownsWatchedEntrypoint(filePath);
+		if (watchedFiles.has(resolvedFilePath)) {
+			if (this.ownsWatchedEntrypoint(resolvedFilePath)) {
+				return true;
+			}
+
+			const outputUrl = watchedFiles.get(resolvedFilePath);
+			if (outputUrl && this.isDevTransformOutputUrl(outputUrl) && this.isReactEntrypoint(resolvedFilePath)) {
+				return true;
+			}
+
+			return false;
 		}
 
-		const dependencyHits = this.context.getEntrypointDependencyGraph().getDependencyEntrypoints(filePath);
+		const dependencyHits = this.context.getEntrypointDependencyGraph().getDependencyEntrypoints(resolvedFilePath);
 		if (dependencyHits.size > 0) {
 			for (const entrypoint of dependencyHits) {
 				if (this.ownsWatchedEntrypoint(entrypoint)) {
@@ -356,6 +401,23 @@ export class ReactHmrStrategy extends HmrStrategy {
 		return { outputPath, outputUrl };
 	}
 
+	/**
+	 * Resolves the browser URL for an HMR entrypoint from the watched-file registry.
+	 *
+	 * @remarks
+	 * Dev transform pages register `__eco_dev__` URLs while legacy HMR emits use
+	 * `_hmr` disk paths. Grouped page rebuilds must preserve the registered URL
+	 * so update broadcasts match client `hmrHandlers` keys.
+	 */
+	private resolveEntrypointOutputUrl(entrypointPath: string): string {
+		const watchedOutputUrl = this.context.getWatchedFiles().get(path.resolve(entrypointPath));
+		if (watchedOutputUrl) {
+			return watchedOutputUrl;
+		}
+
+		return this.getEntrypointOutput(entrypointPath).outputUrl;
+	}
+
 	private getRolldownEntryKey(entrypointPath: string): string {
 		const srcDir = this.context.getSrcDir();
 		const relativePath = path.relative(srcDir, entrypointPath);
@@ -381,7 +443,7 @@ export class ReactHmrStrategy extends HmrStrategy {
 
 			targets.set(entrypointPath, {
 				entrypointPath,
-				outputUrl: this.getEntrypointOutput(entrypointPath).outputUrl,
+				outputUrl: this.resolveEntrypointOutputUrl(entrypointPath),
 			});
 		}
 
@@ -411,7 +473,9 @@ export class ReactHmrStrategy extends HmrStrategy {
 
 		const groupedTargets = new Map(requestedPageTargets.map((target) => [target.entrypointPath, target]));
 		for (const target of await this.collectReactPageBuildTargets()) {
-			groupedTargets.set(target.entrypointPath, target);
+			if (!groupedTargets.has(target.entrypointPath)) {
+				groupedTargets.set(target.entrypointPath, target);
+			}
 		}
 
 		return Array.from(groupedTargets.values()).sort((left, right) =>
@@ -462,6 +526,7 @@ export class ReactHmrStrategy extends HmrStrategy {
 	 */
 	async process(_filePath: string): Promise<HmrAction> {
 		appLogger.debug(`Processing ${_filePath}`);
+		const resolvedFilePath = path.resolve(_filePath);
 		const watchedFiles = this.context.getWatchedFiles();
 
 		if (watchedFiles.size === 0) {
@@ -469,23 +534,23 @@ export class ReactHmrStrategy extends HmrStrategy {
 			return { type: 'none' };
 		}
 
-		const isLayout = this.isLayoutFile(_filePath);
-		const isChangedPageEntrypoint = this.isPageEntrypoint(_filePath);
+		const isLayout = this.isLayoutFile(resolvedFilePath);
+		const isChangedPageEntrypoint = this.isPageEntrypoint(resolvedFilePath);
 		if (isLayout) {
-			appLogger.debug(`Detected layout file change: ${_filePath}`);
+			appLogger.debug(`Detected layout file change: ${resolvedFilePath}`);
 		}
 
-		const changedEntrypointOutput = watchedFiles.get(_filePath);
-		if (changedEntrypointOutput && !this.ownsWatchedEntrypoint(_filePath)) {
-			if (this.isReactEntrypoint(_filePath)) {
-				this.pageMetadataCache.markOwnedEntrypoint(_filePath);
+		const changedEntrypointOutput = watchedFiles.get(resolvedFilePath);
+		if (changedEntrypointOutput && !this.ownsWatchedEntrypoint(resolvedFilePath)) {
+			if (this.isReactEntrypoint(resolvedFilePath)) {
+				this.pageMetadataCache.markOwnedEntrypoint(resolvedFilePath);
 			} else {
-				appLogger.debug(`Skipping non-React watched entrypoint: ${_filePath}`);
+				appLogger.debug(`Skipping non-React watched entrypoint: ${resolvedFilePath}`);
 				return { type: 'none' };
 			}
 		}
 
-		const dependencyHits = this.context.getEntrypointDependencyGraph().getDependencyEntrypoints(_filePath);
+		const dependencyHits = this.context.getEntrypointDependencyGraph().getDependencyEntrypoints(resolvedFilePath);
 		const hasDependencyHits = dependencyHits.size > 0;
 		const affectedEntrypoints = new Map<string, string>();
 		let hasOwnedLayoutDependencyHit = false;
@@ -494,13 +559,17 @@ export class ReactHmrStrategy extends HmrStrategy {
 
 		if (hasDependencyHits && !changedEntrypointOutput) {
 			for (const entrypoint of dependencyHits) {
-				const outputUrl = watchedFiles.get(entrypoint);
-				if (outputUrl && this.ownsWatchedEntrypoint(entrypoint)) {
-					affectedEntrypoints.set(entrypoint, outputUrl);
+				const resolvedEntrypoint = path.resolve(entrypoint);
+				const outputUrl = watchedFiles.get(resolvedEntrypoint);
+				if (
+					outputUrl &&
+					(this.ownsWatchedEntrypoint(resolvedEntrypoint) || this.isDevTransformOutputUrl(outputUrl))
+				) {
+					affectedEntrypoints.set(resolvedEntrypoint, outputUrl);
 					continue;
 				}
 
-				if (this.isLayoutFile(entrypoint) && this.ownsWatchedEntrypoint(entrypoint)) {
+				if (this.isLayoutFile(resolvedEntrypoint) && this.ownsWatchedEntrypoint(resolvedEntrypoint)) {
 					hasOwnedLayoutDependencyHit = true;
 				}
 			}
@@ -514,25 +583,28 @@ export class ReactHmrStrategy extends HmrStrategy {
 		if (changedEntrypointOutput && !isLayout && !isChangedPageEntrypoint) {
 			layoutOwnedPageTargets = await this.collectReactPageBuildTargets();
 			hasLayoutOwnedRequestedTarget = await this.hasLayoutOwnedDependencyTarget(
-				_filePath,
+				resolvedFilePath,
 				layoutOwnedPageTargets,
 			);
 		}
 
 		const requestedTargets = changedEntrypointOutput
 			? hasLayoutOwnedRequestedTarget
-				? [{ entrypointPath: _filePath, outputUrl: changedEntrypointOutput }, ...layoutOwnedPageTargets]
-				: [{ entrypointPath: _filePath, outputUrl: changedEntrypointOutput }]
+				? [{ entrypointPath: resolvedFilePath, outputUrl: changedEntrypointOutput }, ...layoutOwnedPageTargets]
+				: [{ entrypointPath: resolvedFilePath, outputUrl: changedEntrypointOutput }]
 			: hasOwnedLayoutDependencyHit
 				? await this.collectReactPageBuildTargets()
 				: hasDependencyHits
 					? Array.from(affectedEntrypoints, ([entrypointPath, outputUrl]) => ({ entrypointPath, outputUrl }))
 					: Array.from(watchedFiles, ([entrypointPath, outputUrl]) => ({ entrypointPath, outputUrl }));
 
-		const groupedPageTargets = await this.resolveBuildTargets(requestedTargets, _filePath);
+		const groupedPageTargets = await this.resolveBuildTargets(requestedTargets, resolvedFilePath);
 		const { pageTargets, nonPageTargets } = this.partitionBuildTargets(requestedTargets, groupedPageTargets);
 		if (!changedEntrypointOutput) {
-			hasLayoutOwnedRequestedTarget = await this.hasLayoutOwnedDependencyTarget(_filePath, requestedTargets);
+			hasLayoutOwnedRequestedTarget = await this.hasLayoutOwnedDependencyTarget(
+				resolvedFilePath,
+				requestedTargets,
+			);
 		}
 		const requiresLayoutRefresh = isLayout || hasOwnedLayoutDependencyHit || hasLayoutOwnedRequestedTarget;
 
@@ -545,16 +617,20 @@ export class ReactHmrStrategy extends HmrStrategy {
 
 		const updates: string[] = [];
 		const requestedOutputUrls = new Set(requestedTargets.map((target) => target.outputUrl));
-		if (pageTargets.length > 1) {
-			appLogger.debug(`Bundling ${pageTargets.length} React page entrypoints together`);
-			const rebuiltOutputs = await this.bundleReactEntrypoints(pageTargets);
+		const { transformTargets: transformPageTargets, diskTargets: diskPageTargets } =
+			this.partitionDevTransformBuildTargets(pageTargets);
+		this.queueDevTransformOutputUpdates(transformPageTargets, requestedOutputUrls, updates);
+
+		if (diskPageTargets.length > 1) {
+			appLogger.debug(`Bundling ${diskPageTargets.length} React page entrypoints together`);
+			const rebuiltOutputs = await this.bundleReactEntrypoints(diskPageTargets);
 			for (const outputUrl of rebuiltOutputs) {
 				if (requestedOutputUrls.has(outputUrl)) {
 					updates.push(outputUrl);
 				}
 			}
 		} else {
-			for (const { entrypointPath, outputUrl } of pageTargets) {
+			for (const { entrypointPath, outputUrl } of diskPageTargets) {
 				appLogger.debug(`Bundling ${entrypointPath}`);
 				const success = await this.bundleReactEntrypoint(entrypointPath, outputUrl);
 				if (success && requestedOutputUrls.has(outputUrl)) {
@@ -565,6 +641,13 @@ export class ReactHmrStrategy extends HmrStrategy {
 
 		for (const { entrypointPath, outputUrl } of nonPageTargets) {
 			if (!this.isReactEntrypoint(entrypointPath)) {
+				continue;
+			}
+
+			if (this.isDevTransformOutputUrl(outputUrl)) {
+				if (requestedOutputUrls.has(outputUrl)) {
+					updates.push(outputUrl);
+				}
 				continue;
 			}
 

--- a/packages/integrations/react/src/hmr/hmr-strategy.ts
+++ b/packages/integrations/react/src/hmr/hmr-strategy.ts
@@ -252,24 +252,6 @@ export class ReactHmrStrategy extends HmrStrategy {
 		}
 	}
 
-	private partitionDevTransformBuildTargets(targets: readonly ReactHmrBuildTarget[]): {
-		transformTargets: ReactHmrBuildTarget[];
-		diskTargets: ReactHmrBuildTarget[];
-	} {
-		const transformTargets: ReactHmrBuildTarget[] = [];
-		const diskTargets: ReactHmrBuildTarget[] = [];
-
-		for (const target of targets) {
-			if (this.isDevTransformOutputUrl(target.outputUrl)) {
-				transformTargets.push(target);
-			} else {
-				diskTargets.push(target);
-			}
-		}
-
-		return { transformTargets, diskTargets };
-	}
-
 	private ownsWatchedEntrypoint(filePath: string): boolean {
 		return this.pageMetadataCache.ownsEntrypoint(filePath);
 	}
@@ -364,11 +346,6 @@ export class ReactHmrStrategy extends HmrStrategy {
 	async createDevTransformPlugins(entrypointPath: string): Promise<EcoBuildPlugin[]> {
 		const declaredModules = await this.resolveDeclaredModulesForEntrypoint(entrypointPath);
 		return this.buildPluginsForDeclaredModules(declaredModules, entrypointPath.endsWith('.mdx'));
-	}
-
-	override async emitEntrypoint(entrypointPath: string, _outputPath: string): Promise<void> {
-		const { outputUrl } = this.getEntrypointOutput(entrypointPath);
-		await this.bundleReactEntrypoint(entrypointPath, outputUrl);
 	}
 
 	/**
@@ -613,31 +590,11 @@ export class ReactHmrStrategy extends HmrStrategy {
 			...nonPageTargets.map((target) => target.entrypointPath),
 		]);
 
-		await this.clearOutdirsForTargets(pageTargets, nonPageTargets);
+		await this.clearOutdirsForTargets(nonPageTargets);
 
 		const updates: string[] = [];
 		const requestedOutputUrls = new Set(requestedTargets.map((target) => target.outputUrl));
-		const { transformTargets: transformPageTargets, diskTargets: diskPageTargets } =
-			this.partitionDevTransformBuildTargets(pageTargets);
-		this.queueDevTransformOutputUpdates(transformPageTargets, requestedOutputUrls, updates);
-
-		if (diskPageTargets.length > 1) {
-			appLogger.debug(`Bundling ${diskPageTargets.length} React page entrypoints together`);
-			const rebuiltOutputs = await this.bundleReactEntrypoints(diskPageTargets);
-			for (const outputUrl of rebuiltOutputs) {
-				if (requestedOutputUrls.has(outputUrl)) {
-					updates.push(outputUrl);
-				}
-			}
-		} else {
-			for (const { entrypointPath, outputUrl } of diskPageTargets) {
-				appLogger.debug(`Bundling ${entrypointPath}`);
-				const success = await this.bundleReactEntrypoint(entrypointPath, outputUrl);
-				if (success && requestedOutputUrls.has(outputUrl)) {
-					updates.push(outputUrl);
-				}
-			}
-		}
+		this.queueDevTransformOutputUpdates(pageTargets, requestedOutputUrls, updates);
 
 		for (const { entrypointPath, outputUrl } of nonPageTargets) {
 			if (!this.isReactEntrypoint(entrypointPath)) {
@@ -687,28 +644,16 @@ export class ReactHmrStrategy extends HmrStrategy {
 	}
 
 	/**
-	 * Clears stale HMR output once per outdir before any rebuild pass in `process()`.
-	 *
-	 * @remarks
-	 * Grouped page builds share `getDistDir()`; single page and non-page targets use
-	 * per-entrypoint temp directories. Clearing here avoids redundant work when both
-	 * page and non-page targets land in the same outdir.
+	 * Clears stale HMR output before non-page disk rebuilds in `process()`.
 	 */
-	private async clearOutdirsForTargets(
-		pageTargets: ReactHmrBuildTarget[],
-		nonPageTargets: ReactHmrBuildTarget[],
-	): Promise<void> {
+	private async clearOutdirsForTargets(nonPageTargets: ReactHmrBuildTarget[]): Promise<void> {
 		const outdirs = new Set<string>();
 
-		if (pageTargets.length > 1) {
-			outdirs.add(this.context.getDistDir());
-		} else {
-			for (const { entrypointPath } of pageTargets) {
-				outdirs.add(path.dirname(this.getEntrypointOutput(entrypointPath).outputPath));
+		for (const { entrypointPath, outputUrl } of nonPageTargets) {
+			if (this.isDevTransformOutputUrl(outputUrl)) {
+				continue;
 			}
-		}
 
-		for (const { entrypointPath } of nonPageTargets) {
 			outdirs.add(path.dirname(this.getEntrypointOutput(entrypointPath).outputPath));
 		}
 


### PR DESCRIPTION
## Summary
- Make dev transform the only page registration path; remove `ECOPAGES_DEV_CLIENT_DELIVERY` toggle and legacy delivery helpers.
- Fix HMR for transform pages: invalidate transform cache, broadcast `__eco_dev__` URLs that match client handlers, and skip redundant disk page rebuilds.
- Remove dead cold-registration emit chain (`emitIntegrationEntrypoint`) and page disk bundle path in `ReactHmrStrategy.process()`.

## Test plan
- [x] `pnpm run test:vitest`
- [x] `pnpm run test:e2e` (full suite)
- [x] `react-router-persist-layouts-dev-e2e` — page content HMR, layout HMR, persist-layouts navigation

## Depends on
- #231