### PR TITLE
feat: lazy MDX load and allowlisted watch prewarm

### DIFF
--- a/apps/docs/eco.config.ts
+++ b/apps/docs/eco.config.ts
@@ -5,7 +5,7 @@ import { imageProcessorPlugin } from '@ecopages/image-processor';
 import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
 import { postcssProcessorPlugin } from '@ecopages/postcss-processor';
 import { tailwindV4Preset } from '@ecopages/postcss-processor/presets/tailwind-v4';
-import { compareDocsEntries, docsFrontmatterSchema } from './src/content/docs';
+import { compareDocsEntries, docsFrontmatterSchema, DOCS_ROOT } from './src/content/docs';
 import { docsMdxPluginOptions } from './src/lib/docs/mdx-plugin-options';
 
 const config = await new ConfigBuilder()
@@ -33,6 +33,9 @@ const config = await new ConfigBuilder()
 						schema: docsFrontmatterSchema,
 						orderBy: compareDocsEntries,
 						entryType: './src/content/docs#DocsFrontmatter',
+						routePrefix: DOCS_ROOT,
+						devPrewarm: 'all',
+						devPrewarmReadiness: 'beforeReady',
 					},
 				},
 			},

--- a/apps/docs/src/content/docs/ecosystem/content-processor.mdx
+++ b/apps/docs/src/content/docs/ecosystem/content-processor.mdx
@@ -78,6 +78,26 @@ Collection keys must be kebab-case. Each key becomes `ecopages:content/<key>`.
 
 Do not add `slug` or `segments` to your frontmatter schema — the processor derives them from the file path.
 
+### Dev prewarm
+
+Collections can warm known static content routes during development. Add the public route prefix and choose which
+manifest entries to render:
+
+```typescript
+docs: {
+	contentDir: 'content/docs',
+	schema: docsFrontmatterSchema,
+	routePrefix: '/docs',
+	devPrewarm: 'all',
+	devPrewarmReadiness: 'beforeReady',
+}
+```
+
+`devPrewarm` accepts `'first'`, `'all'`, `{ limit }`, or `{ slugs }`. The default readiness is `'background'`;
+`'beforeReady'` waits until the selected paths are rendered before Ecopages reports the framework ready signal
+(not before the listen port opens). Prewarming stores HTML only for the selected paths on the watch page cache
+allowlist and does not enable caching for other development routes.
+
 ### Docs app wiring
 
 - **Frontmatter schema and section config** — `src/content/docs.ts`
@@ -99,29 +119,30 @@ order: 1
 Catch-all render pattern:
 
 ```typescript
-import { getComponent } from 'ecopages:content/docs';
+import { getComponent } from 'ecopages:content/docs/server';
 import { docsMdxComponents } from '@/lib/docs/mdx-components';
 
-const Content = getComponent('getting-started/introduction');
+const Content = await getComponent('getting-started/introduction');
 return await Content({ components: docsMdxComponents });
 ```
 
 ## Virtual module API
 
-Each collection exposes `ecopages:content/<collection>`:
+Each collection exposes `ecopages:content/<collection>` for metadata and `ecopages:content/<collection>/server` for MDX components:
 
 ```typescript
-import { entries, getEntry, getEntryBySegments, getComponent } from 'ecopages:content/docs';
+import { entries, getEntry, getEntryBySegments } from 'ecopages:content/docs';
+import { getComponent } from 'ecopages:content/docs/server';
 import type { Entry } from 'ecopages:content/docs';
 ```
 
-| Export | Description |
-| :----- | :---------- |
-| `entries` | Readonly manifest, sorted by `orderBy` |
-| `getEntry(slug)` | Lookup by joined slug, e.g. `'getting-started/introduction'` |
-| `getEntryBySegments(segments)` | Lookup by segment array |
-| `getComponent(slug)` | MDX component for the entry |
-| `Entry` | Type only — frontmatter fields plus `slug` and `segments` |
+| Export | Module | Description |
+| :----- | :----- | :---------- |
+| `entries` | entries | Readonly manifest, sorted by `orderBy` |
+| `getEntry(slug)` | entries | Lookup by joined slug, e.g. `'getting-started/introduction'` |
+| `getEntryBySegments(segments)` | entries | Lookup by segment array |
+| `getComponent(slug)` | server | `Promise` of the MDX component for the entry |
+| `Entry` | entries | Type only — frontmatter fields plus `slug` and `segments` |
 
 Keep `Entry` on a separate `import type` line in bundled page files.
 

--- a/apps/docs/src/pages/docs/[...slug]/index.tsx
+++ b/apps/docs/src/pages/docs/[...slug]/index.tsx
@@ -45,9 +45,9 @@ export default eco.page<DocsCatchAllProps, JsxRenderable>({
 	}),
 	staticProps,
 	metadata: getMetadata,
-	dependencies: ({ props }) => getEntryDependencies(props.entry.slug),
+	dependencies: async ({ props }) => getEntryDependencies(props.entry.slug),
 	render: async ({ entry }) => {
-		const Content = getComponent(entry.slug);
+		const Content = await getComponent(entry.slug);
 
 		return await Content({ components: docsMdxComponents });
 	},

--- a/e2e/scripts/playwright/start-docs-e2e-server.mjs
+++ b/e2e/scripts/playwright/start-docs-e2e-server.mjs
@@ -18,6 +18,7 @@ const port = process.env.ECOPAGES_PORT || '4009';
 const DOCS_BUILD_INPUT_ROOTS = [
 	docsSrc,
 	path.join(repoRoot, 'packages', 'core', 'src'),
+	path.join(repoRoot, 'packages', 'processors', 'content-processor', 'src'),
 	path.join(repoRoot, 'packages', 'integrations', 'react', 'src'),
 	path.join(repoRoot, 'packages', 'integrations', 'ecopages-jsx', 'src'),
 	path.join(repoRoot, 'packages', 'react-router', 'src'),
@@ -73,6 +74,14 @@ function getNewestMtime(dir) {
 
 function isDistFresh() {
 	if (!existsSync(docsDist)) {
+		return false;
+	}
+
+	/**
+	 * Interrupted builds can leave public assets without rendered HTML. Treat those
+	 * as stale so preview never serves a hollow dist that 404s every docs route.
+	 */
+	if (!existsSync(path.join(docsDist, 'index.html'))) {
 		return false;
 	}
 

--- a/examples/docs-starter/src/pages/docs/[...slug]/index.tsx
+++ b/examples/docs-starter/src/pages/docs/[...slug]/index.tsx
@@ -51,7 +51,7 @@ export default eco.page<DocsCatchAllProps, JsxRenderable>({
 	staticProps,
 	metadata: getMetadata,
 	render: async ({ section, slug }) => {
-		const Content = getComponent(`${section}/${slug}`);
+		const Content = await getComponent(`${section}/${slug}`);
 
 		return await Content({ components: docsMdxComponents });
 	},

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -15,10 +15,13 @@ All notable changes to `@ecopages/core` are documented here.
 - Removed deprecated `config.layout` innermost alias on page configs. Use `config.layouts` and `config.layoutEntries` instead.
 - `createAliasResolverPlugin` now takes the app **project root** (not `srcDir`) and resolves aliases from tsconfig `compilerOptions.paths` only. Apps without tsconfig `paths` get no alias resolver handlers. Hardcoded `@/` → `srcDir` mapping is removed.
 - Removed dev HMR entrypoint disk cache, grouped cold-graph prewarm, and `ECOPAGES_DEV_COLD_CLIENT_GRAPH*` env vars. Dev client modules are transpiled per source file on demand with in-memory caching and lazy `/assets/vendors` prebundles.
+- Removed `ECOPAGES_DEV_PREWARM_ALL_STATIC_ROUTES`. Dev SSR prewarm only renders processor-declared pathnames from `collectDevPrewarmPlan()`.
 
 ### Features
 
-- Dev transform serves per-module browser ESM: transpile one file, rewrite imports to `__eco_dev__` or vendor URLs, memory cache only.
+- Page HTML cache in watch mode defaults to off for undeclared routes; processor `devPrewarm` registers an allowlist on the single watch `PageCacheService` so only those pathnames retain HTML. Set `cache.enabled: true` to cache every dev route.
+- Page Browser Graph per-route reuse is disabled while HMR is enabled; session graphs still cache after build with dependency invalidation.
+- Watch mode SSR-prewarms processor-declared content paths after the HMR-ready response pipeline is configured (`routePrefix` + `devPrewarm`). Optional `devPrewarmReadiness: 'beforeReady'` blocks the framework ready signal until prewarm completes. Concurrent prewarm uses `ECOPAGES_DEV_PREWARM_STATIC_ROUTES_PARALLELISM` (default `3`).
 - Added nested `layout` arrays on `eco.page()` with normalization to `config.layouts` / `config.layoutEntries`.
 - Added `composeChildren` hook on `composeDocumentShell` for integration-owned unified layout+page composition.
 - Added `EcoDeclaredComponent` validation for `dependencies.components` entries.

--- a/packages/core/src/adapters/bun/server-adapter.ts
+++ b/packages/core/src/adapters/bun/server-adapter.ts
@@ -642,6 +642,7 @@ export class BunServerAdapter extends SharedServerAdapter<BunServerAdapterParams
 				appConfig: this.appConfig,
 				runtimeOrigin: this.runtimeOrigin,
 			});
+			await this.startDevStaticRoutePrewarmWhenReady();
 		}
 
 		this.fullyInitialized = true;

--- a/packages/core/src/adapters/node/server-adapter.ts
+++ b/packages/core/src/adapters/node/server-adapter.ts
@@ -407,6 +407,8 @@ export class NodeServerAdapter extends SharedServerAdapter<NodeServerAdapterPara
 
 			this.configureSharedResponseHandlers(this.staticRoutes, this.hmrManager);
 
+			await this.startDevStaticRoutePrewarmWhenReady();
+
 			const watcher = new ProjectWatcher({
 				config: this.appConfig,
 				refreshRouterRoutesCallback: this.createSharedWatchRefreshCallback({

--- a/packages/core/src/adapters/shared/runtime/collect-dev-prewarm-plan.ts
+++ b/packages/core/src/adapters/shared/runtime/collect-dev-prewarm-plan.ts
@@ -1,0 +1,32 @@
+import type { EcoPagesAppConfig } from '../../../types/internal-types.ts';
+import type { Processor } from '../../../plugins/processor.ts';
+import type { DevPrewarmReadiness } from './dev-static-route-prewarm.ts';
+
+export type DevPrewarmPlan = {
+	pathnames: readonly string[];
+	readiness: DevPrewarmReadiness;
+};
+
+/**
+ * Aggregates processor-declared dev prewarm pathnames and readiness into one plan.
+ */
+export async function collectAppDevPrewarmPlan(appConfig: EcoPagesAppConfig): Promise<DevPrewarmPlan> {
+	const pathnames = new Set<string>();
+	let readiness: DevPrewarmReadiness = 'background';
+
+	for (const processor of appConfig.processors.values()) {
+		const contributor = processor as Processor;
+		const plan = await contributor.collectDevPrewarmPlan();
+		for (const pathname of plan.pathnames) {
+			pathnames.add(pathname);
+		}
+		if (plan.readiness === 'beforeReady') {
+			readiness = 'beforeReady';
+		}
+	}
+
+	return {
+		pathnames: [...pathnames],
+		readiness,
+	};
+}

--- a/packages/core/src/adapters/shared/runtime/dev-static-route-prewarm.test.ts
+++ b/packages/core/src/adapters/shared/runtime/dev-static-route-prewarm.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { runDevStaticRoutePrewarm } from './dev-static-route-prewarm.ts';
+
+test('runDevStaticRoutePrewarm renders unique pathnames and registers them before rendering', async () => {
+	const rendered: string[] = [];
+	let registered: readonly string[] | undefined;
+
+	await runDevStaticRoutePrewarm({
+		pathnames: ['/docs/a', '/docs/b', '/docs/a'],
+		renderPath: async (pathname) => {
+			rendered.push(pathname);
+		},
+		onPathnamesResolved: (pathnames) => {
+			registered = pathnames;
+		},
+	});
+
+	assert.deepEqual(registered, ['/docs/a', '/docs/b']);
+	assert.deepEqual(rendered, ['/docs/a', '/docs/b']);
+});
+
+test('runDevStaticRoutePrewarm continues after a path failure', async () => {
+	const rendered: string[] = [];
+
+	await runDevStaticRoutePrewarm({
+		pathnames: ['/ok', '/fail', '/also-ok'],
+		readiness: 'beforeReady',
+		renderPath: async (pathname) => {
+			if (pathname === '/fail') {
+				throw new Error('boom');
+			}
+			rendered.push(pathname);
+		},
+	});
+
+	assert.deepEqual(rendered, ['/ok', '/also-ok']);
+});

--- a/packages/core/src/adapters/shared/runtime/dev-static-route-prewarm.ts
+++ b/packages/core/src/adapters/shared/runtime/dev-static-route-prewarm.ts
@@ -1,0 +1,88 @@
+import { appLogger } from '../../../global/app-logger.ts';
+
+export type DevPrewarmReadiness = 'background' | 'beforeReady';
+
+export type DevStaticRoutePrewarmOptions = {
+	pathnames: readonly string[];
+	readiness?: DevPrewarmReadiness;
+	renderPath: (pathname: string) => Promise<void>;
+	/** Invoked with the pathname list before rendering begins. */
+	onPathnamesResolved?: (pathnames: readonly string[]) => void;
+};
+
+const LOG_PREFIX = '[ecopages:dev-prewarm]';
+
+function resolvePrewarmConcurrency(): number {
+	const fromEnv = process.env.ECOPAGES_DEV_PREWARM_STATIC_ROUTES_PARALLELISM;
+	if (fromEnv) {
+		const parsed = Number(fromEnv);
+		if (Number.isFinite(parsed) && parsed > 0) {
+			return Math.floor(parsed);
+		}
+	}
+
+	return 3;
+}
+
+async function runWithConcurrency<T>(items: readonly T[], concurrency: number, worker: (item: T) => Promise<void>) {
+	if (items.length === 0) {
+		return;
+	}
+
+	let index = 0;
+	const runners = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+		while (index < items.length) {
+			const current = items[index];
+			index += 1;
+			if (current === undefined) {
+				continue;
+			}
+			await worker(current);
+		}
+	});
+
+	await Promise.all(runners);
+}
+
+/**
+ * Renders declared pathnames so first client navigations hit warm graphs and scoped watch HTML cache.
+ */
+export async function runDevStaticRoutePrewarm(options: DevStaticRoutePrewarmOptions): Promise<void> {
+	const pathnames = [...new Set(options.pathnames)];
+	if (pathnames.length === 0) {
+		return;
+	}
+
+	options.onPathnamesResolved?.(pathnames);
+
+	const concurrency = resolvePrewarmConcurrency();
+	const readiness = options.readiness ?? 'background';
+	appLogger.debug(
+		`${LOG_PREFIX} started (${pathnames.length} path(s), concurrency ${concurrency}, readiness=${readiness})`,
+	);
+	appLogger.debug(`${LOG_PREFIX} pathnames: ${pathnames.join(', ')}`);
+
+	await runWithConcurrency(pathnames, concurrency, async (pathname) => {
+		try {
+			await options.renderPath(pathname);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			if (readiness === 'beforeReady') {
+				appLogger.warn(`${LOG_PREFIX} skipped ${pathname}: ${message}`);
+			} else {
+				appLogger.debug(`${LOG_PREFIX} skipped ${pathname}: ${message}`);
+			}
+		}
+	});
+
+	appLogger.debug(`${LOG_PREFIX} finished (${pathnames.length} path(s))`);
+}
+
+/**
+ * Fire-and-forget wrapper around {@link runDevStaticRoutePrewarm}.
+ */
+export function startDevStaticRoutePrewarm(options: DevStaticRoutePrewarmOptions): void {
+	void runDevStaticRoutePrewarm(options).catch((error) => {
+		appLogger.error(`${LOG_PREFIX} failed: ${error instanceof Error ? error.message : String(error)}`);
+	});
+}

--- a/packages/core/src/adapters/shared/runtime/server-adapter.ts
+++ b/packages/core/src/adapters/shared/runtime/server-adapter.ts
@@ -6,7 +6,11 @@ import { RouteRegistry } from '../../../router/server/route-registry.ts';
 import { startupTrace } from '../../../diagnostics/startup-trace.ts';
 import { requestBuildDedupe } from '../../../diagnostics/request-build-dedupe.ts';
 import { MemoryCacheStore } from '../../../services/cache/memory-cache-store.ts';
-import { PageCacheService } from '../../../services/cache/page-cache-service.ts';
+import { AllowlistedMemoryCacheStore } from '../../../services/cache/allowlisted-memory-cache-store.ts';
+import {
+	PageCacheService,
+	registerAppPageCacheService,
+} from '../../../services/cache/page-cache-service.ts';
 import { SchemaValidationService } from '../../../services/validation/schema-validation-service.ts';
 import { StaticSiteGenerator } from '../../../static-site-generator/static-site-generator.ts';
 import { ServerStaticBuilder } from './server-static-builder.ts';
@@ -14,6 +18,8 @@ import { ExplicitStaticRouteMatcher } from '../http/explicit-static-route-matche
 import { FileSystemServerResponseFactory } from '../http/fs-server-response-factory.ts';
 import { FileSystemResponseMatcher } from '../http/fs-server-response-matcher.ts';
 import { ServerRouteHandler } from './server-route-handler.ts';
+import { startDevStaticRoutePrewarm, runDevStaticRoutePrewarm } from './dev-static-route-prewarm.ts';
+import { collectAppDevPrewarmPlan } from './collect-dev-prewarm-plan.ts';
 import { createRenderContext } from './render-context.ts';
 import { ApiRequestPipeline } from '../http/api-request-pipeline.ts';
 import {
@@ -70,6 +76,43 @@ export abstract class SharedServerAdapter<
 		getCacheService: () => this.getCacheService(),
 	});
 	protected hostOwnsDevClient = false;
+	private devStaticRoutePrewarmStarted = false;
+	private sharedPageCacheService: PageCacheService | null | undefined;
+	private watchAllowlistStore: AllowlistedMemoryCacheStore | null = null;
+
+	/**
+	 * Warms declared static paths after the final watch-mode response pipeline exists.
+	 */
+	protected async startDevStaticRoutePrewarmWhenReady(): Promise<void> {
+		if (!this.options?.watch || this.devStaticRoutePrewarmStarted) {
+			return;
+		}
+
+		this.devStaticRoutePrewarmStarted = true;
+
+		const runtimeOrigin = this.runtimeOrigin;
+		const plan = await collectAppDevPrewarmPlan(this.appConfig);
+		const options = {
+			pathnames: plan.pathnames,
+			readiness: plan.readiness,
+			renderPath: async (pathname: string) => {
+				const response = await this.routeHandler.handleResponse(
+					new Request(new URL(pathname, runtimeOrigin).toString(), { method: 'GET' }),
+				);
+				await response.arrayBuffer();
+			},
+			onPathnamesResolved: (pathnames: readonly string[]) => {
+				this.watchAllowlistStore?.registerAllowedKeys(pathnames);
+			},
+		};
+
+		if (plan.readiness === 'beforeReady') {
+			await runDevStaticRoutePrewarm(options);
+			return;
+		}
+
+		startDevStaticRoutePrewarm(options);
+	}
 
 	protected async initializeSharedRouteHandling(options: {
 		staticRoutes: StaticRoute[];
@@ -195,7 +238,7 @@ export abstract class SharedServerAdapter<
 			},
 		});
 
-		const cacheService = this.createSharedPageCacheService();
+		const cacheService = this.getOrCreateSharedPageCacheService();
 		const fileSystemResponseMatcher = new FileSystemResponseMatcher({
 			appConfig: this.appConfig,
 			assetPrefix: path.join(this.appConfig.rootDir, this.appConfig.distDir),
@@ -220,10 +263,36 @@ export abstract class SharedServerAdapter<
 		};
 	}
 
-	private createSharedPageCacheService(): PageCacheService | null {
+	private getOrCreateSharedPageCacheService(): PageCacheService | null {
+		if (this.sharedPageCacheService !== undefined) {
+			return this.sharedPageCacheService;
+		}
+
 		const cacheConfig = this.appConfig.cache;
-		const isCacheEnabled = cacheConfig?.enabled ?? !this.options?.watch;
+		const watch = Boolean(this.options?.watch);
+
+		if (watch) {
+			const useFullWatchCache = cacheConfig?.enabled === true;
+			const store = useFullWatchCache
+				? cacheConfig?.store === 'memory' || !cacheConfig?.store
+					? new MemoryCacheStore({ maxEntries: cacheConfig?.maxEntries })
+					: cacheConfig.store
+				: new AllowlistedMemoryCacheStore({ maxEntries: cacheConfig?.maxEntries });
+
+			if (!useFullWatchCache && store instanceof AllowlistedMemoryCacheStore) {
+				this.watchAllowlistStore = store;
+			}
+
+			const service = new PageCacheService({ store, enabled: true });
+			this.sharedPageCacheService = service;
+			registerAppPageCacheService(this.appConfig, service);
+			return service;
+		}
+
+		const isCacheEnabled = cacheConfig?.enabled ?? true;
 		if (!isCacheEnabled) {
+			this.sharedPageCacheService = null;
+			registerAppPageCacheService(this.appConfig, null);
 			return null;
 		}
 
@@ -231,7 +300,10 @@ export abstract class SharedServerAdapter<
 			cacheConfig?.store === 'memory' || !cacheConfig?.store
 				? new MemoryCacheStore({ maxEntries: cacheConfig?.maxEntries })
 				: cacheConfig.store;
-		return new PageCacheService({ store, enabled: true });
+		const service = new PageCacheService({ store, enabled: true });
+		this.sharedPageCacheService = service;
+		registerAppPageCacheService(this.appConfig, service);
+		return service;
 	}
 
 	protected getCacheService(): CacheInvalidator | null {

--- a/packages/core/src/adapters/shared/runtime/server-adapter.ts
+++ b/packages/core/src/adapters/shared/runtime/server-adapter.ts
@@ -7,10 +7,7 @@ import { startupTrace } from '../../../diagnostics/startup-trace.ts';
 import { requestBuildDedupe } from '../../../diagnostics/request-build-dedupe.ts';
 import { MemoryCacheStore } from '../../../services/cache/memory-cache-store.ts';
 import { AllowlistedMemoryCacheStore } from '../../../services/cache/allowlisted-memory-cache-store.ts';
-import {
-	PageCacheService,
-	registerAppPageCacheService,
-} from '../../../services/cache/page-cache-service.ts';
+import { PageCacheService, registerAppPageCacheService } from '../../../services/cache/page-cache-service.ts';
 import { SchemaValidationService } from '../../../services/validation/schema-validation-service.ts';
 import { StaticSiteGenerator } from '../../../static-site-generator/static-site-generator.ts';
 import { ServerStaticBuilder } from './server-static-builder.ts';

--- a/packages/core/src/plugins/processor.ts
+++ b/packages/core/src/plugins/processor.ts
@@ -173,6 +173,16 @@ export abstract class Processor<TOptions = Record<string, unknown>> {
 	async prepareBuildContributions(): Promise<void> {}
 
 	/**
+	 * Declares watch-mode SSR prewarm pathnames and readiness for core.
+	 *
+	 * @remarks
+	 * Processors return paths and readiness only; core owns parallel rendering and page cache population.
+	 */
+	collectDevPrewarmPlan(): Promise<{ pathnames: readonly string[]; readiness: 'background' | 'beforeReady' }> {
+		return Promise.resolve({ pathnames: [], readiness: 'background' });
+	}
+
+	/**
 	 * Reports whether this processor's build inputs changed since the last
 	 * incremental static build.
 	 *

--- a/packages/core/src/route-renderer/README.md
+++ b/packages/core/src/route-renderer/README.md
@@ -69,7 +69,9 @@ Domain folders:
 
 **Page Browser Graph session behavior:**
 
-- In development, each Page Browser Graph is built on first request, cached in `page-browser-graph-session` with generation-safe commits, and invalidated when a tracked dependency changes. Hosts call `prepareHmrFileChange()` before HMR dispatch and defer client broadcasts when no browser subscribers are connected.
+- In development, each Page Browser Graph is built on first request, cached in `page-browser-graph-session` with generation-safe commits, and invalidated when a tracked dependency changes. The per-route fast path is disabled while HMR is enabled so prop-dependent `dependencies(props)` cannot reuse the wrong graph. Hosts call `prepareHmrFileChange()` before HMR dispatch and defer client broadcasts when no browser subscribers are connected.
+- Dev SSR prewarm registers processor-declared pathnames on an allowlisted memory store backing the single watch `PageCacheService`, then renders those paths. Undeclared routes stay uncached unless `cache.enabled: true`. The watcher awaits `clearAppPageCache` before continuing invalidation.
+- **Measuring dev page load:** set `ECOPAGES_STARTUP_TRACE=true` and compare `/`, an early docs slug, and a late manifest slug. Target: first warmed docs navigation should hit the allowlisted page cache (`X-Cache: HIT`) and avoid cold MDX compile when prewarm finished.
 - Production static export prebuilds browser graphs from the finalized route list into the in-memory `page-browser-graph-session` via `production-page-browser-graph-prebuild.ts`. Failed exports clear staged production session records so retries cannot reuse partial graph output.
 - Integrations activate lazily on first render or graph prebuild via `ensureIntegrationRuntimeReady()`. Processors and loaders still initialize eagerly during `setupAppRuntimePlugins()`.
 

--- a/packages/core/src/route-renderer/orchestration/integration-renderer.ts
+++ b/packages/core/src/route-renderer/orchestration/integration-renderer.ts
@@ -11,7 +11,6 @@ import type {
 	EcoComponent,
 	EcoComponentDependencies,
 	EcoFunctionComponent,
-	EcoPageComponent,
 	EcoPageFile,
 	EcoPagesElement,
 	BaseIntegrationContext,

--- a/packages/core/src/services/README.md
+++ b/packages/core/src/services/README.md
@@ -18,6 +18,7 @@ Typical responsibilities include:
 
 - `module-loading/`: framework-owned config/app bootstrap loading and server-side source loading
 - `assets/`: shared browser build coordination and processed asset pipelines
+- `cache/`: page HTML cache stores and request coordination, including watch-mode allowlisted memory storage for prewarm pathnames
 - `invalidation/`: file-change classification and invalidation policy
 - `runtime-state/`: app-owned invalidation state and dependency graphs
 - `runtime-manifest/`: node runtime manifest derivation and persistence

--- a/packages/core/src/services/cache/allowlisted-memory-cache-store.ts
+++ b/packages/core/src/services/cache/allowlisted-memory-cache-store.ts
@@ -1,0 +1,62 @@
+import type { CacheEntry, CacheStats, CacheStore } from './cache.types.ts';
+import { MemoryCacheStore } from './memory-cache-store.ts';
+
+/**
+ * Memory cache store that only accepts an explicit set of keys.
+ *
+ * @remarks
+ * Used in watch mode so only processor-declared prewarm pathnames retain HTML.
+ * Unlisted keys always miss and never write.
+ */
+export class AllowlistedMemoryCacheStore implements CacheStore {
+	private readonly inner: MemoryCacheStore;
+	private readonly allowedKeys = new Set<string>();
+
+	constructor(options?: { maxEntries?: number }) {
+		this.inner = new MemoryCacheStore(options);
+	}
+
+	/**
+	 * Replaces the set of keys that may be stored or retrieved.
+	 */
+	registerAllowedKeys(keys: readonly string[]): void {
+		this.allowedKeys.clear();
+		for (const key of keys) {
+			this.allowedKeys.add(key);
+		}
+	}
+
+	async get(key: string): Promise<CacheEntry | null> {
+		if (!this.allowedKeys.has(key)) {
+			return null;
+		}
+		return this.inner.get(key);
+	}
+
+	async set(key: string, entry: CacheEntry): Promise<void> {
+		if (!this.allowedKeys.has(key)) {
+			return;
+		}
+		await this.inner.set(key, entry);
+	}
+
+	async delete(key: string): Promise<boolean> {
+		return this.inner.delete(key);
+	}
+
+	async invalidateByTags(tags: string[]): Promise<number> {
+		return this.inner.invalidateByTags(tags);
+	}
+
+	async invalidateByPaths(paths: string[]): Promise<number> {
+		return this.inner.invalidateByPaths(paths);
+	}
+
+	async clear(): Promise<void> {
+		await this.inner.clear();
+	}
+
+	async stats(): Promise<CacheStats> {
+		return (await this.inner.stats?.()) ?? { entries: 0 };
+	}
+}

--- a/packages/core/src/services/cache/cache.types.ts
+++ b/packages/core/src/services/cache/cache.types.ts
@@ -100,8 +100,8 @@ export interface CacheConfig {
 
 	/**
 	 * Whether caching is enabled.
-	 * Automatically disabled in dev mode unless explicitly set.
-	 * @default true (production), false (development)
+	 * In watch mode, defaults to `false` unless explicitly enabled.
+	 * @default true in production builds, false in watch when omitted
 	 */
 	enabled?: boolean;
 

--- a/packages/core/src/services/cache/index.ts
+++ b/packages/core/src/services/cache/index.ts
@@ -17,8 +17,4 @@ export { MemoryCacheStore, type MemoryCacheStoreOptions } from './memory-cache-s
 export { AllowlistedMemoryCacheStore } from './allowlisted-memory-cache-store.ts';
 
 export { getCacheControlHeader, PageCacheService, type PageCacheServiceOptions } from './page-cache-service.ts';
-export {
-	clearAppPageCache,
-	getAppPageCacheService,
-	registerAppPageCacheService,
-} from './page-cache-service.ts';
+export { clearAppPageCache, getAppPageCacheService, registerAppPageCacheService } from './page-cache-service.ts';

--- a/packages/core/src/services/cache/index.ts
+++ b/packages/core/src/services/cache/index.ts
@@ -14,5 +14,11 @@ export type {
 } from './cache.types.ts';
 
 export { MemoryCacheStore, type MemoryCacheStoreOptions } from './memory-cache-store.ts';
+export { AllowlistedMemoryCacheStore } from './allowlisted-memory-cache-store.ts';
 
 export { getCacheControlHeader, PageCacheService, type PageCacheServiceOptions } from './page-cache-service.ts';
+export {
+	clearAppPageCache,
+	getAppPageCacheService,
+	registerAppPageCacheService,
+} from './page-cache-service.ts';

--- a/packages/core/src/services/cache/page-cache-service.ts
+++ b/packages/core/src/services/cache/page-cache-service.ts
@@ -5,6 +5,7 @@
  */
 
 import { appLogger } from '../../global/app-logger.ts';
+import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 import type { CacheEntry, CacheResult, CacheStore, CacheStrategy, RenderResult } from './cache.types.ts';
 import { MemoryCacheStore } from './memory-cache-store.ts';
 
@@ -20,6 +21,7 @@ export class PageCacheService {
 	private store: CacheStore;
 	private enabled: boolean;
 	private regenerationPromises = new Map<string, Promise<string>>();
+	private missPromises = new Map<string, Promise<CacheResult>>();
 
 	constructor(options: PageCacheServiceOptions = {}) {
 		this.store = options.store ?? new MemoryCacheStore();
@@ -85,6 +87,24 @@ export class PageCacheService {
 			return { html, status: 'miss', strategy };
 		}
 
+		const pendingMiss = this.missPromises.get(key);
+		if (pendingMiss) {
+			return pendingMiss;
+		}
+
+		const missPromise = this.resolveOrCreate(key, defaultStrategy, renderFn).finally(() => {
+			this.missPromises.delete(key);
+		});
+
+		this.missPromises.set(key, missPromise);
+		return missPromise;
+	}
+
+	private async resolveOrCreate(
+		key: string,
+		defaultStrategy: CacheStrategy,
+		renderFn: () => Promise<RenderResult>,
+	): Promise<CacheResult> {
 		const entry = await this.store.get(key);
 
 		if (!entry) {
@@ -199,4 +219,32 @@ export function getCacheControlHeader(strategy: CacheStrategy | 'disabled'): str
 	}
 
 	return 'no-store';
+}
+
+const pageCacheByAppConfig = new WeakMap<EcoPagesAppConfig, PageCacheService>();
+
+/**
+ * Registers the page cache service for one app config instance.
+ */
+export function registerAppPageCacheService(appConfig: EcoPagesAppConfig, service: PageCacheService | null): void {
+	if (service) {
+		pageCacheByAppConfig.set(appConfig, service);
+		return;
+	}
+
+	pageCacheByAppConfig.delete(appConfig);
+}
+
+/**
+ * Returns the registered page cache service for one app config, if any.
+ */
+export function getAppPageCacheService(appConfig: EcoPagesAppConfig): PageCacheService | null {
+	return pageCacheByAppConfig.get(appConfig) ?? null;
+}
+
+/**
+ * Clears rendered HTML cache entries for one app during development invalidation.
+ */
+export async function clearAppPageCache(appConfig: EcoPagesAppConfig): Promise<void> {
+	await getAppPageCacheService(appConfig)?.clear();
 }

--- a/packages/core/src/services/cache/page-request-cache-coordinator.dev-prewarm.test.ts
+++ b/packages/core/src/services/cache/page-request-cache-coordinator.dev-prewarm.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test, vi } from 'vitest';
+import { AllowlistedMemoryCacheStore } from './allowlisted-memory-cache-store.ts';
+import { PageCacheService } from './page-cache-service.ts';
+import { PageRequestCacheCoordinator } from './page-request-cache-coordinator.service.ts';
+
+describe('watch allowlisted page cache', () => {
+	test('prewarm fills the same PageCacheService the live handler uses', async () => {
+		const store = new AllowlistedMemoryCacheStore();
+		const cacheService = new PageCacheService({ store, enabled: true });
+		const coordinator = new PageRequestCacheCoordinator(cacheService, 'static');
+		const renderFn = vi.fn().mockResolvedValue({ html: '<html>warm</html>', strategy: 'static' as const });
+
+		store.registerAllowedKeys(['/docs/intro']);
+
+		await coordinator.render({
+			cacheKey: '/docs/intro',
+			pageCacheStrategy: 'static',
+			renderFn,
+		});
+		const second = await coordinator.render({
+			cacheKey: '/docs/intro',
+			pageCacheStrategy: 'static',
+			renderFn,
+		});
+
+		expect(renderFn).toHaveBeenCalledTimes(1);
+		expect(second.headers.get('X-Cache')).toBe('HIT');
+	});
+
+	test('unlisted pathnames miss and do not write', async () => {
+		const store = new AllowlistedMemoryCacheStore();
+		const cacheService = new PageCacheService({ store, enabled: true });
+		const coordinator = new PageRequestCacheCoordinator(cacheService, 'static');
+		const renderFn = vi.fn().mockResolvedValue({ html: '<html>cold</html>', strategy: 'static' as const });
+
+		store.registerAllowedKeys(['/docs/intro']);
+
+		await coordinator.render({
+			cacheKey: '/other',
+			pageCacheStrategy: 'static',
+			renderFn,
+		});
+		await coordinator.render({
+			cacheKey: '/other',
+			pageCacheStrategy: 'static',
+			renderFn,
+		});
+
+		expect(renderFn).toHaveBeenCalledTimes(2);
+	});
+
+	test('coalesces concurrent misses for the same key', async () => {
+		const store = new AllowlistedMemoryCacheStore();
+		store.registerAllowedKeys(['/docs/intro']);
+		const cacheService = new PageCacheService({ store, enabled: true });
+
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+
+		const renderFn = vi.fn(async () => {
+			await gate;
+			return { html: '<html>once</html>', strategy: 'static' as const };
+		});
+
+		const first = cacheService.getOrCreate('/docs/intro', 'static', renderFn);
+		const second = cacheService.getOrCreate('/docs/intro', 'static', renderFn);
+		release();
+
+		const [firstResult, secondResult] = await Promise.all([first, second]);
+
+		expect(renderFn).toHaveBeenCalledTimes(1);
+		expect(firstResult.html).toBe('<html>once</html>');
+		expect(secondResult.html).toBe('<html>once</html>');
+		expect(firstResult.status).toBe('miss');
+		expect(secondResult.status).toBe('miss');
+	});
+});

--- a/packages/core/src/watchers/project-watcher.test.ts
+++ b/packages/core/src/watchers/project-watcher.test.ts
@@ -217,9 +217,9 @@ describe('ProjectWatcher - File Change Handling', () => {
 			});
 
 			const pendingChange = (watcher as any).handleFileChange(pageFilePath, 'add');
-			await Promise.resolve();
-
-			expect(asyncRefreshCallback).toHaveBeenCalledTimes(1);
+			await vi.waitFor(() => {
+				expect(asyncRefreshCallback).toHaveBeenCalledTimes(1);
+			});
 			expect(HmrManager.handleFileChange).not.toHaveBeenCalled();
 
 			releaseRefresh();

--- a/packages/core/src/watchers/project-watcher.ts
+++ b/packages/core/src/watchers/project-watcher.ts
@@ -9,6 +9,7 @@ import {
 	type DevelopmentInvalidationPlan,
 } from '../services/invalidation/development-invalidation.service.ts';
 import { prepareHmrFileChange } from '../hmr/hmr-file-change-prep.ts';
+import { clearAppPageCache } from '../services/cache/page-cache-service.ts';
 import { getAppPageBrowserGraphSession } from '../route-renderer/orchestration/page-browser-graph/page-browser-graph-session.ts';
 import { isRegisteredDevTransformEntrypoint } from '../hmr/hmr-entrypoint-output.ts';
 import { resolveInternalExecutionDir } from '../utils/resolve-work-dir.ts';
@@ -217,6 +218,7 @@ export class ProjectWatcher {
 
 			this.uncacheModules();
 			const resolvedFilePath = path.resolve(filePath);
+			await clearAppPageCache(this.appConfig);
 			const graphPreparation = this.hmrManager.isEnabled()
 				? prepareHmrFileChange(this.appConfig, resolvedFilePath)
 				: undefined;

--- a/packages/processors/content-processor/CHANGELOG.md
+++ b/packages/processors/content-processor/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to `@ecopages/content-processor` are documented here.
 
 ### Features
 
+- Server collection modules (`ecopages:content/<collection>/server`) lazy-load MDX entries per slug via dynamic `import()`; `getComponent` and `getEntryDependencies` are async. Concurrent `getComponent` calls for the same slug share one in-flight load.
+- Collection `routePrefix` + `devPrewarm` declare URL pathnames for core's single `collectDevPrewarmPlan()` hook (parallel rendering stays in `@ecopages/core`).
+- `devPrewarmReadiness: 'beforeReady'` optionally blocks the framework ready signal until prewarm completes.
 - Added build-time content collections exposed as `ecopages:content/<collection>` virtual modules.
 - Added Standard Schema frontmatter validation, generated manifest modules, and virtual-module TypeScript declarations.
 - Added `ContentScanner` for reuse in build scripts and `withContentMdxPlugins()` for MDX frontmatter wiring.

--- a/packages/processors/content-processor/README.md
+++ b/packages/processors/content-processor/README.md
@@ -75,16 +75,16 @@ export default await new ConfigBuilder()
 
 ### Collection options
 
-| Option       | Required | Description                                                                                                                                          |
-| :----------- | :------: | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `contentDir` |   yes    | Directory relative to app `srcDir`, e.g. `content/docs`.                                                                                             |
-| `schema`     |   yes    | Standard Schema validator for frontmatter.                                                                                                           |
-| `entryType`  |    no    | Frontmatter type for generated virtual-module types. Format: `./path/to/schema#TypeName`. The processor wraps it as `ContentEntry<YourFrontmatter>`. |
-| `orderBy`    |    no    | Comparator function for manifest sort. Default: {@link compareEntriesBySlug}. Use {@link compareEntriesByField} for frontmatter fields.              |
-| `extensions` |    no    | File extensions to scan. Default: `['.mdx']`.                                                                                                        |
-| `routePrefix` |   no    | Public URL prefix for entries, e.g. `/docs`. Used with `devPrewarm`.                                                                                 |
-| `devPrewarm` |    no    | Dev prewarm: `'first'`, `'all'`, `{ slugs }`, or `{ limit }`. Core SSR-prewarms after the HMR-ready pipeline exists; HTML is stored only for these allowlisted paths on the watch page cache. |
-| `devPrewarmReadiness` | no | `'background'` (default) or `'beforeReady'` to block the framework ready signal until prewarm finishes (listen port may already be open). |
+| Option                | Required | Description                                                                                                                                                                                   |
+| :-------------------- | :------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `contentDir`          |   yes    | Directory relative to app `srcDir`, e.g. `content/docs`.                                                                                                                                      |
+| `schema`              |   yes    | Standard Schema validator for frontmatter.                                                                                                                                                    |
+| `entryType`           |    no    | Frontmatter type for generated virtual-module types. Format: `./path/to/schema#TypeName`. The processor wraps it as `ContentEntry<YourFrontmatter>`.                                          |
+| `orderBy`             |    no    | Comparator function for manifest sort. Default: {@link compareEntriesBySlug}. Use {@link compareEntriesByField} for frontmatter fields.                                                       |
+| `extensions`          |    no    | File extensions to scan. Default: `['.mdx']`.                                                                                                                                                 |
+| `routePrefix`         |    no    | Public URL prefix for entries, e.g. `/docs`. Used with `devPrewarm`.                                                                                                                          |
+| `devPrewarm`          |    no    | Dev prewarm: `'first'`, `'all'`, `{ slugs }`, or `{ limit }`. Core SSR-prewarms after the HMR-ready pipeline exists; HTML is stored only for these allowlisted paths on the watch page cache. |
+| `devPrewarmReadiness` |    no    | `'background'` (default) or `'beforeReady'` to block the framework ready signal until prewarm finishes (listen port may already be open).                                                     |
 
 Collection keys must be kebab-case (`docs`, `api-reference`). Each key becomes `ecopages:content/<key>`.
 

--- a/packages/processors/content-processor/README.md
+++ b/packages/processors/content-processor/README.md
@@ -23,7 +23,7 @@ The processor gives you a typed manifest and MDX components at build time. Wire 
 
 ## Features
 
-- **Build-time scanning** — content metadata and MDX imports are resolved before page bundles ship.
+- **Build-time scanning** — content metadata is resolved before page bundles ship; MDX entry modules load on demand per slug on the server.
 - **Standard Schema validation** — frontmatter schemas stay in your app; the library validates through the Standard Schema interface.
 - **Typed virtual modules** — `ecopages:content/<collection>` with generated `Entry` types.
 - **Multiple collections** — docs, blog, changelog, or any keyed collection you configure.
@@ -82,6 +82,9 @@ export default await new ConfigBuilder()
 | `entryType`  |    no    | Frontmatter type for generated virtual-module types. Format: `./path/to/schema#TypeName`. The processor wraps it as `ContentEntry<YourFrontmatter>`. |
 | `orderBy`    |    no    | Comparator function for manifest sort. Default: {@link compareEntriesBySlug}. Use {@link compareEntriesByField} for frontmatter fields.              |
 | `extensions` |    no    | File extensions to scan. Default: `['.mdx']`.                                                                                                        |
+| `routePrefix` |   no    | Public URL prefix for entries, e.g. `/docs`. Used with `devPrewarm`.                                                                                 |
+| `devPrewarm` |    no    | Dev prewarm: `'first'`, `'all'`, `{ slugs }`, or `{ limit }`. Core SSR-prewarms after the HMR-ready pipeline exists; HTML is stored only for these allowlisted paths on the watch page cache. |
+| `devPrewarmReadiness` | no | `'background'` (default) or `'beforeReady'` to block the framework ready signal until prewarm finishes (listen port may already be open). |
 
 Collection keys must be kebab-case (`docs`, `api-reference`). Each key becomes `ecopages:content/<key>`.
 
@@ -160,8 +163,8 @@ import type { Entry } from 'ecopages:content/docs';
 | `entries`                      | entries | Readonly manifest of all entries, sorted by `orderBy`.                                          |
 | `getEntry(slug)`               | entries | Lookup by joined slug, e.g. `'getting-started/intro'`.                                          |
 | `getEntryBySegments(segments)` | entries | Lookup by segment array, e.g. `['getting-started', 'intro']`.                                   |
-| `getComponent(slug)`           | server  | MDX component for the entry.                                                                    |
-| `getEntryDependencies(slug)`   | server  | Browser dependency bag for the entry, with MDX source ownership for catch-all routes.           |
+| `getComponent(slug)`           | server  | `Promise` of the MDX component for the entry (lazy-loaded per slug).                            |
+| `getEntryDependencies(slug)`   | server  | `Promise` of the browser dependency bag for the entry, with MDX source ownership.               |
 | `Entry`                        | entries | **Type only.** `ContentEntry<YourFrontmatter>` — frontmatter fields plus `slug` and `segments`. |
 
 **Important:** `Entry` exists only in generated `.d.ts` files, not in the runtime cache module. Keep type imports on a separate `import type` line in page files that get bundled. Mixed imports like `import { entries, type Entry }` can cause the bundler to treat `Entry` as a runtime export and fail with `MISSING_EXPORT`.
@@ -191,13 +194,13 @@ export default eco.page<{ entry: Entry }>({
 			props: { entry: getEntryBySegments(segments) },
 		};
 	},
-	dependencies: ({ props }) => getEntryDependencies(props.entry.slug),
+	dependencies: async ({ props }) => getEntryDependencies(props.entry.slug),
 	metadata: ({ props: { entry } }) => ({
 		title: entry.title,
 		description: entry.description,
 	}),
 	render: async ({ entry }) => {
-		const Content = getComponent(entry.slug);
+		const Content = await getComponent(entry.slug);
 		return <Content />;
 	},
 });
@@ -219,7 +222,7 @@ export const config = {
 <WeatherApp />
 ```
 
-`getComponent()` returns the MDX default component with exported `config` attached. Pair that with `getEntryDependencies()` on the catch-all page so only the active entry contributes to the Page Browser Graph. The helper includes `ownerFile` so relative `scripts`, `stylesheets`, and `modules` declared in MDX resolve against the entry file, not the catch-all route.
+`getComponent()` lazy-loads one MDX module per slug and returns the default component with exported `config` attached. Pair that with `getEntryDependencies()` on the catch-all page so only the active entry contributes to the Page Browser Graph. The helper includes `ownerFile` so relative `scripts`, `stylesheets`, and `modules` declared in MDX resolve against the entry file, not the catch-all route.
 
 ## Navigation (app-side)
 

--- a/packages/processors/content-processor/src/codegen.ts
+++ b/packages/processors/content-processor/src/codegen.ts
@@ -1,10 +1,6 @@
 import { relative, resolve, dirname, join } from 'node:path';
 import type { ContentEntry } from './types.ts';
 
-function slugToIdentifier(collectionName: string, slug: string): string {
-	return `${collectionName}_${slug.replace(/[^a-zA-Z0-9]/g, '_')}`;
-}
-
 function serializeEntry(entry: ContentEntry): string {
 	return JSON.stringify(entry);
 }
@@ -83,21 +79,19 @@ function attachMdxExports(module: ContentMdxModule, sourceFile: string): EcoComp
 }
 
 export function renderCollectionComponentsModule(
-	collectionName: string,
+	_collectionName: string,
 	outputDir: string,
 	entrySources: Array<{ entry: ContentEntry; filePath: string }>,
 ): string {
-	const importLines: string[] = [];
-	const componentMapLines: string[] = [];
+	const loaderLines: string[] = [];
 	const entrySourceFilesBySlugLines: string[] = [];
 
 	for (const { entry, filePath } of entrySources) {
-		const identifier = slugToIdentifier(collectionName, entry.slug);
 		const importPath = relative(outputDir, filePath).split('\\').join('/');
+		const escapedImportPath = importPath.replace(/'/g, "\\'");
 		const sourceFile = filePath.split('\\').join('/');
 		const escapedSourceFile = sourceFile.replace(/'/g, "\\'");
-		importLines.push(`import * as ${identifier}_module from '${importPath}';`);
-		componentMapLines.push(`\t'${entry.slug}': attachMdxExports(${identifier}_module, '${escapedSourceFile}'),`);
+		loaderLines.push(`\t'${entry.slug}': () => import('${escapedImportPath}'),`);
 		entrySourceFilesBySlugLines.push(`\t'${entry.slug}': '${escapedSourceFile}',`);
 	}
 
@@ -107,24 +101,48 @@ import type { EcoComponent, PageDependenciesResult } from '@ecopages/core';
 
 ${renderAttachMdxExportsHelper()}
 
-${importLines.join('\n')}
-
-const componentsBySlug: Record<string, EcoComponent<Record<string, unknown>>> = {
-${componentMapLines.join('\n')}
+const loadersBySlug: Record<string, () => Promise<ContentMdxModule>> = {
+${loaderLines.join('\n')}
 };
 
 const entrySourceFilesBySlug: Record<string, string> = {
 ${entrySourceFilesBySlugLines.join('\n')}
 };
 
-export function getComponent(slug: string): EcoComponent<Record<string, unknown>> {
-	const component = componentsBySlug[slug];
-	if (!component) throw new Error(\`Unknown content entry: \${slug}\`);
-	return component;
+const componentCache = new Map<string, EcoComponent<Record<string, unknown>>>();
+const componentLoadPromises = new Map<string, Promise<EcoComponent<Record<string, unknown>>>>();
+
+export async function getComponent(slug: string): Promise<EcoComponent<Record<string, unknown>>> {
+	const cached = componentCache.get(slug);
+	if (cached) {
+		return cached;
+	}
+
+	const pending = componentLoadPromises.get(slug);
+	if (pending) {
+		return pending;
+	}
+
+	const load = loadersBySlug[slug];
+	if (!load) {
+		throw new Error(\`Unknown content entry: \${slug}\`);
+	}
+
+	const loadPromise = (async () => {
+		const module = await load();
+		const component = attachMdxExports(module, entrySourceFilesBySlug[slug]!);
+		componentCache.set(slug, component);
+		return component;
+	})().finally(() => {
+		componentLoadPromises.delete(slug);
+	});
+
+	componentLoadPromises.set(slug, loadPromise);
+	return loadPromise;
 }
 
-export function getEntryDependencies(slug: string): PageDependenciesResult | undefined {
-	const component = getComponent(slug);
+export async function getEntryDependencies(slug: string): Promise<PageDependenciesResult | undefined> {
+	const component = await getComponent(slug);
 	const dependencies = component.config?.dependencies;
 	if (!dependencies) {
 		return undefined;
@@ -186,8 +204,8 @@ function renderCollectionComponentsTypesModule(collectionName: string): string {
 	return `declare module "ecopages:content/${collectionName}/server" {
 	import type { EcoComponent, PageDependenciesResult } from '@ecopages/core';
 
-	export function getComponent(slug: string): EcoComponent<Record<string, unknown>>;
-	export function getEntryDependencies(slug: string): PageDependenciesResult | undefined;
+	export function getComponent(slug: string): Promise<EcoComponent<Record<string, unknown>>>;
+	export function getEntryDependencies(slug: string): Promise<PageDependenciesResult | undefined>;
 }`;
 }
 

--- a/packages/processors/content-processor/src/collection-types.ts
+++ b/packages/processors/content-processor/src/collection-types.ts
@@ -37,11 +37,7 @@ export type ContentCollectionDefinition<TFrontmatter extends Record<string, unkn
 };
 
 /** Dev prewarm selection for a content collection manifest. */
-export type ContentDevPrewarmConfig =
-	| 'first'
-	| 'all'
-	| { slugs: readonly string[] }
-	| { limit: number };
+export type ContentDevPrewarmConfig = 'first' | 'all' | { slugs: readonly string[] } | { limit: number };
 
 /**
  * Collection registry keyed by collection name.

--- a/packages/processors/content-processor/src/collection-types.ts
+++ b/packages/processors/content-processor/src/collection-types.ts
@@ -19,7 +19,29 @@ export type ContentCollectionDefinition<TFrontmatter extends Record<string, unkn
 	 * Format: `./path/to/schema-file#ExportedTypeName`
 	 */
 	entryType?: string;
+	/**
+	 * Public URL prefix for entries in this collection, e.g. `/docs`.
+	 * Used with {@link ContentDevPrewarmConfig} to build dev prewarm paths.
+	 */
+	routePrefix?: string;
+	/**
+	 * Which entries to SSR-prewarm in dev when {@link routePrefix} is set.
+	 * Rendering is performed by core; this only declares pathnames from the manifest.
+	 */
+	devPrewarm?: ContentDevPrewarmConfig;
+	/**
+	 * When `beforeReady`, core awaits SSR prewarm for declared paths before the dev server reports ready.
+	 * @default 'background'
+	 */
+	devPrewarmReadiness?: 'background' | 'beforeReady';
 };
+
+/** Dev prewarm selection for a content collection manifest. */
+export type ContentDevPrewarmConfig =
+	| 'first'
+	| 'all'
+	| { slugs: readonly string[] }
+	| { limit: number };
 
 /**
  * Collection registry keyed by collection name.

--- a/packages/processors/content-processor/src/content-scanner.ts
+++ b/packages/processors/content-processor/src/content-scanner.ts
@@ -111,9 +111,7 @@ export class ContentScanner<T extends Record<string, unknown> = Record<string, u
 		return fileSystem.readFile(filePath);
 	}
 
-	async getEntrySources(): Promise<
-		Array<{ entry: ContentEntry<T>; filePath: string }>
-	> {
+	async getEntrySources(): Promise<Array<{ entry: ContentEntry<T>; filePath: string }>> {
 		const cache = await this.getCache();
 		return cache.manifest.map((entry) => ({
 			entry,

--- a/packages/processors/content-processor/src/content-scanner.ts
+++ b/packages/processors/content-processor/src/content-scanner.ts
@@ -71,7 +71,10 @@ export class ContentScanner<T extends Record<string, unknown> = Record<string, u
 					slug,
 					segments: slug.split('/'),
 				};
-				return { filePath, entry };
+				return {
+					filePath,
+					entry,
+				};
 			}),
 		);
 
@@ -108,7 +111,9 @@ export class ContentScanner<T extends Record<string, unknown> = Record<string, u
 		return fileSystem.readFile(filePath);
 	}
 
-	async getEntrySources(): Promise<Array<{ entry: ContentEntry<T>; filePath: string }>> {
+	async getEntrySources(): Promise<
+		Array<{ entry: ContentEntry<T>; filePath: string }>
+	> {
 		const cache = await this.getCache();
 		return cache.manifest.map((entry) => ({
 			entry,

--- a/packages/processors/content-processor/src/content-server-boundary-plugin.ts
+++ b/packages/processors/content-processor/src/content-server-boundary-plugin.ts
@@ -5,7 +5,7 @@ import { CONTENT_SERVER_VIRTUAL_MODULE_PATTERN } from './constants.ts';
  * Keeps `ecopages:content/<collection>/server` out of browser bundles.
  *
  * @remarks
- * Server modules static-import every MDX entry for `getComponent`. Browser builds
+ * Server modules lazy-load MDX entries via dynamic `import()` for `getComponent`. Browser builds
  * must never follow that graph — highlighted MDX output belongs in SSR HTML only.
  */
 export function createContentServerBoundaryPlugin(): EcoBuildPlugin {

--- a/packages/processors/content-processor/src/dev-prewarm-paths.ts
+++ b/packages/processors/content-processor/src/dev-prewarm-paths.ts
@@ -1,0 +1,46 @@
+import type { ContentEntry } from './types.ts';
+import type { ContentCollectionDefinition, ContentDevPrewarmConfig } from './collection-types.ts';
+
+/**
+ * Resolves entry slugs to prewarm for one collection from processor config.
+ */
+export function resolveContentDevPrewarmSlugs<T extends Record<string, unknown>>(
+	config: ContentDevPrewarmConfig,
+	entries: readonly ContentEntry<T>[],
+): string[] {
+	if (config === 'first') {
+		const first = entries[0];
+		return first ? [first.slug] : [];
+	}
+
+	if (config === 'all') {
+		return entries.map((entry) => entry.slug);
+	}
+
+	if ('slugs' in config) {
+		return [...config.slugs];
+	}
+
+	if ('limit' in config) {
+		return entries.slice(0, Math.max(0, config.limit)).map((entry) => entry.slug);
+	}
+
+	return [];
+}
+
+/**
+ * Builds absolute URL pathnames for dev prewarm from collection config and manifest order.
+ */
+export function buildContentDevPrewarmPathnames<T extends Record<string, unknown>>(
+	definition: Pick<ContentCollectionDefinition<T>, 'routePrefix' | 'devPrewarm'>,
+	entries: readonly ContentEntry<T>[],
+): string[] {
+	if (!definition.devPrewarm || !definition.routePrefix) {
+		return [];
+	}
+
+	const prefix = definition.routePrefix.replace(/\/$/, '');
+	const slugs = resolveContentDevPrewarmSlugs(definition.devPrewarm, entries);
+
+	return slugs.map((slug) => `${prefix}/${slug}`.replace(/\/{2,}/g, '/'));
+}

--- a/packages/processors/content-processor/src/plugin.ts
+++ b/packages/processors/content-processor/src/plugin.ts
@@ -30,6 +30,7 @@ import {
 import { createContentServerBoundaryPlugin } from './content-server-boundary-plugin.ts';
 import { COLLECTION_NAME_PATTERN, CONTENT_PROCESSOR_NAME } from './constants.ts';
 import type { ContentProcessorConfig } from './collection-types.ts';
+import { buildContentDevPrewarmPathnames } from './dev-prewarm-paths.ts';
 
 const logger = new Logger('[@ecopages/content-processor]', {
 	debug: process.env.ECOPAGES_LOGGER_DEBUG === 'true',
@@ -304,6 +305,41 @@ export class ContentProcessorPlugin extends Processor<ContentProcessorConfig> {
 
 	override async process(_input: unknown): Promise<void> {
 		await this.regenerateAllCollections();
+	}
+
+	/**
+	 * Declares watch-mode SSR prewarm pathnames and readiness derived from collection manifests.
+	 *
+	 * @remarks
+	 * Core executes rendering in parallel; this hook only maps `routePrefix` + entry slugs to URLs.
+	 */
+	override async collectDevPrewarmPlan(): Promise<{
+		pathnames: readonly string[];
+		readiness: 'background' | 'beforeReady';
+	}> {
+		await this.ensureCollectionsGenerated();
+
+		const pathnames: string[] = [];
+		let readiness: 'background' | 'beforeReady' = 'background';
+
+		for (const [collectionName, definition] of Object.entries(this.getCollectionsConfig())) {
+			if (definition.devPrewarmReadiness === 'beforeReady') {
+				readiness = 'beforeReady';
+			}
+
+			if (!definition.devPrewarm || !definition.routePrefix) {
+				continue;
+			}
+
+			const scanner = this.getOrCreateScanner(collectionName);
+			const entries = await scanner.getManifest();
+			pathnames.push(...buildContentDevPrewarmPathnames(definition, entries));
+		}
+
+		return {
+			pathnames: [...new Set(pathnames)],
+			readiness,
+		};
 	}
 }
 

--- a/packages/processors/content-processor/src/test/codegen.test.ts
+++ b/packages/processors/content-processor/src/test/codegen.test.ts
@@ -35,10 +35,8 @@ describe('codegen', () => {
 			},
 		]);
 
-		expect(output).toContain(
-			"'intro': () => import('../../app/src/content/docs/intro.mdx'),",
-		);
-		expect(output).not.toContain("import * as docs_intro_module from");
+		expect(output).toContain("'intro': () => import('../../app/src/content/docs/intro.mdx'),");
+		expect(output).not.toContain('import * as docs_intro_module from');
 		expect(output).toContain('function attachMdxExports(module: ContentMdxModule, sourceFile: string)');
 		expect(output).toContain('const componentCache = new Map');
 		expect(output).toContain('const componentLoadPromises = new Map');

--- a/packages/processors/content-processor/src/test/codegen.test.ts
+++ b/packages/processors/content-processor/src/test/codegen.test.ts
@@ -22,7 +22,7 @@ describe('codegen', () => {
 		expect(output).not.toContain('getComponent');
 	});
 
-	test('renderCollectionComponentsModule emits namespace MDX imports, attach helper, and getComponent', () => {
+	test('renderCollectionComponentsModule emits lazy MDX loaders, attach helper, and async getComponent', () => {
 		const output = renderCollectionComponentsModule('docs', '/tmp/cache', [
 			{
 				entry: {
@@ -35,13 +35,17 @@ describe('codegen', () => {
 			},
 		]);
 
-		expect(output).toContain("import * as docs_intro_module from '../../app/src/content/docs/intro.mdx';");
+		expect(output).toContain(
+			"'intro': () => import('../../app/src/content/docs/intro.mdx'),",
+		);
+		expect(output).not.toContain("import * as docs_intro_module from");
 		expect(output).toContain('function attachMdxExports(module: ContentMdxModule, sourceFile: string)');
-		expect(output).toContain("'intro': attachMdxExports(docs_intro_module, '/app/src/content/docs/intro.mdx'),");
+		expect(output).toContain('const componentCache = new Map');
+		expect(output).toContain('const componentLoadPromises = new Map');
 		expect(output).toContain("import type { EcoComponent, PageDependenciesResult } from '@ecopages/core';");
 		expect(output).toContain("'intro': '/app/src/content/docs/intro.mdx',");
-		expect(output).toContain('export function getComponent(slug: string)');
-		expect(output).toContain('export function getEntryDependencies(slug: string)');
+		expect(output).toContain('export async function getComponent(slug: string)');
+		expect(output).toContain('export async function getEntryDependencies(slug: string)');
 		expect(output).toContain('ownerFile: entrySourceFilesBySlug[slug]');
 		expect(output).not.toContain('export const entries');
 	});
@@ -69,7 +73,7 @@ describe('codegen', () => {
 		expect(output).toContain('declare module "ecopages:content/docs"');
 		expect(output).toContain('declare module "ecopages:content/docs/server"');
 		expect(output).toContain(
-			'export function getEntryDependencies(slug: string): PageDependenciesResult | undefined',
+			'export function getEntryDependencies(slug: string): Promise<PageDependenciesResult | undefined>',
 		);
 		expect(output).toContain('declare module "ecopages:content/blog"');
 		expect(output).toContain('declare module "ecopages:content/blog/server"');

--- a/packages/processors/content-processor/src/test/dev-prewarm-paths.test.ts
+++ b/packages/processors/content-processor/src/test/dev-prewarm-paths.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { buildContentDevPrewarmPathnames, resolveContentDevPrewarmSlugs } from '../dev-prewarm-paths.ts';
+
+test('resolveContentDevPrewarmSlugs supports first, all, slugs, and limit', () => {
+	const entries = [
+		{ slug: 'a/one', segments: ['a', 'one'] },
+		{ slug: 'b/two', segments: ['b', 'two'] },
+	];
+
+	assert.deepEqual(resolveContentDevPrewarmSlugs('first', entries), ['a/one']);
+	assert.deepEqual(resolveContentDevPrewarmSlugs('all', entries), ['a/one', 'b/two']);
+	assert.deepEqual(resolveContentDevPrewarmSlugs({ slugs: ['b/two'] }, entries), ['b/two']);
+	assert.deepEqual(resolveContentDevPrewarmSlugs({ limit: 1 }, entries), ['a/one']);
+});
+
+test('buildContentDevPrewarmPathnames joins routePrefix and slugs', () => {
+	const paths = buildContentDevPrewarmPathnames(
+		{ routePrefix: '/docs', devPrewarm: { slugs: ['getting-started/introduction'] } },
+		[{ slug: 'getting-started/introduction', segments: ['getting-started', 'introduction'] }],
+	);
+
+	assert.deepEqual(paths, ['/docs/getting-started/introduction']);
+});

--- a/packages/processors/content-processor/src/test/plugin.test.ts
+++ b/packages/processors/content-processor/src/test/plugin.test.ts
@@ -76,8 +76,8 @@ order: 1
 		expect(fileSystem.readFileSync(cacheFile)).not.toContain('getComponent');
 		const serverCacheFile = path.join(workDir, GENERATED_BASE_PATHS.cache, plugin.name, 'docs.server.ts');
 		expect(fileSystem.exists(serverCacheFile)).toBe(true);
-		expect(fileSystem.readFileSync(serverCacheFile)).toContain('export function getComponent');
-		expect(fileSystem.readFileSync(serverCacheFile)).toContain('export function getEntryDependencies');
+		expect(fileSystem.readFileSync(serverCacheFile)).toContain('export async function getComponent');
+		expect(fileSystem.readFileSync(serverCacheFile)).toContain('export async function getEntryDependencies');
 		expect(fileSystem.exists(typesFile)).toBe(true);
 		expect(fileSystem.readFileSync(typesFile)).toContain('declare module "ecopages:content/docs"');
 		expect(fileSystem.readFileSync(typesFile)).toContain('declare module "ecopages:content/docs/server"');
@@ -280,5 +280,44 @@ order: 2
 		fileSystem.remove(introPath);
 		await watchConfig.onDelete({ path: introPath } as never);
 		expect(fileSystem.readFileSync(cacheFile)).not.toContain('"slug":"intro"');
+	});
+
+	test('collectDevPrewarmPlan honors collection pathnames and readiness', async () => {
+		const rootDir = createTempRoot('ecopages-content-prewarm-');
+		tempRoots.push(rootDir);
+
+		const contentDir = path.join(rootDir, 'src', 'content', 'docs');
+		fileSystem.ensureDir(contentDir);
+		fileSystem.write(
+			path.join(contentDir, 'intro.mdx'),
+			`---
+title: Intro
+description: Welcome
+order: 1
+---
+# Intro
+`,
+		);
+
+		const plugin = contentProcessorPlugin({
+			options: {
+				collections: {
+					docs: {
+						contentDir: 'content/docs',
+						schema: testContentSchema,
+						routePrefix: '/docs',
+						devPrewarm: 'first',
+						devPrewarmReadiness: 'beforeReady',
+					},
+				},
+			},
+		});
+
+		await new ConfigBuilder().setRootDir(rootDir).setBaseUrl('http://localhost:3000').setProcessors([plugin]).build();
+
+		expect(await plugin.collectDevPrewarmPlan()).toEqual({
+			pathnames: ['/docs/intro'],
+			readiness: 'beforeReady',
+		});
 	});
 });

--- a/packages/processors/content-processor/src/test/plugin.test.ts
+++ b/packages/processors/content-processor/src/test/plugin.test.ts
@@ -313,7 +313,11 @@ order: 1
 			},
 		});
 
-		await new ConfigBuilder().setRootDir(rootDir).setBaseUrl('http://localhost:3000').setProcessors([plugin]).build();
+		await new ConfigBuilder()
+			.setRootDir(rootDir)
+			.setBaseUrl('http://localhost:3000')
+			.setProcessors([plugin])
+			.build();
 
 		expect(await plugin.collectDevPrewarmPlan()).toEqual({
 			pathnames: ['/docs/intro'],

--- a/packages/processors/content-processor/src/types.ts
+++ b/packages/processors/content-processor/src/types.ts
@@ -26,8 +26,8 @@ export type ContentCollectionEntriesModule<TEntry extends Record<string, unknown
 
 /** Runtime shape of a generated `ecopages:content/<collection>/server` module. */
 export type ContentCollectionComponentsModule = {
-	getComponent(slug: string): EcoComponent<Record<string, unknown>>;
-	getEntryDependencies(slug: string): PageDependenciesResult | undefined;
+	getComponent(slug: string): Promise<EcoComponent<Record<string, unknown>>>;
+	getEntryDependencies(slug: string): Promise<PageDependenciesResult | undefined>;
 };
 
 /** @deprecated Import entries and server modules separately. */


### PR DESCRIPTION
## Summary
- Lazy-load content-processor MDX entries per slug via dynamic `import()`, with in-flight `getComponent` coalescing
- Add `routePrefix` / `devPrewarm` / `collectDevPrewarmPlan()` so core SSR-prewarms declared paths after the HMR-ready pipeline
- Use one watch `PageCacheService` backed by an allowlisted memory store (no dual caches / all-static env); coalesce concurrent cache misses
- Harden docs e2e freshness so hollow dists rebuild and content-processor changes invalidate cache

## Test plan
- [x] Focused unit tests (cache, prewarm, content-processor)
- [x] Docs e2e (`--project=docs-e2e`) — 21 passed
- [x] `pnpm test:all` running against this branch