### PR TITLE
refactor(react-hmr): extract disk bundler from strategy

### DIFF
--- a/packages/integrations/react/src/hmr/hmr-strategy.test.ts
+++ b/packages/integrations/react/src/hmr/hmr-strategy.test.ts
@@ -301,7 +301,7 @@ describe('ReactHmrStrategy', () => {
 			runtimeManifest: defaultRuntimeManifest,
 		});
 
-		(strategy as any).processOutput = vi.fn(async () => true);
+		(strategy as any).diskBundler.processOutput = vi.fn(async () => true);
 		vi.spyOn(fileSystem, 'exists').mockReturnValue(true);
 
 		const success = await (strategy as any).bundleReactEntrypoint(entrypointPath, '/_hmr/pages/index.js');
@@ -343,7 +343,7 @@ describe('ReactHmrStrategy', () => {
 			runtimeManifest: defaultRuntimeManifest,
 		});
 
-		(strategy as any).processOutput = vi.fn(async () => true);
+		(strategy as any).diskBundler.processOutput = vi.fn(async () => true);
 		vi.spyOn(fileSystem, 'exists').mockReturnValue(true);
 
 		const success = await (strategy as any).bundleReactEntrypoint(
@@ -378,7 +378,7 @@ describe('ReactHmrStrategy', () => {
 		const globSpy = vi
 			.spyOn(fileSystem, 'glob')
 			.mockResolvedValue(['/tmp/.eco/assets/_hmr/pages/index.123.tmp.js']);
-		(strategy as any).processOutput = vi.fn(async () => true);
+		(strategy as any).diskBundler.processOutput = vi.fn(async () => true);
 
 		const success = await (strategy as any).bundleReactEntrypoint(
 			'/tmp/src/pages/index.tsx',
@@ -389,7 +389,7 @@ describe('ReactHmrStrategy', () => {
 		expect(globSpy).toHaveBeenCalledWith(['index.*.tmp.js'], {
 			cwd: '/tmp/.eco/assets/_hmr/pages',
 		});
-		expect((strategy as any).processOutput).toHaveBeenCalledWith(
+		expect((strategy as any).diskBundler.processOutput).toHaveBeenCalledWith(
 			'/tmp/.eco/assets/_hmr/pages/index.123.tmp.js',
 			'/tmp/.eco/assets/_hmr/pages/index.js',
 			'/_hmr/pages/index.js',
@@ -700,7 +700,7 @@ describe('ReactHmrStrategy', () => {
 			runtimeManifest: defaultRuntimeManifest,
 		});
 
-		(strategy as any).processOutput = vi.fn(async () => true);
+		(strategy as any).diskBundler.processOutput = vi.fn(async () => true);
 		vi.spyOn(fileSystem, 'exists').mockReturnValue(true);
 
 		const outputs = await (strategy as any).bundleReactEntrypoints([
@@ -711,7 +711,7 @@ describe('ReactHmrStrategy', () => {
 		]);
 
 		expect(outputs).toEqual(['/assets/_hmr/pages/posts/_slug_.js']);
-		expect((strategy as any).processOutput).toHaveBeenCalledWith(
+		expect((strategy as any).diskBundler.processOutput).toHaveBeenCalledWith(
 			'/tmp/.eco/assets/_hmr/pages/posts/_slug_.123.tmp.js',
 			'/tmp/.eco/assets/_hmr/pages/posts/_slug_.js',
 			'/assets/_hmr/pages/posts/_slug_.js',

--- a/packages/integrations/react/src/hmr/hmr-strategy.ts
+++ b/packages/integrations/react/src/hmr/hmr-strategy.ts
@@ -12,7 +12,6 @@ import fs from 'node:fs';
 
 import { HmrStrategy, HmrStrategyType, type HmrAction } from '@ecopages/core/hmr/hmr-strategy';
 import { isRegisteredScriptEntrypoint } from '@ecopages/core/hmr/hmr-entrypoint-output';
-import { RESOLVED_ASSETS_DIR } from '@ecopages/core/constants';
 import { DEV_TRANSFORM_URL_PREFIX } from '@ecopages/core/dev/transform-server';
 import type { EcoBuildPlugin } from '@ecopages/core/plugins/integration-plugin';
 import { createBrowserRuntimePlugin } from '@ecopages/core/build/browser-runtime-plugin';
@@ -24,19 +23,17 @@ import {
 	setDevHmrEntrypointCacheEntry,
 	type DevHmrEntrypointCache,
 } from '@ecopages/core/build/dev-hmr-entrypoint-cache';
-import { FileNotFoundError, fileSystem } from '@ecopages/file-system';
+import { fileSystem } from '@ecopages/file-system';
 import { Logger } from '@ecopages/logger';
 import type { DefaultHmrContext } from '@ecopages/core';
 import type { CompileOptions } from '@mdx-js/mdx';
-import { injectHmrHandler } from './hmr-scripts.ts';
 import { createClientGraphBoundaryPlugin } from '../client-graph/boundary-plugin.ts';
 import { ClientGraphBoundaryCache } from '../client-graph/boundary-cache.ts';
-import { collectPageDeclaredModules, collectPageDeclaredModulesFromModule } from '../client-graph/declared-modules.ts';
 import { someInConfigTree } from '../client-graph/component-config-traversal.ts';
-import { createReactMdxLoaderPlugin } from '../mdx/mdx-loader-plugin.ts';
 import { getReactClientGraphAllowSpecifiers } from '../bundling/runtime-alias-map.ts';
 import type { HmrPageMetadataCache } from './page-metadata-cache.ts';
 import type { EcoComponentConfig } from '@ecopages/core';
+import { ReactHmrDiskBundler, type ReactHmrBuildTarget } from './react-hmr-disk-bundler.ts';
 
 const appLogger = new Logger('[ReactHmrStrategy]');
 
@@ -78,79 +75,23 @@ type ImportedReactPageModule = {
 };
 
 /**
- * Shared HMR build target for one React-owned browser entrypoint.
- *
- * @remarks
- * Grouped HMR rebuilds operate on these normalized pairs so the strategy can
- * expand one requested page or layout change into the full set of page entries
- * that should share a browser graph, while still knowing which emitted URLs are
- * relevant to the current update broadcast.
- */
-type ReactHmrBuildTarget = {
-	entrypointPath: string;
-	outputUrl: string;
-};
-
-/**
  * Strategy for handling React component HMR updates.
- *
- * This strategy provides React-specific HMR handling by rebuilding entrypoints
- * and injecting HMR acceptance handlers that trigger module invalidation.
- *
- * The processing steps are:
- * 1. Check if any React entrypoints are registered
- * 2. Rebuild all React entrypoints (the changed file could be a dependency)
- * 3. Rebuild browser output through the shared browser bundle service while
- *    preserving React-specific runtime aliases and graph policy
- * 4. Read page config metadata through the shared server-module loading path
- * 5. Inject HMR acceptance handler
- * 6. Broadcast update events for each rebuilt entrypoint
- *
- * @remarks
- * This strategy has higher priority than generic JsHmrStrategy, allowing it
- * to handle React files specially while falling back to generic handling for
- * non-React files.
- *
- * Future enhancement: Track dependencies using Bun's transpiler API to only
- * rebuild affected entrypoints instead of all of them.
- *
- * @see https://bun.sh/docs/runtime/transpiler
- *
- * @example
- * ```typescript
- * const context = {
- *   getWatchedFiles: () => watchedFilesMap,
- *   getDistDir: () => '/path/to/dist/_hmr',
- *   getPlugins: () => [],
- *   getSrcDir: () => '/path/to/src',
- *   getLayoutsDir: () => '/path/to/src/layouts'
- * };
- * const strategy = new ReactHmrStrategy({
- *   context,
- *   pageMetadataCache,
- *   runtimeManifest
- * });
- * ```
  */
 export class ReactHmrStrategy extends HmrStrategy {
 	readonly type = HmrStrategyType.INTEGRATION;
 	private mdxCompilerOptions?: CompileOptions;
 	private readonly ownedTemplateExtensions: Set<string>;
 	private readonly allTemplateExtensions: string[];
+	private readonly context: DefaultHmrContext;
+	private readonly pageMetadataCache: HmrPageMetadataCache;
+	private readonly runtimeManifest: BrowserRuntimeManifest;
+	private readonly clientGraphBoundaryCache: ClientGraphBoundaryCache;
+	private readonly diskBundler: ReactHmrDiskBundler;
+	private devHmrEntrypointCache?: DevHmrEntrypointCache;
+
 	private async importNodePageModule(entrypointPath: string): Promise<ImportedReactPageModule> {
 		return await this.context.importServerModule(entrypointPath);
 	}
-
-	/**
-	 * Creates a new React HMR strategy instance.
-	 *
-	 * @param options - React HMR runtime services and behavior flags.
-	 */
-	private context: DefaultHmrContext;
-	private pageMetadataCache: HmrPageMetadataCache;
-	private readonly runtimeManifest: BrowserRuntimeManifest;
-	private readonly clientGraphBoundaryCache: ClientGraphBoundaryCache;
-	private devHmrEntrypointCache?: DevHmrEntrypointCache;
 
 	constructor(options: ReactHmrStrategyOptions) {
 		super();
@@ -163,18 +104,15 @@ export class ReactHmrStrategy extends HmrStrategy {
 		this.allTemplateExtensions = [...(options.allTemplateExtensions ?? ['.tsx'])].sort(
 			(a, b) => b.length - a.length,
 		);
+		this.diskBundler = new ReactHmrDiskBundler({
+			context: this.context,
+			pageMetadataCache: this.pageMetadataCache,
+			mdxCompilerOptions: this.mdxCompilerOptions,
+			getBuildPlugins: (declaredModules) => this.getBuildPlugins(declaredModules),
+			importNodePageModule: (entrypointPath) => this.importNodePageModule(entrypointPath),
+		});
 	}
 
-	/**
-	 * Returns build plugins for React HMR bundling.
-	 *
-	 * Includes the client graph boundary plugin to prevent undeclared imports
-	 * (including `node:*`) from breaking the browser bundle.
-	 *
-	 * @remarks
-	 * HMR builds receive the React runtime manifest and rewrite manifest-owned
-	 * runtime imports to concrete asset URLs before module resolution.
-	 */
 	private getBuildPlugins(declaredModules?: readonly string[]): EcoBuildPlugin[] {
 		const allowSpecifiers = getReactClientGraphAllowSpecifiers(
 			this.runtimeManifest.assets.map((asset) => asset.specifier),
@@ -222,8 +160,6 @@ export class ReactHmrStrategy extends HmrStrategy {
 	}
 
 	/**
-	 * Returns true when a route file uses a compound extension like `page.foo.tsx`.
-	 *
 	 * @remarks
 	 * React integration owns plain `.tsx` route templates. Compound extensions in
 	 * pages/layouts are integration-specific route templates and should not be
@@ -293,19 +229,6 @@ export class ReactHmrStrategy extends HmrStrategy {
 		return false;
 	}
 
-	/**
-	 * Determines if the file is a React/MDX entrypoint that's registered for HMR.
-	 *
-	 * Uses a three-way decision strategy for selective invalidation:
-	 * 1. If the file is a watched entrypoint, check if React owns it
-	 * 2. If the file is a dependency of watched entrypoints (via dependency graph),
-	 *    check if any affected entrypoints are React-owned. Returns false if hits
-	 *    exist but none are owned (prevents unnecessary rebuilds).
-	 * 3. Otherwise, check if the file itself is a React entrypoint template
-	 *
-	 * @param filePath - Absolute path to the changed file
-	 * @returns True if this file should trigger React HMR rebuilds
-	 */
 	matches(filePath: string): boolean {
 		const watchedFiles = this.context.getWatchedFiles();
 		const resolvedFilePath = path.resolve(filePath);
@@ -352,25 +275,11 @@ export class ReactHmrStrategy extends HmrStrategy {
 		);
 	}
 
-	/**
-	 * Returns Ecopages build plugins for dev transform Rolldown bundles.
-	 */
 	async createDevTransformPlugins(entrypointPath: string): Promise<EcoBuildPlugin[]> {
-		const declaredModules = await this.resolveDeclaredModulesForEntrypoint(entrypointPath);
-		return this.buildPluginsForDeclaredModules(declaredModules, entrypointPath.endsWith('.mdx'));
+		const declaredModules = await this.diskBundler.resolveDeclaredModulesForEntrypoint(entrypointPath);
+		return this.diskBundler.buildPluginsForDeclaredModules(declaredModules, entrypointPath.endsWith('.mdx'));
 	}
 
-	/**
-	 * Checks if a file is a layout file.
-	 *
-	 * Layout files require special HMR handling because they wrap multiple pages and affect
-	 * the entire page structure. When a layout changes, we trigger a 'layout-update' event
-	 * instead of a regular 'update' event, which instructs the browser to perform a full
-	 * page reload (or clear cache and re-render) rather than attempting module-level HMR.
-	 *
-	 * @param filePath - Absolute path to the file
-	 * @returns True if the file is in the layouts directory
-	 */
 	private isLayoutFile(filePath: string): boolean {
 		return filePath.startsWith(this.context.getLayoutsDir());
 	}
@@ -379,20 +288,7 @@ export class ReactHmrStrategy extends HmrStrategy {
 		return filePath.startsWith(this.context.getPagesDir()) && this.isReactEntrypoint(filePath);
 	}
 
-	private getEntrypointOutput(entrypointPath: string): { outputPath: string; outputUrl: string } {
-		const srcDir = this.context.getSrcDir();
-		const relativePath = path.relative(srcDir, entrypointPath);
-		const relativePathJs = relativePath.replace(/\.(tsx?|jsx?|mdx)$/, '.js');
-		const encodedPathJs = this.encodeDynamicSegments(relativePathJs);
-		const outputPath = path.join(this.context.getDistDir(), encodedPathJs);
-		const outputUrl = `/${path.join(RESOLVED_ASSETS_DIR, '_hmr', encodedPathJs).split(path.sep).join('/')}`;
-
-		return { outputPath, outputUrl };
-	}
-
 	/**
-	 * Resolves the browser URL for an HMR entrypoint from the watched-file registry.
-	 *
 	 * @remarks
 	 * Dev transform pages register `__eco_dev__` URLs while legacy HMR emits use
 	 * `_hmr` disk paths. Grouped page rebuilds must preserve the registered URL
@@ -404,22 +300,7 @@ export class ReactHmrStrategy extends HmrStrategy {
 			return watchedOutputUrl;
 		}
 
-		return this.getEntrypointOutput(entrypointPath).outputUrl;
-	}
-
-	private getRolldownEntryKey(entrypointPath: string): string {
-		const srcDir = this.context.getSrcDir();
-		const relativePath = path.relative(srcDir, entrypointPath);
-		const relativePathNoExt = relativePath.replace(/\.(tsx?|jsx?|mdx)$/, '');
-		return relativePathNoExt;
-	}
-
-	private getTempFileBasename(entrypointPath: string): string {
-		const srcDir = this.context.getSrcDir();
-		const relativePath = path.relative(srcDir, entrypointPath);
-		const relativePathNoExt = relativePath.replace(/\.(tsx?|jsx?|mdx)$/, '');
-		const encodedPath = this.encodeDynamicSegments(relativePathNoExt);
-		return path.basename(encodedPath);
+		return this.diskBundler.getEntrypointOutput(entrypointPath).outputUrl;
 	}
 
 	private async collectReactPageBuildTargets(): Promise<ReactHmrBuildTarget[]> {
@@ -441,14 +322,6 @@ export class ReactHmrStrategy extends HmrStrategy {
 		);
 	}
 
-	/**
-	 * Expands one HMR request into the full React page build cohort when needed.
-	 *
-	 * @remarks
-	 * Page and layout changes need one shared rebuild pass so sibling routes keep
-	 * a consistent client module graph. Non-page changes that do not touch a page
-	 * cohort can stay scoped to the originally requested targets.
-	 */
 	private async resolveBuildTargets(
 		requestedTargets: ReactHmrBuildTarget[],
 		changedFilePath: string,
@@ -497,22 +370,6 @@ export class ReactHmrStrategy extends HmrStrategy {
 		};
 	}
 
-	/**
-	 * Processes a React file change by rebuilding affected React entrypoints.
-	 *
-	 * Uses a three-way decision strategy for selective invalidation:
-	 * 1. Changed file is a watched entrypoint: rebuild only that entrypoint
-	 * 2. Dependency graph has hits: rebuild only affected React-owned entrypoints.
-	 *    If hits exist but none map to React-owned entrypoints, return 'none' to
-	 *    prevent unnecessary rebuilds.
-	 * 3. Dependency graph miss: fall back to rebuilding all watched entrypoints
-	 *
-	 * For layout files, broadcasts a 'layout-update' event to trigger full page reload.
-	 * For regular components/pages, broadcasts 'update' events for module-level HMR.
-	 *
-	 * @param _filePath - Absolute path to the changed file
-	 * @returns Action to broadcast update events (layout-update for layouts, update for components)
-	 */
 	async process(_filePath: string): Promise<HmrAction> {
 		appLogger.debug(`Processing ${_filePath}`);
 		const resolvedFilePath = path.resolve(_filePath);
@@ -602,7 +459,7 @@ export class ReactHmrStrategy extends HmrStrategy {
 			...nonPageTargets.map((target) => target.entrypointPath),
 		]);
 
-		await this.clearOutdirsForTargets(nonPageTargets);
+		await this.diskBundler.clearOutdirsForTargets(nonPageTargets);
 
 		const updates: string[] = [];
 		const requestedOutputUrls = new Set(requestedTargets.map((target) => target.outputUrl));
@@ -655,356 +512,28 @@ export class ReactHmrStrategy extends HmrStrategy {
 		return { type: 'none' };
 	}
 
-	/**
-	 * Clears stale HMR output before non-page disk rebuilds in `process()`.
-	 */
-	private async clearOutdirsForTargets(nonPageTargets: ReactHmrBuildTarget[]): Promise<void> {
-		const outdirs = new Set<string>();
-
-		for (const { entrypointPath, outputUrl } of nonPageTargets) {
-			if (this.isDevTransformOutputUrl(outputUrl)) {
-				continue;
-			}
-
-			outdirs.add(path.dirname(this.getEntrypointOutput(entrypointPath).outputPath));
-		}
-
-		await Promise.all([...outdirs].map((outdir) => this.clearHmrOutdir(outdir)));
-	}
-
-	private async resolveDeclaredModulesForEntrypoint(entrypointPath: string): Promise<readonly string[]> {
-		const cached = this.pageMetadataCache.getDeclaredModules(entrypointPath);
-		if (cached) {
-			return cached;
-		}
-
-		const declaredModules = entrypointPath.endsWith('.mdx')
-			? await collectPageDeclaredModules(entrypointPath)
-			: collectPageDeclaredModulesFromModule(await this.importNodePageModule(entrypointPath));
-		this.pageMetadataCache.setDeclaredModules(entrypointPath, declaredModules);
-		return declaredModules;
-	}
-
-	private async collectDeclaredModulesForTargets(
-		targets: ReactHmrBuildTarget[],
-	): Promise<{ declaredModules: string[]; shouldEnableMdx: boolean }> {
-		const declaredModules = new Set<string>();
-		let shouldEnableMdx = false;
-
-		for (const { entrypointPath } of targets) {
-			const entrypointDeclaredModules = await this.resolveDeclaredModulesForEntrypoint(entrypointPath);
-			for (const declaredModule of entrypointDeclaredModules) {
-				declaredModules.add(declaredModule);
-			}
-
-			if (entrypointPath.endsWith('.mdx')) {
-				shouldEnableMdx = true;
-			}
-		}
-
-		return { declaredModules: [...declaredModules], shouldEnableMdx };
-	}
-
-	private buildPluginsForDeclaredModules(
-		declaredModules: readonly string[],
-		shouldEnableMdx: boolean,
-	): ReturnType<ReactHmrStrategy['getBuildPlugins']> {
-		const plugins = this.getBuildPlugins(declaredModules);
-
-		if (shouldEnableMdx && this.mdxCompilerOptions) {
-			plugins.unshift(createReactMdxLoaderPlugin(this.mdxCompilerOptions));
-		}
-
-		return plugins;
-	}
-
-	private recordBuildDependencyGraph(result: { dependencyGraph?: { entrypoints?: Record<string, string[]> } }): void {
-		if (!result.dependencyGraph?.entrypoints) {
-			return;
-		}
-
-		const dependencyGraph = this.context.getEntrypointDependencyGraph();
-		for (const [entrypoint, deps] of Object.entries(result.dependencyGraph.entrypoints)) {
-			dependencyGraph.setEntrypointDependencies(entrypoint, deps);
-		}
-	}
-
-	/**
-	 * Bundles a single React/MDX entrypoint with HMR support.
-	 *
-	 * After successful bundling, populates the entrypoint dependency graph with
-	 * the build's dependency metadata. This enables selective invalidation on
-	 * subsequent file changes, so only entrypoints affected by a changed
-	 * dependency are rebuilt.
-	 *
-	 * @param entrypointPath - Absolute path to the source file
-	 * @param outputUrl - URL path for the bundled file
-	 * @returns True if bundling was successful
-	 */
 	private async bundleReactEntrypoint(entrypointPath: string, outputUrl: string): Promise<boolean> {
-		const rebuiltOutputs = await this.bundleReactBuildTargets([{ entrypointPath, outputUrl }], { grouped: false });
-		return rebuiltOutputs.length > 0;
+		return this.diskBundler.bundleEntrypoint(entrypointPath, outputUrl);
 	}
 
-	/**
-	 * Bundles multiple React/MDX entrypoints in a single build pass.
-	 *
-	 * Uses code splitting to share common dependencies across entrypoints.
-	 * After successful bundling, populates the entrypoint dependency graph with
-	 * the build's dependency metadata for selective invalidation.
-	 *
-	 * @param entrypoints - Array of entrypoint paths and their output URLs
-	 * @returns Array of output URLs that were successfully built
-	 */
 	private async bundleReactEntrypoints(entrypoints: ReactHmrBuildTarget[]): Promise<string[]> {
-		return this.bundleReactBuildTargets(entrypoints, { grouped: true });
+		return this.diskBundler.bundleEntrypoints(entrypoints);
 	}
 
-	private async bundleReactBuildTargets(
-		targets: ReactHmrBuildTarget[],
-		options: { grouped: boolean },
-	): Promise<string[]> {
-		if (targets.length === 0) {
-			return [];
-		}
+	private async processOutput(tempPath: string, finalPath: string, url: string): Promise<boolean> {
+		return this.diskBundler.processOutput(tempPath, finalPath, url);
+	}
 
-		try {
-			const { declaredModules, shouldEnableMdx } = await this.collectDeclaredModulesForTargets(targets);
-			const plugins = this.buildPluginsForDeclaredModules(declaredModules, shouldEnableMdx);
-
-			if (options.grouped) {
-				const entryNameByPath = new Map<string, { key: string; basename: string }>();
-				for (const { entrypointPath } of targets) {
-					entryNameByPath.set(entrypointPath, {
-						key: this.getRolldownEntryKey(entrypointPath),
-						basename: this.getTempFileBasename(entrypointPath),
-					});
-				}
-
-				const result = await this.context.getBrowserBundleService().bundle({
-					profile: 'hmr-entrypoint',
-					entrypoints: Object.fromEntries(
-						targets.map(({ entrypointPath }) => [entryNameByPath.get(entrypointPath)!.key, entrypointPath]),
-					),
-					outdir: this.context.getDistDir(),
-					naming: '[name].[hash].tmp',
-					splitting: true,
-					plugins,
-					minify: false,
-				});
-
-				if (!result.success) {
-					appLogger.error(`Failed to build grouped React entrypoints:`, result.logs);
-					return [];
-				}
-
-				this.recordBuildDependencyGraph(result);
-
-				const updatedOutputs: string[] = [];
-				for (const { entrypointPath, outputUrl } of targets) {
-					const { outputPath } = this.getEntrypointOutput(entrypointPath);
-					const { basename: tempBasename, key: entryKey } = entryNameByPath.get(entrypointPath)!;
-					const expectedSubdir = path.join(this.context.getDistDir(), path.dirname(entryKey));
-					const tempOutput = result.outputs.find((output) => {
-						return (
-							path.dirname(output.path) === expectedSubdir &&
-							path.basename(output.path).startsWith(`${tempBasename}.`) &&
-							path.basename(output.path).includes('.tmp')
-						);
-					})?.path;
-
-					const resolvedTempOutput = tempOutput
-						? await this.resolveTempOutputPath(tempOutput)
-						: await this.resolveTempOutputPath(path.join(expectedSubdir, `${tempBasename}.[hash].tmp.js`));
-
-					if (!resolvedTempOutput) {
-						appLogger.debug(`Missing grouped temp output for ${outputUrl}`);
-						continue;
-					}
-
-					const processed = await this.processOutput(resolvedTempOutput, outputPath, outputUrl);
-					if (processed) {
-						updatedOutputs.push(outputUrl);
-					}
-				}
-
-				return updatedOutputs;
-			}
-
-			const { entrypointPath, outputUrl } = targets[0]!;
-			const { outputPath } = this.getEntrypointOutput(entrypointPath);
-			const tempDir = path.dirname(outputPath);
-
-			const result = await this.context.getBrowserBundleService().bundle({
-				profile: 'hmr-entrypoint',
-				entrypoints: [entrypointPath],
-				outdir: tempDir,
-				naming: `[name].[hash].tmp`,
-				plugins,
-				minify: false,
-			});
-
-			if (!result.success) {
-				appLogger.error(`Failed to build ${entrypointPath}:`, result.logs);
-				return [];
-			}
-
-			this.recordBuildDependencyGraph(result);
-
-			const tempFile = result.outputs[0]?.path;
-			if (!tempFile) {
-				appLogger.error(`No output file generated for ${entrypointPath}`);
-				return [];
-			}
-
-			const resolvedTempFile = await this.resolveTempOutputPath(tempFile);
-			if (!resolvedTempFile) {
-				appLogger.debug(`Skipping stale temp output for ${outputUrl}: ${tempFile}`);
-				return [];
-			}
-
-			const processed = await this.processOutput(resolvedTempFile, outputPath, outputUrl);
-			return processed ? [outputUrl] : [];
-		} catch (error) {
-			const label = options.grouped
-				? 'grouped React entrypoints'
-				: (targets[0]?.entrypointPath ?? 'React entrypoint');
-			appLogger.error(`Error bundling ${label}:`, error as Error);
-			return [];
-		}
+	private getRolldownEntryKey(entrypointPath: string): string {
+		return this.diskBundler.getRolldownEntryKey(entrypointPath);
 	}
 
 	private async resolveTempOutputPath(tempPath: string): Promise<string | null> {
-		if (fileSystem.exists(tempPath)) {
-			return tempPath;
-		}
-
-		if (!tempPath.includes('[hash]')) {
-			return null;
-		}
-
-		const directory = path.dirname(tempPath);
-		const pattern = path.basename(tempPath).replaceAll('[hash]', '*');
-		const matches = await fileSystem.glob([pattern], { cwd: directory });
-
-		if (matches.length === 0) {
-			return null;
-		}
-
-		return path.isAbsolute(matches[0]!) ? matches[0]! : path.join(directory, matches[0]!);
+		return this.diskBundler.resolveTempOutputPath(tempPath);
 	}
 
-	/**
-	 * Clears stale HMR output from a directory before a rebuild.
-	 *
-	 * Only removes:
-	 * - `*.tmp.js` files (the per-build bundler output the strategy owns)
-	 * - the `chunks/` subdirectory (the bundler's splitting target)
-	 *
-	 * The HMR runtime script (`_hmr_runtime.js`) and any user-authored
-	 * assets in the outdir are preserved. This is the minimal set of
-	 * files that, if left from a previous build, can cause the bundler
-	 * to emit `ENOENT` for chunk references that point to entrypoints
-	 * whose hash has since changed.
-	 */
 	private async clearHmrOutdir(outdir: string): Promise<void> {
-		if (!fileSystem.exists(outdir)) {
-			return;
-		}
-
-		const tempFiles = await fileSystem.glob(['**/*.tmp.js'], { cwd: outdir });
-		await Promise.all(
-			tempFiles.map((relativePath) => {
-				const absolutePath = path.isAbsolute(relativePath) ? relativePath : path.join(outdir, relativePath);
-				return fileSystem.removeAsync(absolutePath).catch(() => undefined);
-			}),
-		);
-
-		const chunksDir = path.join(outdir, 'chunks');
-		if (fileSystem.exists(chunksDir)) {
-			await fileSystem.removeAsync(chunksDir).catch(() => undefined);
-		}
-	}
-
-	/**
-	 * Encodes dynamic route segments (brackets) in file paths.
-	 * Converts `[slug]` to `_slug_` to avoid filesystem issues.
-	 */
-	private encodeDynamicSegments(filepath: string): string {
-		return filepath.replace(/\[([^\]]+)\]/g, '_$1_');
-	}
-
-	private rewriteChunkImportUrls(code: string): string {
-		const hmrChunkBaseUrl = `/${path.join(RESOLVED_ASSETS_DIR, '_hmr').split(path.sep).join('/')}`;
-
-		return code.replace(/(['"])(?:\.\.\/)+(chunk-[^'"]+\.js)\1/g, (_match, quote, chunkFile) => {
-			return `${quote}${hmrChunkBaseUrl}/${chunkFile}${quote}`;
-		});
-	}
-
-	private isMissingTempOutputError(error: unknown): boolean {
-		if (error instanceof FileNotFoundError) {
-			return true;
-		}
-
-		if (!(error instanceof Error)) {
-			return false;
-		}
-
-		if (error.message.includes('not found') || error.message.includes('ENOENT')) {
-			return true;
-		}
-
-		const errorCause = error.cause;
-		if (errorCause instanceof FileNotFoundError) {
-			return true;
-		}
-
-		return (
-			typeof errorCause === 'object' &&
-			errorCause !== null &&
-			'code' in errorCause &&
-			errorCause.code === 'ENOENT'
-		);
-	}
-
-	/**
-	 * Processes bundled output and injects the React HMR handler.
-	 * Writes to temp file first, then renames atomically to avoid conflicts.
-	 *
-	 * @param tempPath - Path to the temporary bundled file
-	 * @param finalPath - Final destination path
-	 * @param url - URL path for logging
-	 * @returns True if processing was successful
-	 */
-	private async processOutput(tempPath: string, finalPath: string, url: string): Promise<boolean> {
-		if (!fileSystem.exists(tempPath)) {
-			appLogger.debug(`Skipping stale temp output for ${url}: ${tempPath}`);
-			return false;
-		}
-
-		try {
-			let code = await fileSystem.readFile(tempPath);
-
-			code = this.rewriteChunkImportUrls(code);
-			code = injectHmrHandler(code);
-
-			await fileSystem.writeAsync(finalPath, code);
-			await fileSystem.removeAsync(tempPath).catch(() => {});
-
-			appLogger.debug(`Processed ${url} with HMR handler`);
-			return true;
-		} catch (error) {
-			if (this.isMissingTempOutputError(error)) {
-				appLogger.debug(`Skipping stale temp output for ${url}: ${tempPath}`);
-				await fileSystem.removeAsync(tempPath).catch(() => {});
-				return false;
-			}
-
-			appLogger.error(`Error processing output for ${url}:`, error as Error);
-			await fileSystem.removeAsync(tempPath).catch(() => {});
-			return false;
-		}
+		return this.diskBundler.clearHmrOutdir(outdir);
 	}
 
 	/**

--- a/packages/integrations/react/src/hmr/react-hmr-disk-bundler.ts
+++ b/packages/integrations/react/src/hmr/react-hmr-disk-bundler.ts
@@ -1,0 +1,370 @@
+import path from 'node:path';
+
+import { RESOLVED_ASSETS_DIR } from '@ecopages/core/constants';
+import { DEV_TRANSFORM_URL_PREFIX } from '@ecopages/core/dev/transform-server';
+import type { EcoBuildPlugin } from '@ecopages/core/plugins/integration-plugin';
+import type { DefaultHmrContext, EcoComponentConfig } from '@ecopages/core';
+import type { CompileOptions } from '@mdx-js/mdx';
+import { FileNotFoundError, fileSystem } from '@ecopages/file-system';
+import { Logger } from '@ecopages/logger';
+import { collectPageDeclaredModules, collectPageDeclaredModulesFromModule } from '../client-graph/declared-modules.ts';
+import { createReactMdxLoaderPlugin } from '../mdx/mdx-loader-plugin.ts';
+import type { HmrPageMetadataCache } from './page-metadata-cache.ts';
+import { injectHmrHandler } from './hmr-scripts.ts';
+
+const appLogger = new Logger('[ReactHmrDiskBundler]');
+
+export type ReactHmrBuildTarget = {
+	entrypointPath: string;
+	outputUrl: string;
+};
+
+type ImportedReactPageModule = {
+	default?: { config?: EcoComponentConfig };
+	config?: EcoComponentConfig;
+};
+
+export type ReactHmrDiskBundlerOptions = {
+	context: DefaultHmrContext;
+	pageMetadataCache: HmrPageMetadataCache;
+	mdxCompilerOptions?: CompileOptions;
+	getBuildPlugins: (declaredModules?: readonly string[]) => EcoBuildPlugin[];
+	importNodePageModule: (entrypointPath: string) => Promise<ImportedReactPageModule>;
+};
+
+export class ReactHmrDiskBundler {
+	private readonly context: DefaultHmrContext;
+	private readonly pageMetadataCache: HmrPageMetadataCache;
+	private readonly mdxCompilerOptions?: CompileOptions;
+	private readonly getBuildPlugins: (declaredModules?: readonly string[]) => EcoBuildPlugin[];
+	private readonly importNodePageModule: (entrypointPath: string) => Promise<ImportedReactPageModule>;
+
+	constructor(options: ReactHmrDiskBundlerOptions) {
+		this.context = options.context;
+		this.pageMetadataCache = options.pageMetadataCache;
+		this.mdxCompilerOptions = options.mdxCompilerOptions;
+		this.getBuildPlugins = options.getBuildPlugins;
+		this.importNodePageModule = options.importNodePageModule;
+	}
+
+	isDevTransformOutputUrl(outputUrl: string): boolean {
+		return outputUrl.startsWith(`${DEV_TRANSFORM_URL_PREFIX}/`);
+	}
+
+	getEntrypointOutput(entrypointPath: string): { outputPath: string; outputUrl: string } {
+		const srcDir = this.context.getSrcDir();
+		const relativePath = path.relative(srcDir, entrypointPath);
+		const relativePathJs = relativePath.replace(/\.(tsx?|jsx?|mdx)$/, '.js');
+		const encodedPathJs = encodeDynamicSegments(relativePathJs);
+		const outputPath = path.join(this.context.getDistDir(), encodedPathJs);
+		const outputUrl = `/${path.join(RESOLVED_ASSETS_DIR, '_hmr', encodedPathJs).split(path.sep).join('/')}`;
+
+		return { outputPath, outputUrl };
+	}
+
+	async resolveDeclaredModulesForEntrypoint(entrypointPath: string): Promise<readonly string[]> {
+		const cached = this.pageMetadataCache.getDeclaredModules(entrypointPath);
+		if (cached) {
+			return cached;
+		}
+
+		const declaredModules = entrypointPath.endsWith('.mdx')
+			? await collectPageDeclaredModules(entrypointPath)
+			: collectPageDeclaredModulesFromModule(await this.importNodePageModule(entrypointPath));
+		this.pageMetadataCache.setDeclaredModules(entrypointPath, declaredModules);
+		return declaredModules;
+	}
+
+	buildPluginsForDeclaredModules(declaredModules: readonly string[], shouldEnableMdx: boolean): EcoBuildPlugin[] {
+		const plugins = this.getBuildPlugins(declaredModules);
+
+		if (shouldEnableMdx && this.mdxCompilerOptions) {
+			plugins.unshift(createReactMdxLoaderPlugin(this.mdxCompilerOptions));
+		}
+
+		return plugins;
+	}
+
+	async clearOutdirsForTargets(nonPageTargets: ReactHmrBuildTarget[]): Promise<void> {
+		const outdirs = new Set<string>();
+
+		for (const { entrypointPath, outputUrl } of nonPageTargets) {
+			if (this.isDevTransformOutputUrl(outputUrl)) {
+				continue;
+			}
+
+			outdirs.add(path.dirname(this.getEntrypointOutput(entrypointPath).outputPath));
+		}
+
+		await Promise.all([...outdirs].map((outdir) => this.clearHmrOutdir(outdir)));
+	}
+
+	async bundleEntrypoint(entrypointPath: string, outputUrl: string): Promise<boolean> {
+		const rebuiltOutputs = await this.bundleTargets([{ entrypointPath, outputUrl }], { grouped: false });
+		return rebuiltOutputs.length > 0;
+	}
+
+	async bundleEntrypoints(entrypoints: ReactHmrBuildTarget[]): Promise<string[]> {
+		return this.bundleTargets(entrypoints, { grouped: true });
+	}
+
+	async bundleTargets(targets: ReactHmrBuildTarget[], options: { grouped: boolean }): Promise<string[]> {
+		if (targets.length === 0) {
+			return [];
+		}
+
+		try {
+			const { declaredModules, shouldEnableMdx } = await this.collectDeclaredModulesForTargets(targets);
+			const plugins = this.buildPluginsForDeclaredModules(declaredModules, shouldEnableMdx);
+
+			if (options.grouped) {
+				const entryNameByPath = new Map<string, { key: string; basename: string }>();
+				for (const { entrypointPath } of targets) {
+					entryNameByPath.set(entrypointPath, {
+						key: this.getRolldownEntryKey(entrypointPath),
+						basename: this.getTempFileBasename(entrypointPath),
+					});
+				}
+
+				const result = await this.context.getBrowserBundleService().bundle({
+					profile: 'hmr-entrypoint',
+					entrypoints: Object.fromEntries(
+						targets.map(({ entrypointPath }) => [entryNameByPath.get(entrypointPath)!.key, entrypointPath]),
+					),
+					outdir: this.context.getDistDir(),
+					naming: '[name].[hash].tmp',
+					splitting: true,
+					plugins,
+					minify: false,
+				});
+
+				if (!result.success) {
+					appLogger.error(`Failed to build grouped React entrypoints:`, result.logs);
+					return [];
+				}
+
+				this.recordBuildDependencyGraph(result);
+
+				const updatedOutputs: string[] = [];
+				for (const { entrypointPath, outputUrl } of targets) {
+					const { outputPath } = this.getEntrypointOutput(entrypointPath);
+					const { basename: tempBasename, key: entryKey } = entryNameByPath.get(entrypointPath)!;
+					const expectedSubdir = path.join(this.context.getDistDir(), path.dirname(entryKey));
+					const tempOutput = result.outputs.find((output) => {
+						return (
+							path.dirname(output.path) === expectedSubdir &&
+							path.basename(output.path).startsWith(`${tempBasename}.`) &&
+							path.basename(output.path).includes('.tmp')
+						);
+					})?.path;
+
+					const resolvedTempOutput = tempOutput
+						? await this.resolveTempOutputPath(tempOutput)
+						: await this.resolveTempOutputPath(path.join(expectedSubdir, `${tempBasename}.[hash].tmp.js`));
+
+					if (!resolvedTempOutput) {
+						appLogger.debug(`Missing grouped temp output for ${outputUrl}`);
+						continue;
+					}
+
+					const processed = await this.processOutput(resolvedTempOutput, outputPath, outputUrl);
+					if (processed) {
+						updatedOutputs.push(outputUrl);
+					}
+				}
+
+				return updatedOutputs;
+			}
+
+			const { entrypointPath, outputUrl } = targets[0]!;
+			const { outputPath } = this.getEntrypointOutput(entrypointPath);
+			const tempDir = path.dirname(outputPath);
+
+			const result = await this.context.getBrowserBundleService().bundle({
+				profile: 'hmr-entrypoint',
+				entrypoints: [entrypointPath],
+				outdir: tempDir,
+				naming: `[name].[hash].tmp`,
+				plugins,
+				minify: false,
+			});
+
+			if (!result.success) {
+				appLogger.error(`Failed to build ${entrypointPath}:`, result.logs);
+				return [];
+			}
+
+			this.recordBuildDependencyGraph(result);
+
+			const tempFile = result.outputs[0]?.path;
+			if (!tempFile) {
+				appLogger.error(`No output file generated for ${entrypointPath}`);
+				return [];
+			}
+
+			const resolvedTempFile = await this.resolveTempOutputPath(tempFile);
+			if (!resolvedTempFile) {
+				appLogger.debug(`Skipping stale temp output for ${outputUrl}: ${tempFile}`);
+				return [];
+			}
+
+			const processed = await this.processOutput(resolvedTempFile, outputPath, outputUrl);
+			return processed ? [outputUrl] : [];
+		} catch (error) {
+			const label = options.grouped
+				? 'grouped React entrypoints'
+				: (targets[0]?.entrypointPath ?? 'React entrypoint');
+			appLogger.error(`Error bundling ${label}:`, error as Error);
+			return [];
+		}
+	}
+
+	async clearHmrOutdir(outdir: string): Promise<void> {
+		if (!fileSystem.exists(outdir)) {
+			return;
+		}
+
+		const tempFiles = await fileSystem.glob(['**/*.tmp.js'], { cwd: outdir });
+		await Promise.all(
+			tempFiles.map((relativePath) => {
+				const absolutePath = path.isAbsolute(relativePath) ? relativePath : path.join(outdir, relativePath);
+				return fileSystem.removeAsync(absolutePath).catch(() => undefined);
+			}),
+		);
+
+		const chunksDir = path.join(outdir, 'chunks');
+		if (fileSystem.exists(chunksDir)) {
+			await fileSystem.removeAsync(chunksDir).catch(() => undefined);
+		}
+	}
+
+	private async collectDeclaredModulesForTargets(
+		targets: ReactHmrBuildTarget[],
+	): Promise<{ declaredModules: string[]; shouldEnableMdx: boolean }> {
+		const declaredModules = new Set<string>();
+		let shouldEnableMdx = false;
+
+		for (const { entrypointPath } of targets) {
+			const entrypointDeclaredModules = await this.resolveDeclaredModulesForEntrypoint(entrypointPath);
+			for (const declaredModule of entrypointDeclaredModules) {
+				declaredModules.add(declaredModule);
+			}
+
+			if (entrypointPath.endsWith('.mdx')) {
+				shouldEnableMdx = true;
+			}
+		}
+
+		return { declaredModules: [...declaredModules], shouldEnableMdx };
+	}
+
+	private recordBuildDependencyGraph(result: { dependencyGraph?: { entrypoints?: Record<string, string[]> } }): void {
+		if (!result.dependencyGraph?.entrypoints) {
+			return;
+		}
+
+		const dependencyGraph = this.context.getEntrypointDependencyGraph();
+		for (const [entrypoint, deps] of Object.entries(result.dependencyGraph.entrypoints)) {
+			dependencyGraph.setEntrypointDependencies(entrypoint, deps);
+		}
+	}
+
+	getRolldownEntryKey(entrypointPath: string): string {
+		const srcDir = this.context.getSrcDir();
+		const relativePath = path.relative(srcDir, entrypointPath);
+		return relativePath.replace(/\.(tsx?|jsx?|mdx)$/, '');
+	}
+
+	private getTempFileBasename(entrypointPath: string): string {
+		const srcDir = this.context.getSrcDir();
+		const relativePath = path.relative(srcDir, entrypointPath);
+		const relativePathNoExt = relativePath.replace(/\.(tsx?|jsx?|mdx)$/, '');
+		const encodedPath = encodeDynamicSegments(relativePathNoExt);
+		return path.basename(encodedPath);
+	}
+
+	async resolveTempOutputPath(tempPath: string): Promise<string | null> {
+		if (fileSystem.exists(tempPath)) {
+			return tempPath;
+		}
+
+		if (!tempPath.includes('[hash]')) {
+			return null;
+		}
+
+		const directory = path.dirname(tempPath);
+		const pattern = path.basename(tempPath).replaceAll('[hash]', '*');
+		const matches = await fileSystem.glob([pattern], { cwd: directory });
+
+		if (matches.length === 0) {
+			return null;
+		}
+
+		return path.isAbsolute(matches[0]!) ? matches[0]! : path.join(directory, matches[0]!);
+	}
+
+	async processOutput(tempPath: string, finalPath: string, url: string): Promise<boolean> {
+		if (!fileSystem.exists(tempPath)) {
+			appLogger.debug(`Skipping stale temp output for ${url}: ${tempPath}`);
+			return false;
+		}
+
+		try {
+			let code = await fileSystem.readFile(tempPath);
+
+			code = rewriteChunkImportUrls(code);
+			code = injectHmrHandler(code);
+
+			await fileSystem.writeAsync(finalPath, code);
+			await fileSystem.removeAsync(tempPath).catch(() => {});
+
+			appLogger.debug(`Processed ${url} with HMR handler`);
+			return true;
+		} catch (error) {
+			if (isMissingTempOutputError(error)) {
+				appLogger.debug(`Skipping stale temp output for ${url}: ${tempPath}`);
+				await fileSystem.removeAsync(tempPath).catch(() => {});
+				return false;
+			}
+
+			appLogger.error(`Error processing output for ${url}:`, error as Error);
+			await fileSystem.removeAsync(tempPath).catch(() => {});
+			return false;
+		}
+	}
+}
+
+function encodeDynamicSegments(filepath: string): string {
+	return filepath.replace(/\[([^\]]+)\]/g, '_$1_');
+}
+
+function rewriteChunkImportUrls(code: string): string {
+	const hmrChunkBaseUrl = `/${path.join(RESOLVED_ASSETS_DIR, '_hmr').split(path.sep).join('/')}`;
+
+	return code.replace(/(['"])(?:\.\.\/)+(chunk-[^'"]+\.js)\1/g, (_match, quote, chunkFile) => {
+		return `${quote}${hmrChunkBaseUrl}/${chunkFile}${quote}`;
+	});
+}
+
+function isMissingTempOutputError(error: unknown): boolean {
+	if (error instanceof FileNotFoundError) {
+		return true;
+	}
+
+	if (!(error instanceof Error)) {
+		return false;
+	}
+
+	if (error.message.includes('not found') || error.message.includes('ENOENT')) {
+		return true;
+	}
+
+	const errorCause = error.cause;
+	if (errorCause instanceof FileNotFoundError) {
+		return true;
+	}
+
+	return (
+		typeof errorCause === 'object' && errorCause !== null && 'code' in errorCause && errorCause.code === 'ENOENT'
+	);
+}


### PR DESCRIPTION
## Summary
- Extract legacy `_hmr` disk bundle/output processing from `ReactHmrStrategy` into `ReactHmrDiskBundler`
- Keep strategy focused on orchestration: `matches`, `process`, dev-transform plugins, page cohort grouping
- Brings `hmr-strategy.ts` from ~980 lines to ~507 lines (well under the 1k limit)

## Test plan
- [x] `pnpm exec vitest run packages/integrations/react/src/hmr/hmr-strategy.test.ts` (37/37)
- [x] Pre-commit: vitest (2016), lint, typecheck