### PR TITLE
perf(core,react): normalize parser and client graph caching

### DIFF
--- a/packages/core/src/build/browser/browser-runtime-plugin.ts
+++ b/packages/core/src/build/browser/browser-runtime-plugin.ts
@@ -23,7 +23,7 @@
 import path from 'node:path';
 import { existsSync, readFileSync } from 'node:fs';
 
-import { cachedParseSync } from '../../cache/module-parse-cache.ts';
+import { parseModuleSource } from '../../cache/module-parse-cache.ts';
 import type { EcoBuildLoader, EcoBuildPlugin } from '../contracts/build-types.ts';
 import { getBrowserRuntimeSpecifierMap, type BrowserRuntimeManifest } from './browser-runtime-manifest.ts';
 import { buildSpecifierFilter } from './browser-runtime-plugin-helpers.ts';
@@ -139,10 +139,7 @@ export function rewriteBrowserRuntimeImports(
 	const edits: Edit[] = [];
 
 	try {
-		const result = cachedParseSync(filePath, code, {
-			sourceType: 'module',
-			lang: path.extname(filePath).endsWith('x') ? 'tsx' : 'ts',
-		});
+		const result = parseModuleSource(filePath, code);
 
 		const walk = (node: unknown) => {
 			if (!isRecord(node)) {

--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -3,4 +3,13 @@
  *
  * @module @ecopages/core/cache
  */
-export { ModuleParseCache, moduleParseCache, cachedParseSync, type ModuleParseOptions } from './module-parse-cache.ts';
+export {
+	ModuleParseCache,
+	moduleParseCache,
+	cachedParseSync,
+	parseModuleSource,
+	parserLanguageForFile,
+	type ModuleParseOptions,
+	type ParserLanguage,
+} from './module-parse-cache.ts';
+export { flushModuleTransformProfile, recordModuleTransformProfile } from './module-transform-profiler.ts';

--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -12,4 +12,4 @@ export {
 	type ModuleParseOptions,
 	type ParserLanguage,
 } from './module-parse-cache.ts';
-export { flushModuleTransformProfile, recordModuleTransformProfile } from './module-transform-profiler.ts';
+export { recordModuleTransformProfile } from './module-transform-profiler.ts';

--- a/packages/core/src/cache/module-parse-cache.test.ts
+++ b/packages/core/src/cache/module-parse-cache.test.ts
@@ -36,6 +36,14 @@ describe('ModuleParseCache', () => {
 		expect(b).not.toBe(a);
 	});
 
+	it('normalizes omitted source options to the same cache entry', () => {
+		const cache = new ModuleParseCache();
+		const source = 'export const Component = <div />;';
+		const implicit = cache.getOrParse('/component.jsx', source);
+		const explicit = cache.getOrParse('/component.jsx', source, { lang: 'jsx', sourceType: 'module' });
+		expect(explicit).toBe(implicit);
+	});
+
 	it('evicts oldest entry when capacity exceeded', () => {
 		const cache = new ModuleParseCache(2);
 		cache.getOrParse('/a.ts', 'a');

--- a/packages/core/src/cache/module-parse-cache.ts
+++ b/packages/core/src/cache/module-parse-cache.ts
@@ -14,6 +14,7 @@
  * still-valid parse.
  */
 
+import { extname } from 'node:path';
 import { parseSync, type ParseResult, type ParserOptions } from 'oxc-parser';
 import { rapidhash } from '../utils/hash.ts';
 
@@ -27,6 +28,22 @@ export type ModuleParseOptions = ParserOptions & {
 	 */
 	lang?: ParserOptions['lang'];
 };
+
+export type ParserLanguage = 'js' | 'jsx' | 'ts' | 'tsx';
+
+/** Resolves the Oxc dialect for a source module from its file extension. */
+export function parserLanguageForFile(filePath: string): ParserLanguage {
+	const extension = extname(filePath).toLowerCase();
+	if (extension === '.tsx') return 'tsx';
+	if (extension === '.ts' || extension === '.mts' || extension === '.cts') return 'ts';
+	if (extension === '.jsx') return 'jsx';
+	return 'js';
+}
+
+/** Parses an ECMAScript module with the shared, normalized cache contract. */
+export function parseModuleSource(filePath: string, source: string, options: ModuleParseOptions = {}): ParseResult {
+	return moduleParseCache.getOrParse(filePath, source, normalizeModuleParseOptions(filePath, options));
+}
 
 type CacheKey = string;
 
@@ -60,8 +77,9 @@ export class ModuleParseCache {
 	 * @returns the {@link ParseResult} from `oxc-parser.parseSync`.
 	 */
 	getOrParse(filePath: string, source: string, options: ModuleParseOptions = {}): ParseResult {
+		const normalizedOptions = normalizeModuleParseOptions(filePath, options);
 		const hash = rapidhash(source);
-		const key = makeKey(filePath, hash, options);
+		const key = makeKey(filePath, hash, normalizedOptions);
 
 		const existing = this.entries.get(key);
 		if (existing && existing.hash === hash) {
@@ -73,7 +91,7 @@ export class ModuleParseCache {
 		}
 
 		this.misses += 1;
-		const result = parseSync(filePath, source, options);
+		const result = parseSync(filePath, source, normalizedOptions);
 		this.entries.set(key, { hash, result });
 
 		if (this.entries.size > this.maxEntries) {
@@ -125,7 +143,15 @@ export const moduleParseCache = new ModuleParseCache();
  * on user/source files during a build.
  */
 export function cachedParseSync(filePath: string, source: string, options: ModuleParseOptions = {}): ParseResult {
-	return moduleParseCache.getOrParse(filePath, source, options);
+	return parseModuleSource(filePath, source, options);
+}
+
+function normalizeModuleParseOptions(filePath: string, options: ModuleParseOptions): ModuleParseOptions {
+	return {
+		...options,
+		lang: options.lang ?? parserLanguageForFile(filePath),
+		sourceType: options.sourceType ?? 'module',
+	};
 }
 
 function makeKey(filePath: string, sourceHash: number | bigint, options: ModuleParseOptions): CacheKey {

--- a/packages/core/src/cache/module-transform-profiler.ts
+++ b/packages/core/src/cache/module-transform-profiler.ts
@@ -5,28 +5,12 @@ type ProfileRecord = {
 	cacheHit?: boolean;
 };
 
-const records: ProfileRecord[] = [];
-
 export function recordModuleTransformProfile(record: ProfileRecord): void {
 	if (process.env.ECO_AST_PROFILE !== '1') return;
-	records.push(record);
-}
-
-export function flushModuleTransformProfile(reason: string): void {
-	if (process.env.ECO_AST_PROFILE !== '1' || records.length === 0) return;
-	const summary = new Map<string, { count: number; ms: number; hits: number }>();
-	for (const record of records) {
-		const key = `${record.category}:${record.phase}`;
-		const current = summary.get(key) ?? { count: 0, ms: 0, hits: 0 };
-		current.count += 1;
-		current.ms += record.ms;
-		if (record.cacheHit) current.hits += 1;
-		summary.set(key, current);
-	}
 	console.info(
-		`[ecopages:ast-profile] ${reason} ${JSON.stringify(
-			Array.from(summary, ([phase, value]) => ({ phase, ...value })),
-		)}`,
+		`[ecopages:ast-profile] ${JSON.stringify({
+			...record,
+			ms: Number(record.ms.toFixed(3)),
+		})}`,
 	);
-	records.length = 0;
 }

--- a/packages/core/src/cache/module-transform-profiler.ts
+++ b/packages/core/src/cache/module-transform-profiler.ts
@@ -1,0 +1,32 @@
+type ProfileRecord = {
+	category: string;
+	phase: string;
+	ms: number;
+	cacheHit?: boolean;
+};
+
+const records: ProfileRecord[] = [];
+
+export function recordModuleTransformProfile(record: ProfileRecord): void {
+	if (process.env.ECO_AST_PROFILE !== '1') return;
+	records.push(record);
+}
+
+export function flushModuleTransformProfile(reason: string): void {
+	if (process.env.ECO_AST_PROFILE !== '1' || records.length === 0) return;
+	const summary = new Map<string, { count: number; ms: number; hits: number }>();
+	for (const record of records) {
+		const key = `${record.category}:${record.phase}`;
+		const current = summary.get(key) ?? { count: 0, ms: 0, hits: 0 };
+		current.count += 1;
+		current.ms += record.ms;
+		if (record.cacheHit) current.hits += 1;
+		summary.set(key, current);
+	}
+	console.info(
+		`[ecopages:ast-profile] ${reason} ${JSON.stringify(
+			Array.from(summary, ([phase, value]) => ({ phase, ...value })),
+		)}`,
+	);
+	records.length = 0;
+}

--- a/packages/core/src/route-renderer/page-loading/ecopages-virtual-imports.ts
+++ b/packages/core/src/route-renderer/page-loading/ecopages-virtual-imports.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { parseSync } from 'oxc-parser';
+import { parseModuleSource } from '../../cache/module-parse-cache.ts';
 
 export type EcopagesVirtualImport = {
 	from: string;
@@ -34,7 +34,7 @@ export function extractEcopagesVirtualImports(file: string): EcopagesVirtualImpo
 
 	let result;
 	try {
-		result = parseSync(file, source, { sourceType: 'module' });
+		result = parseModuleSource(file, source);
 	} catch {
 		return [];
 	}

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -109,6 +109,8 @@ Think about each React page as two related graphs:
 
 The React integration builds the client graph conservatively. If a server-only module becomes reachable from the hydrated render path, the build should fail rather than silently shipping unsafe code.
 
+The boundary cache is owned by the React plugin and shared by normal Page Browser Graph bundles and HMR. Cache entries include the module source, allowlist, and inbound requested exports; each build still starts with a fresh requested-export registry. Set `ECO_AST_PROFILE=1` to emit per-phase client-graph timing summaries while investigating a docs build or development rebuild.
+
 ### `explicitGraph` option
 
 `reactPlugin({ explicitGraph: true })` forces the page browser graph (hydration assets) to emit for every React page, even when the page does not declare `dependencies.modules` and no router is configured.

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -109,7 +109,7 @@ Think about each React page as two related graphs:
 
 The React integration builds the client graph conservatively. If a server-only module becomes reachable from the hydrated render path, the build should fail rather than silently shipping unsafe code.
 
-The boundary cache is owned by the React plugin and shared by normal Page Browser Graph bundles and HMR. Cache entries include the module source, allowlist, and inbound requested exports; each build still starts with a fresh requested-export registry. Set `ECO_AST_PROFILE=1` to emit one structured timing record per client-graph cache lookup and analysis while investigating a docs build or development rebuild.
+The boundary cache is owned by the React plugin and shared by normal Page Browser Graph bundles and HMR. Cache entries include the module source, allow-list package names with their permitted exports, and inbound requested exports; each build still starts with a fresh requested-export registry. Modules that inline external file contents are never cached. Set `ECO_AST_PROFILE=1` to emit one structured timing record per client-graph cache lookup and analysis while investigating a docs build or development rebuild.
 
 ### `explicitGraph` option
 

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -109,7 +109,7 @@ Think about each React page as two related graphs:
 
 The React integration builds the client graph conservatively. If a server-only module becomes reachable from the hydrated render path, the build should fail rather than silently shipping unsafe code.
 
-The boundary cache is owned by the React plugin and shared by normal Page Browser Graph bundles and HMR. Cache entries include the module source, allowlist, and inbound requested exports; each build still starts with a fresh requested-export registry. Set `ECO_AST_PROFILE=1` to emit per-phase client-graph timing summaries while investigating a docs build or development rebuild.
+The boundary cache is owned by the React plugin and shared by normal Page Browser Graph bundles and HMR. Cache entries include the module source, allowlist, and inbound requested exports; each build still starts with a fresh requested-export registry. Set `ECO_AST_PROFILE=1` to emit one structured timing record per client-graph cache lookup and analysis while investigating a docs build or development rebuild.
 
 ### `explicitGraph` option
 

--- a/packages/integrations/react/src/bundling/bundle.ts
+++ b/packages/integrations/react/src/bundling/bundle.ts
@@ -19,6 +19,7 @@ import { RuntimeBundleService, type ReactRuntimeImports } from './runtime-bundle
 import type { ResolvedReactPluginRuntimeModule } from './runtime-modules.ts';
 import { createReactMdxLoaderPlugin } from '../mdx/mdx-loader-plugin.ts';
 import { isReactProductionRuntime } from './runtime-mode.ts';
+import type { ClientGraphBoundaryCache } from '../client-graph/boundary-cache.ts';
 
 /**
  * Configuration for the BundleService.
@@ -30,6 +31,7 @@ export interface BundleServiceConfig {
 	routerAdapter?: ReactRouterAdapter;
 	runtimeModules?: ResolvedReactPluginRuntimeModule[];
 	mdxCompilerOptions?: CompileOptions;
+	clientGraphBoundaryCache?: ClientGraphBoundaryCache;
 }
 
 /**
@@ -151,6 +153,7 @@ export class BundleService {
 				this.runtimeBundleService.getConfiguredRuntimeModuleSpecifiers(),
 				this.config.routerAdapter,
 			),
+			cache: this.config.clientGraphBoundaryCache,
 		});
 
 		const [foreignJsxOverridePlugin] = getHostScopedJsxOwnershipPlugins(

--- a/packages/integrations/react/src/client-graph/ast-transform.ts
+++ b/packages/integrations/react/src/client-graph/ast-transform.ts
@@ -2,8 +2,7 @@
  * AST transforms for the client graph boundary plugin.
  */
 
-import { extname } from 'node:path';
-import { cachedParseSync } from '@ecopages/core/cache';
+import { parseModuleSource } from '@ecopages/core/cache';
 import type { RequestedExportRules } from './boundary-cache.ts';
 import { analyzeReachability } from './reachability-analyzer.ts';
 import {
@@ -27,19 +26,6 @@ const SERVER_ONLY_ECO_PAGE_OPTION_KEYS = new Set([
 	'staticPaths',
 ]);
 
-/**
- * Returns the proper OxC parser dialect to use for string source parsing.
- *
- * @param filename - File path.
- * @returns Language string.
- */
-function parserLanguageForFile(filename: string): 'js' | 'jsx' | 'ts' | 'tsx' {
-	const extension = extname(filename).toLowerCase();
-	if (extension === '.tsx') return 'tsx';
-	if (extension === '.ts') return 'ts';
-	if (extension === '.jsx') return 'jsx';
-	return 'js';
-}
 
 /**
  * Extracts a static property key name from an object literal property node.
@@ -155,6 +141,7 @@ export function transformModuleImports(
 	globallyAllowed: Map<string, Set<string> | '*'>,
 	requestedExports: Map<string, RequestedExportRules>,
 	projectRoot?: string,
+	stripServerOnlyPageOptions = false,
 ): { transformed: string; modified: boolean } {
 	/**
 	 * Parse the source
@@ -166,10 +153,7 @@ export function transformModuleImports(
 	 */
 	let result;
 	try {
-		result = cachedParseSync(filename, source, {
-			sourceType: 'module',
-			lang: parserLanguageForFile(filename),
-		});
+		result = parseModuleSource(filename, source);
 	} catch {
 		return { transformed: source, modified: false };
 	}
@@ -470,7 +454,7 @@ export function transformModuleImports(
 	walkImports(program);
 
 	if (edits.length === 0) {
-		return stripServerOnlyEcoPageOptions(source, program);
+		return stripServerOnlyPageOptions ? stripServerOnlyEcoPageOptions(source, program) : { transformed: source, modified: false };
 	}
 
 	edits.sort((a, b) => b.start - a.start);
@@ -481,15 +465,14 @@ export function transformModuleImports(
 
 	let reparsedResult;
 	try {
-		reparsedResult = cachedParseSync(filename, transformed, {
-			sourceType: 'module',
-			lang: parserLanguageForFile(filename),
-		});
+		reparsedResult = parseModuleSource(filename, transformed);
 	} catch {
 		return { transformed, modified: true };
 	}
 
-	const strippedPageOptions = stripServerOnlyEcoPageOptions(transformed, reparsedResult.program);
+	const strippedPageOptions = stripServerOnlyPageOptions
+		? stripServerOnlyEcoPageOptions(transformed, reparsedResult.program)
+		: { transformed, modified: false };
 	if (strippedPageOptions.modified) {
 		return strippedPageOptions;
 	}

--- a/packages/integrations/react/src/client-graph/ast-transform.ts
+++ b/packages/integrations/react/src/client-graph/ast-transform.ts
@@ -26,7 +26,6 @@ const SERVER_ONLY_ECO_PAGE_OPTION_KEYS = new Set([
 	'staticPaths',
 ]);
 
-
 /**
  * Extracts a static property key name from an object literal property node.
  *
@@ -454,7 +453,9 @@ export function transformModuleImports(
 	walkImports(program);
 
 	if (edits.length === 0) {
-		return stripServerOnlyPageOptions ? stripServerOnlyEcoPageOptions(source, program) : { transformed: source, modified: false };
+		return stripServerOnlyPageOptions
+			? stripServerOnlyEcoPageOptions(source, program)
+			: { transformed: source, modified: false };
 	}
 
 	edits.sort((a, b) => b.start - a.start);

--- a/packages/integrations/react/src/client-graph/boundary-cache.test.ts
+++ b/packages/integrations/react/src/client-graph/boundary-cache.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { ClientGraphBoundaryCache } from './boundary-cache.ts';
+import { ClientGraphBoundaryCache, hashAllowList } from './boundary-cache.ts';
 
 describe('ClientGraphBoundaryCache', () => {
+	const filePath = '/a.ts';
+	const allowList = new Map<string, Set<string> | '*'>([
+		['react', '*'],
+		['react-dom', '*'],
+	]);
+
 	it('misses when inbound requested exports differ', () => {
 		const cache = new ClientGraphBoundaryCache();
 		cache.set(
 			'/entry.tsx',
 			'export const one = 1;',
-			[],
+			new Map(),
 			{
 				transformed: 'export const one = 1;',
 				modified: false,
@@ -15,10 +21,21 @@ describe('ClientGraphBoundaryCache', () => {
 			},
 			new Set(['one']),
 		);
-		expect(cache.get('/entry.tsx', 'export const one = 1;', [], new Set(['two']))).toBeUndefined();
+		expect(cache.get('/entry.tsx', 'export const one = 1;', new Map(), new Set(['two']))).toBeUndefined();
 	});
-	const filePath = '/a.ts';
-	const allowList = ['react', 'react-dom'];
+
+	it('misses when allow-list export rules differ for the same package', () => {
+		const cache = new ClientGraphBoundaryCache();
+		const readOnlyFs = new Map<string, Set<string> | '*'>([['node:fs', new Set(['readFileSync'])]]);
+		const writeFs = new Map<string, Set<string> | '*'>([['node:fs', new Set(['writeFileSync'])]]);
+		cache.set(filePath, 'src', readOnlyFs, {
+			transformed: 'src',
+			modified: false,
+			rulesAdded: new Map(),
+		});
+		expect(cache.get(filePath, 'src', writeFs)).toBeUndefined();
+		expect(hashAllowList(readOnlyFs)).not.toBe(hashAllowList(writeFs));
+	});
 
 	it('returns undefined for an uncached file', () => {
 		const cache = new ClientGraphBoundaryCache();
@@ -50,14 +67,24 @@ describe('ClientGraphBoundaryCache', () => {
 		expect(cache.get(filePath, 'export const x = 2;', allowList)).toBeUndefined();
 	});
 
-	it('misses when allow list changes', () => {
+	it('misses when allow list package set changes', () => {
 		const cache = new ClientGraphBoundaryCache();
 		cache.set(filePath, 'src', allowList, {
 			transformed: 'src',
 			modified: false,
 			rulesAdded: new Map(),
 		});
-		expect(cache.get(filePath, 'src', ['react', 'react-dom', 'lit'])).toBeUndefined();
+		expect(
+			cache.get(
+				filePath,
+				'src',
+				new Map([
+					['react', '*'],
+					['react-dom', '*'],
+					['lit', '*'],
+				]),
+			),
+		).toBeUndefined();
 	});
 
 	it('evicts oldest entry when capacity exceeded', () => {
@@ -66,7 +93,6 @@ describe('ClientGraphBoundaryCache', () => {
 		cache.set('/b', 'b', allowList, { transformed: 'b', modified: false, rulesAdded: new Map() });
 		cache.set('/c', 'c', allowList, { transformed: 'c', modified: false, rulesAdded: new Map() });
 		expect(cache.size).toBe(2);
-		// /a should have been evicted; reading it is a miss
 		expect(cache.get('/a', 'a', allowList)).toBeUndefined();
 	});
 
@@ -111,9 +137,7 @@ describe('ClientGraphBoundaryCache', () => {
 			modified: false,
 			rulesAdded: new Map([['/b', originalRules]]),
 		});
-		// Mutate the live set
 		originalRules.add('Baz');
-		// Cache should not reflect the mutation
 		const cached = cache.get('/a', 'a', allowList);
 		const cachedRules = cached?.rulesAdded.get('/b');
 		expect(cachedRules).toBeInstanceOf(Set);
@@ -121,11 +145,6 @@ describe('ClientGraphBoundaryCache', () => {
 	});
 
 	it('rulesAdded stores the after-state, not just additions (Set growth)', () => {
-		// Regression for code review: the original snapshot logic captured
-		// only entries whose key was newly added (using Map.size delta),
-		// missing the case where a transform grows an existing key's
-		// Set via union. The cache must store the after-state so replay
-		// against a fresh registry produces the same final value.
 		const cache = new ClientGraphBoundaryCache();
 		const grown = new Set(['Foo', 'Bar']);
 		cache.set('/b', 'b', allowList, {

--- a/packages/integrations/react/src/client-graph/boundary-cache.test.ts
+++ b/packages/integrations/react/src/client-graph/boundary-cache.test.ts
@@ -2,6 +2,21 @@ import { describe, expect, it } from 'vitest';
 import { ClientGraphBoundaryCache } from './boundary-cache.ts';
 
 describe('ClientGraphBoundaryCache', () => {
+	it('misses when inbound requested exports differ', () => {
+		const cache = new ClientGraphBoundaryCache();
+		cache.set(
+			'/entry.tsx',
+			'export const one = 1;',
+			[],
+			{
+				transformed: 'export const one = 1;',
+				modified: false,
+				rulesAdded: new Map(),
+			},
+			new Set(['one']),
+		);
+		expect(cache.get('/entry.tsx', 'export const one = 1;', [], new Set(['two']))).toBeUndefined();
+	});
 	const filePath = '/a.ts';
 	const allowList = ['react', 'react-dom'];
 

--- a/packages/integrations/react/src/client-graph/boundary-cache.ts
+++ b/packages/integrations/react/src/client-graph/boundary-cache.ts
@@ -38,6 +38,8 @@ export type CachedTransform = {
 	sourceHash: number | bigint;
 	/** Hash of the globally-allowed modules map at the time the transform was cached. */
 	allowListHash: number | bigint;
+	/** Hash of the requested export rules already propagated to this module. */
+	inboundRulesHash: number | bigint;
 	/** The transformed source (or original if `modified` is false). */
 	transformed: string;
 	/** Whether the transform changed the source. */
@@ -91,12 +93,23 @@ export class ClientGraphBoundaryCache {
 	 * the entry was stored. The caller is responsible for re-running the
 	 * transform in that case and calling `set` to update the entry.
 	 */
-	get(filePath: string, source: string, globallyAllowedSpecifiers: Iterable<string>): CachedTransform | undefined {
+	get(
+		filePath: string,
+		source: string,
+		globallyAllowedSpecifiers: Iterable<string>,
+		inboundRules?: RequestedExportRules,
+	): CachedTransform | undefined {
 		const sourceHash = rapidhash(source);
 		const allowListHash = hashAllowList(globallyAllowedSpecifiers);
+		const inboundRulesHash = hashRequestedExportRules(inboundRules);
 
 		const existing = this.entries.get(filePath);
-		if (existing && existing.sourceHash === sourceHash && existing.allowListHash === allowListHash) {
+		if (
+			existing &&
+			existing.sourceHash === sourceHash &&
+			existing.allowListHash === allowListHash &&
+			existing.inboundRulesHash === inboundRulesHash
+		) {
 			this.hits += 1;
 			// Refresh LRU position.
 			this.entries.delete(filePath);
@@ -119,10 +132,12 @@ export class ClientGraphBoundaryCache {
 		filePath: string,
 		source: string,
 		globallyAllowedSpecifiers: Iterable<string>,
-		entry: Omit<CachedTransform, 'sourceHash' | 'allowListHash'>,
+		entry: Omit<CachedTransform, 'sourceHash' | 'allowListHash' | 'inboundRulesHash'>,
+		inboundRules?: RequestedExportRules,
 	): void {
 		const sourceHash = rapidhash(source);
 		const allowListHash = hashAllowList(globallyAllowedSpecifiers);
+		const inboundRulesHash = hashRequestedExportRules(inboundRules);
 
 		const rulesAddedCopy = new Map<string, RequestedExportRules>();
 		for (const [key, rules] of entry.rulesAdded) {
@@ -132,6 +147,7 @@ export class ClientGraphBoundaryCache {
 		const full: CachedTransform = {
 			sourceHash,
 			allowListHash,
+			inboundRulesHash,
 			transformed: entry.transformed,
 			modified: entry.modified,
 			rulesAdded: rulesAddedCopy,
@@ -202,4 +218,10 @@ export class ClientGraphBoundaryCache {
 function hashAllowList(specifiers: Iterable<string>): number | bigint {
 	const sorted = Array.from(specifiers).sort();
 	return rapidhash(sorted.join('\n'));
+}
+
+function hashRequestedExportRules(rules: RequestedExportRules | undefined): number | bigint {
+	if (rules === '*') return rapidhash('*');
+	if (!rules) return rapidhash('');
+	return rapidhash(Array.from(rules).sort().join('\n'));
 }

--- a/packages/integrations/react/src/client-graph/boundary-cache.ts
+++ b/packages/integrations/react/src/client-graph/boundary-cache.ts
@@ -17,6 +17,14 @@
  * The cache is content-hashed (via `rapidhash`) so a `touch`/`utimes`
  * does not invalidate a still-valid entry.
  *
+ * Cache identity is `(filePath, source, allowListRules, inboundRules)`.
+ * Allow-list hashing includes each package's permitted exports, not just
+ * package names — otherwise `node:fs{readFileSync}` and
+ * `node:fs{writeFileSync}` would collide.
+ *
+ * Modules that inline external file contents (`readFileSync` rewrite) are
+ * not stored: their output depends on files outside the importer source.
+ *
  * **`rulesAdded` semantics:** the map holds the **after-state** of
  * every registry key this transform touched — both newly added keys
  * and keys that were grown (Set union) or promoted to `'*'`. On
@@ -32,6 +40,9 @@ import { rapidhash } from '@ecopages/core/utils/hash';
 const DEFAULT_MAX_ENTRIES = 5_000;
 
 export type RequestedExportRules = Set<string> | '*';
+
+/** Globally declared modules with their permitted export rules. */
+export type ClientGraphAllowList = ReadonlyMap<string, RequestedExportRules>;
 
 export type CachedTransform = {
 	/** Hash of the source string at the time the transform was cached. */
@@ -69,9 +80,10 @@ function cloneRules(rules: RequestedExportRules): RequestedExportRules {
  * LRU-bounded cache for client-graph-boundary transform results.
  *
  * One instance is owned by the React plugin for the app's lifetime and
- * shared across all builds. The cache key is `(filePath, source, allowList)`
- * so a file whose source or whose global allow list changes gets a fresh
- * entry, while everything else hits.
+ * shared across all builds. The cache key is
+ * `(filePath, source, allowListRules, inboundRules)` so a file whose
+ * source, allow-list export rules, or inbound requested exports change
+ * gets a fresh entry.
  */
 export class ClientGraphBoundaryCache {
 	private readonly entries = new Map<string, CachedTransform>();
@@ -89,18 +101,17 @@ export class ClientGraphBoundaryCache {
 	/**
 	 * Look up a cached transform for `filePath`.
 	 *
-	 * Returns `undefined` if the source or allow list has changed since
-	 * the entry was stored. The caller is responsible for re-running the
-	 * transform in that case and calling `set` to update the entry.
+	 * Returns `undefined` if the source, allow-list rules, or inbound
+	 * requested exports have changed since the entry was stored.
 	 */
 	get(
 		filePath: string,
 		source: string,
-		globallyAllowedSpecifiers: Iterable<string>,
+		allowList: ClientGraphAllowList,
 		inboundRules?: RequestedExportRules,
 	): CachedTransform | undefined {
 		const sourceHash = rapidhash(source);
-		const allowListHash = hashAllowList(globallyAllowedSpecifiers);
+		const allowListHash = hashAllowList(allowList);
 		const inboundRulesHash = hashRequestedExportRules(inboundRules);
 
 		const existing = this.entries.get(filePath);
@@ -111,7 +122,6 @@ export class ClientGraphBoundaryCache {
 			existing.inboundRulesHash === inboundRulesHash
 		) {
 			this.hits += 1;
-			// Refresh LRU position.
 			this.entries.delete(filePath);
 			this.entries.set(filePath, existing);
 			return existing;
@@ -131,12 +141,12 @@ export class ClientGraphBoundaryCache {
 	set(
 		filePath: string,
 		source: string,
-		globallyAllowedSpecifiers: Iterable<string>,
+		allowList: ClientGraphAllowList,
 		entry: Omit<CachedTransform, 'sourceHash' | 'allowListHash' | 'inboundRulesHash'>,
 		inboundRules?: RequestedExportRules,
 	): void {
 		const sourceHash = rapidhash(source);
-		const allowListHash = hashAllowList(globallyAllowedSpecifiers);
+		const allowListHash = hashAllowList(allowList);
 		const inboundRulesHash = hashRequestedExportRules(inboundRules);
 
 		const rulesAddedCopy = new Map<string, RequestedExportRules>();
@@ -172,8 +182,7 @@ export class ClientGraphBoundaryCache {
 	}
 
 	/**
-	 * Invalidate every file whose key matches a prefix. Useful for
-	 * "anything under `src/pages/` changed" signals.
+	 * Invalidate every file whose key matches a predicate.
 	 */
 	invalidateMatching(predicate: (filePath: string) => boolean): number {
 		let removed = 0;
@@ -211,13 +220,20 @@ export class ClientGraphBoundaryCache {
 }
 
 /**
- * Hash a list of globally-allowed specifiers. The order of iteration
- * must be stable for the hash to be deterministic; we sort before
- * hashing.
+ * Hash allow-list package names together with each package's permitted exports.
  */
-function hashAllowList(specifiers: Iterable<string>): number | bigint {
-	const sorted = Array.from(specifiers).sort();
-	return rapidhash(sorted.join('\n'));
+export function hashAllowList(allowList: ClientGraphAllowList): number | bigint {
+	const lines: string[] = [];
+	for (const packageName of Array.from(allowList.keys()).sort()) {
+		const rules = allowList.get(packageName);
+		if (rules === '*') {
+			lines.push(`${packageName}=*`);
+			continue;
+		}
+		const named = rules ? Array.from(rules).sort().join(',') : '';
+		lines.push(`${packageName}={${named}}`);
+	}
+	return rapidhash(lines.join('\n'));
 }
 
 function hashRequestedExportRules(rules: RequestedExportRules | undefined): number | bigint {

--- a/packages/integrations/react/src/client-graph/boundary-plugin.test.ts
+++ b/packages/integrations/react/src/client-graph/boundary-plugin.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
@@ -103,7 +103,9 @@ describe('createClientGraphBoundaryPlugin', () => {
 
 	it('keeps imports declared via plugin options', async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), 'eco-client-graph-'));
-		const filePath = join(tempDir, 'entry.tsx');
+		const pagesDir = join(tempDir, 'pages');
+		mkdirSync(pagesDir);
+		const filePath = join(pagesDir, 'entry.tsx');
 		writeFileSync(
 			filePath,
 			"import fs from 'node:fs';\nimport dayjs from 'dayjs';\nexport default dayjs() + String(!!fs);\n",
@@ -124,7 +126,9 @@ describe('createClientGraphBoundaryPlugin', () => {
 
 	it('keeps relative imports untouched', async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), 'eco-client-graph-'));
-		const filePath = join(tempDir, 'entry.tsx');
+		const pagesDir = join(tempDir, 'pages');
+		mkdirSync(pagesDir);
+		const filePath = join(pagesDir, 'entry.tsx');
 		writeFileSync(filePath, "import { helper } from './helper';\nexport default helper;\n", 'utf-8');
 
 		try {
@@ -139,7 +143,9 @@ describe('createClientGraphBoundaryPlugin', () => {
 
 	it('keeps project alias imports untouched', async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), 'eco-client-graph-'));
-		const filePath = join(tempDir, 'entry.tsx');
+		const pagesDir = join(tempDir, 'pages');
+		mkdirSync(pagesDir);
+		const filePath = join(pagesDir, 'entry.tsx');
 		writeFileSync(
 			join(tempDir, 'tsconfig.json'),
 			JSON.stringify({ compilerOptions: { paths: { '@/*': ['./*'] } } }),
@@ -402,7 +408,9 @@ describe('createClientGraphBoundaryPlugin', () => {
 
 	it('strips server-only eco.page options so unreachable middleware imports do not leak into the browser bundle', async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), 'eco-client-graph-'));
-		const filePath = join(tempDir, 'entry.tsx');
+		const pagesDir = join(tempDir, 'pages');
+		mkdirSync(pagesDir);
+		const filePath = join(pagesDir, 'entry.tsx');
 		writeFileSync(
 			filePath,
 			[
@@ -437,7 +445,9 @@ describe('createClientGraphBoundaryPlugin', () => {
 
 	it('strips staticProps imports from .server helpers before shipping a page entry to the browser', async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), 'eco-client-graph-'));
-		const filePath = join(tempDir, 'entry.tsx');
+		const pagesDir = join(tempDir, 'pages');
+		mkdirSync(pagesDir);
+		const filePath = join(pagesDir, 'entry.tsx');
 
 		writeFileSync(
 			filePath,
@@ -467,7 +477,9 @@ describe('createClientGraphBoundaryPlugin', () => {
 
 	it('strips metadata that references direct filesystem imports, leaving import cleanup to downstream treeshaking', async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), 'eco-client-graph-'));
-		const filePath = join(tempDir, 'entry.tsx');
+		const pagesDir = join(tempDir, 'pages');
+		mkdirSync(pagesDir);
+		const filePath = join(pagesDir, 'entry.tsx');
 
 		writeFileSync(
 			filePath,

--- a/packages/integrations/react/src/client-graph/boundary-plugin.ts
+++ b/packages/integrations/react/src/client-graph/boundary-plugin.ts
@@ -13,10 +13,13 @@ import {
 	parseDeclaredModules,
 	toModuleBaseSpecifier,
 	mergeRequestedExportRules,
+	normalizeRequestedExportsKey,
 	snapshotRegistry,
 	diffRequestedExportRules,
 } from './specifier-classification.ts';
 import { transformModuleImports } from './ast-transform.ts';
+import { classifyClientGraphModule, isPageOrLayoutEntry } from './module-classification.ts';
+import { recordModuleTransformProfile } from '@ecopages/core/cache';
 
 const SOURCE_FILE_FILTER = /\.(tsx?|jsx?)$/;
 
@@ -74,6 +77,10 @@ export function createClientGraphBoundaryPlugin(options?: ClientGraphBoundaryOpt
 			const allowListForCache = Array.from(globallyDeclaredSources.keys()).sort();
 
 			build.onLoad({ filter: SOURCE_FILE_FILTER }, (args) => {
+				const category = classifyClientGraphModule(args.path, options?.projectRoot);
+				if (category === 'package' || category === 'vendored' || category === 'virtual') {
+					return undefined;
+				}
 				let source: string;
 				try {
 					source = readFileSync(args.path, 'utf-8');
@@ -88,8 +95,16 @@ export function createClientGraphBoundaryPlugin(options?: ClientGraphBoundaryOpt
 				 * the cached transformed source. Skips the entire
 				 * `parseSync` + AST walk on a no-op rebuild.
 				 */
+				const inboundRules = requestedExports.get(normalizeRequestedExportsKey(args.path));
 				if (cache) {
-					const cached = cache.get(args.path, source, allowListForCache);
+					const cacheStartedAt = performance.now();
+					const cached = cache.get(args.path, source, allowListForCache, inboundRules);
+					recordModuleTransformProfile({
+						category,
+						phase: 'cache-lookup',
+						ms: performance.now() - cacheStartedAt,
+						cacheHit: Boolean(cached),
+					});
 					if (cached) {
 						for (const [moduleKey, rules] of cached.rulesAdded) {
 							mergeRequestedExportRules(requestedExports, moduleKey, rules);
@@ -140,13 +155,20 @@ export function createClientGraphBoundaryPlugin(options?: ClientGraphBoundaryOpt
 				// to `'*'`. A snapshot keyed only on newly-added entries
 				// would under-populate the registry on cache hit.
 				const registryBefore = snapshotRegistry(requestedExports);
+				const analysisStartedAt = performance.now();
 				const { transformed: oxcTransformed, modified: importsModified } = transformModuleImports(
 					transformed,
 					args.path,
 					globallyDeclaredSources,
 					requestedExports,
 					options?.projectRoot,
+					isPageOrLayoutEntry(args.path) || source.includes('eco.page'),
 				);
+				recordModuleTransformProfile({
+					category,
+					phase: 'analysis',
+					ms: performance.now() - analysisStartedAt,
+				});
 
 				if (importsModified) {
 					modified = true;
@@ -162,12 +184,12 @@ export function createClientGraphBoundaryPlugin(options?: ClientGraphBoundaryOpt
 						if (!diff) continue;
 						rulesAdded.set(key, diff);
 					}
-					const entry: Omit<CachedTransform, 'sourceHash' | 'allowListHash'> = {
+					const entry: Omit<CachedTransform, 'sourceHash' | 'allowListHash' | 'inboundRulesHash'> = {
 						transformed,
 						modified,
 						rulesAdded,
 					};
-					cache.set(args.path, source, allowListForCache, entry);
+					cache.set(args.path, source, allowListForCache, entry, inboundRules);
 				}
 
 				if (!modified) return undefined;

--- a/packages/integrations/react/src/client-graph/boundary-plugin.ts
+++ b/packages/integrations/react/src/client-graph/boundary-plugin.ts
@@ -5,7 +5,7 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, extname, resolve } from 'node:path';
+import { dirname, extname, resolve, sep } from 'node:path';
 import type { EcoBuildPlugin } from '@ecopages/core/plugins/integration-plugin';
 import { ClientGraphBoundaryCache, type CachedTransform } from './boundary-cache.ts';
 import type { RequestedExportRules } from './boundary-cache.ts';
@@ -69,13 +69,6 @@ export function createClientGraphBoundaryPlugin(options?: ClientGraphBoundaryOpt
 				globallyDeclaredSources.set(toModuleBaseSpecifier(alwaysAllow), '*');
 			}
 
-			/**
-			 * Stable list of globally-allowed specifiers, used as part of
-			 * the cache key. Sorted on construction so iteration order is
-			 * deterministic for hashing.
-			 */
-			const allowListForCache = Array.from(globallyDeclaredSources.keys()).sort();
-
 			build.onLoad({ filter: SOURCE_FILE_FILTER }, (args) => {
 				const category = classifyClientGraphModule(args.path, options?.projectRoot);
 				if (category === 'package' || category === 'vendored' || category === 'virtual') {
@@ -90,15 +83,14 @@ export function createClientGraphBoundaryPlugin(options?: ClientGraphBoundaryOpt
 
 				/**
 				 * Fast path: if the cache has a transform result for this
-				 * exact (filePath, source, allowList) tuple, replay the
-				 * captured `rulesAdded` into the live registry and return
-				 * the cached transformed source. Skips the entire
-				 * `parseSync` + AST walk on a no-op rebuild.
+				 * exact (filePath, source, allowListRules, inboundRules) tuple,
+				 * replay the captured `rulesAdded` into the live registry and
+				 * return the cached transformed source.
 				 */
 				const inboundRules = requestedExports.get(normalizeRequestedExportsKey(args.path));
 				if (cache) {
 					const cacheStartedAt = performance.now();
-					const cached = cache.get(args.path, source, allowListForCache, inboundRules);
+					const cached = cache.get(args.path, source, globallyDeclaredSources, inboundRules);
 					recordModuleTransformProfile({
 						category,
 						phase: 'cache-lookup',
@@ -117,17 +109,17 @@ export function createClientGraphBoundaryPlugin(options?: ClientGraphBoundaryOpt
 
 				let transformed = source;
 				let modified = false;
+				let inlinedExternalFile = false;
 
 				if (source.includes('readFileSync')) {
 					const readFileTransformed = transformed.replace(
 						/\bfs\.readFileSync\s*\(\s*path\.resolve\s*\(\s*(['"`])([^'"`\n]+)\1\s*\)\s*,\s*['"`]utf-?8['"`]\s*\)/g,
 						(_match, _q, relPath) => {
 							modified = true;
+							inlinedExternalFile = true;
 							try {
 								const sourceDir = dirname(args.path);
-								const srcDirIndex = args.path.lastIndexOf('/src/');
-								const inferredProjectRoot =
-									srcDirIndex >= 0 ? args.path.slice(0, srcDirIndex) : undefined;
+								const inferredProjectRoot = inferProjectRootFromSourcePath(args.path);
 								const candidates = [
 									resolve(absWorkingDir, relPath),
 									resolve(process.cwd(), relPath),
@@ -175,8 +167,11 @@ export function createClientGraphBoundaryPlugin(options?: ClientGraphBoundaryOpt
 					transformed = oxcTransformed;
 				}
 
-				// Build the rulesAdded diff for cache storage.
-				if (cache) {
+				/**
+				 * Skip persistent cache when the transform inlined another file:
+				 * output depends on content outside the importer source hash.
+				 */
+				if (cache && !inlinedExternalFile) {
 					const rulesAdded = new Map<string, RequestedExportRules>();
 					for (const [key, afterRules] of requestedExports) {
 						const beforeRules = registryBefore.get(key);
@@ -189,7 +184,7 @@ export function createClientGraphBoundaryPlugin(options?: ClientGraphBoundaryOpt
 						modified,
 						rulesAdded,
 					};
-					cache.set(args.path, source, allowListForCache, entry, inboundRules);
+					cache.set(args.path, source, globallyDeclaredSources, entry, inboundRules);
 				}
 
 				if (!modified) return undefined;
@@ -199,4 +194,11 @@ export function createClientGraphBoundaryPlugin(options?: ClientGraphBoundaryOpt
 			});
 		},
 	};
+}
+
+function inferProjectRootFromSourcePath(filePath: string): string | undefined {
+	const parts = filePath.split(/[\\/]/);
+	const srcIndex = parts.lastIndexOf('src');
+	if (srcIndex <= 0) return undefined;
+	return parts.slice(0, srcIndex).join(sep);
 }

--- a/packages/integrations/react/src/client-graph/boundary-plugin.ts
+++ b/packages/integrations/react/src/client-graph/boundary-plugin.ts
@@ -162,7 +162,7 @@ export function createClientGraphBoundaryPlugin(options?: ClientGraphBoundaryOpt
 					globallyDeclaredSources,
 					requestedExports,
 					options?.projectRoot,
-					isPageOrLayoutEntry(args.path) || source.includes('eco.page'),
+					isPageOrLayoutEntry(args.path),
 				);
 				recordModuleTransformProfile({
 					category,

--- a/packages/integrations/react/src/client-graph/module-classification.test.ts
+++ b/packages/integrations/react/src/client-graph/module-classification.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { classifyClientGraphModule, isPageOrLayoutEntry } from './module-classification.ts';
+
+describe('classifyClientGraphModule', () => {
+	it('classifies package modules with POSIX and Windows separators', () => {
+		expect(classifyClientGraphModule('/app/node_modules/react/index.js')).toBe('package');
+		expect(classifyClientGraphModule('C:\\app\\node_modules\\react\\index.js')).toBe('package');
+	});
+
+	it('classifies vendored modules with either separator', () => {
+		expect(classifyClientGraphModule('/app/.eco/runtime.js')).toBe('vendored');
+		expect(classifyClientGraphModule('C:\\app\\.eco\\runtime.js')).toBe('vendored');
+		expect(classifyClientGraphModule('/app/assets/vendors/react.js')).toBe('vendored');
+		expect(classifyClientGraphModule('C:\\app\\assets\\vendors\\react.js')).toBe('vendored');
+	});
+
+	it('classifies app modules under project root', () => {
+		expect(classifyClientGraphModule('/app/src/pages/index.tsx', '/app')).toBe('app');
+	});
+});
+
+describe('isPageOrLayoutEntry', () => {
+	it('detects pages and layouts with either separator', () => {
+		expect(isPageOrLayoutEntry('/app/src/pages/index.tsx')).toBe(true);
+		expect(isPageOrLayoutEntry('C:\\app\\src\\pages\\index.tsx')).toBe(true);
+		expect(isPageOrLayoutEntry('/app/src/layouts/main.tsx')).toBe(true);
+		expect(isPageOrLayoutEntry('C:\\app\\src\\layouts\\main.tsx')).toBe(true);
+		expect(isPageOrLayoutEntry('/app/src/components/button.tsx')).toBe(false);
+	});
+});

--- a/packages/integrations/react/src/client-graph/module-classification.ts
+++ b/packages/integrations/react/src/client-graph/module-classification.ts
@@ -1,0 +1,15 @@
+import path from 'node:path';
+
+export type ClientGraphModuleKind = 'app' | 'workspace' | 'package' | 'vendored' | 'virtual';
+
+export function classifyClientGraphModule(filePath: string, projectRoot?: string): ClientGraphModuleKind {
+	if (filePath.startsWith('\0') || filePath.includes('?')) return 'virtual';
+	if (filePath.includes('/node_modules/')) return 'package';
+	if (filePath.includes('/.eco/') || filePath.includes('/assets/vendors/')) return 'vendored';
+	if (projectRoot && filePath.startsWith(`${path.resolve(projectRoot)}${path.sep}`)) return 'app';
+	return 'workspace';
+}
+
+export function isPageOrLayoutEntry(filePath: string): boolean {
+	return /\/(pages|layouts)\//.test(filePath);
+}

--- a/packages/integrations/react/src/client-graph/module-classification.ts
+++ b/packages/integrations/react/src/client-graph/module-classification.ts
@@ -2,14 +2,46 @@ import path from 'node:path';
 
 export type ClientGraphModuleKind = 'app' | 'workspace' | 'package' | 'vendored' | 'virtual';
 
+/**
+ * Splits a file path into OS-agnostic segments.
+ *
+ * @remarks
+ * Bundlers may pass POSIX or Windows separators; classification must not depend
+ * on the host's `path.sep` alone.
+ */
+function pathSegments(filePath: string): string[] {
+	return filePath.split(/[\\/]+/).filter(Boolean);
+}
+
+function hasPathSegment(filePath: string, segment: string): boolean {
+	return pathSegments(filePath).includes(segment);
+}
+
+function hasPathSuffix(filePath: string, segments: readonly string[]): boolean {
+	const parts = pathSegments(filePath);
+	for (let index = 0; index <= parts.length - segments.length; index += 1) {
+		if (segments.every((segment, offset) => parts[index + offset] === segment)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 export function classifyClientGraphModule(filePath: string, projectRoot?: string): ClientGraphModuleKind {
 	if (filePath.startsWith('\0') || filePath.includes('?')) return 'virtual';
-	if (filePath.includes('/node_modules/')) return 'package';
-	if (filePath.includes('/.eco/') || filePath.includes('/assets/vendors/')) return 'vendored';
-	if (projectRoot && filePath.startsWith(`${path.resolve(projectRoot)}${path.sep}`)) return 'app';
+	if (hasPathSegment(filePath, 'node_modules')) return 'package';
+	if (hasPathSegment(filePath, '.eco') || hasPathSuffix(filePath, ['assets', 'vendors'])) return 'vendored';
+	if (projectRoot) {
+		const resolvedRoot = path.resolve(projectRoot);
+		const resolvedFile = path.resolve(filePath);
+		if (resolvedFile === resolvedRoot || resolvedFile.startsWith(`${resolvedRoot}${path.sep}`)) {
+			return 'app';
+		}
+	}
 	return 'workspace';
 }
 
 export function isPageOrLayoutEntry(filePath: string): boolean {
-	return /\/(pages|layouts)\//.test(filePath);
+	const segments = pathSegments(filePath);
+	return segments.includes('pages') || segments.includes('layouts');
 }

--- a/packages/integrations/react/src/client-graph/reachability-analyzer.ts
+++ b/packages/integrations/react/src/client-graph/reachability-analyzer.ts
@@ -11,24 +11,8 @@
  * by the browser to hydrate the page, and which imports are unused on the client (and thus can be pruned).
  */
 
-import { parseSync } from 'oxc-parser';
-import { extname } from 'node:path';
-
-type ParserLanguage = 'js' | 'jsx' | 'ts' | 'tsx';
-
-/**
- * Determines the appropriate parser language configuration for a given file name.
- *
- * @param filename - The absolute or relative path to the file.
- * @returns The Oxc parser language dialect to use ('js', 'jsx', 'ts', or 'tsx').
- */
-export function parserLanguageForFile(filename: string): ParserLanguage {
-	const extension = extname(filename).toLowerCase();
-	if (extension === '.tsx') return 'tsx';
-	if (extension === '.ts') return 'ts';
-	if (extension === '.jsx') return 'jsx';
-	return 'js';
-}
+import { parseModuleSource } from '@ecopages/core/cache';
+import type { ParseResult } from 'oxc-parser';
 
 /**
  * Represents the computed results of a reachability analysis pass.
@@ -82,7 +66,7 @@ type ExplicitlyRequestedExports = Set<string> | '*';
 export function analyzeReachability(
 	source: string,
 	filename: string,
-	program?: ReturnType<typeof parseSync>['program'],
+	program?: ParseResult['program'],
 	explicitlyRequestedExports?: ExplicitlyRequestedExports,
 ): ReachabilityResult {
 	/**
@@ -92,17 +76,14 @@ export function analyzeReachability(
 	 * pipeline), we reuse it directly to avoid double-parsing the same source text.
 	 * Otherwise we parse here and return early with an empty "unanalyzed" result on failure.
 	 */
-	let resolvedProgram: ReturnType<typeof parseSync>['program'];
+	let resolvedProgram: ParseResult['program'];
 
 	if (program) {
 		resolvedProgram = program;
 	} else {
 		let result;
 		try {
-			result = parseSync(filename, source, {
-				sourceType: 'module',
-				lang: parserLanguageForFile(filename),
-			});
+			result = parseModuleSource(filename, source);
 		} catch {
 			return {
 				reachableImports: new Map(),

--- a/packages/integrations/react/src/plugin/react.plugin.ts
+++ b/packages/integrations/react/src/plugin/react.plugin.ts
@@ -147,6 +147,7 @@ export class ReactPlugin extends IntegrationPlugin<React.ReactNode> {
 			mdxExtensions: this.mdxExtensions,
 			hmrPageMetadataCache: this.hmrPageMetadataCache,
 			forceBrowserGraph: this.forceBrowserGraph,
+			clientGraphBoundaryCache: this.clientGraphBoundaryCache,
 		};
 
 		if (this.mdxEnabled) {

--- a/packages/integrations/react/src/plugin/react.types.ts
+++ b/packages/integrations/react/src/plugin/react.types.ts
@@ -3,6 +3,7 @@ import type { CompileOptions } from '@mdx-js/mdx';
 import type { ReactRouterAdapter } from '../contracts/router-adapter.ts';
 import type { HmrPageMetadataCache } from '../hmr/page-metadata-cache.ts';
 import type { ReactPluginRuntimeModule, ResolvedReactPluginRuntimeModule } from '../bundling/runtime-modules.ts';
+import type { ClientGraphBoundaryCache } from '../client-graph/boundary-cache.ts';
 
 /**
  * MDX configuration options for the React plugin.
@@ -141,6 +142,8 @@ export type ReactRendererConfig = {
 	mdxCompilerOptions?: CompileOptions;
 	mdxExtensions?: string[];
 	hmrPageMetadataCache?: HmrPageMetadataCache;
+	/** Persistent React-plugin-owned cache shared by bundles and HMR transforms. */
+	clientGraphBoundaryCache?: ClientGraphBoundaryCache;
 	/**
 	 * When true, always emit page browser graph / hydration assets for React pages.
 	 *

--- a/packages/integrations/react/src/render/react-renderer.ts
+++ b/packages/integrations/react/src/render/react-renderer.ts
@@ -123,6 +123,7 @@ export class ReactRenderer extends IntegrationRenderer<ReactNode> {
 			routerAdapter: this.routerAdapter,
 			runtimeModules: reactConfig?.runtimeModules,
 			mdxCompilerOptions: this.mdxCompilerOptions,
+			clientGraphBoundaryCache: reactConfig?.clientGraphBoundaryCache,
 		});
 
 		this.pageModuleService = new PageModuleService({


### PR DESCRIPTION
## Summary
- Normalize the shared module parser cache contract for core and React client-graph transforms.
- Add module transform profiling and client-graph classification/cache-key support.
- Keep server-only page option stripping scoped to the relevant transform entries.

## Test plan
- [x] Focused Vitest suite: 4 files, 41 tests
- [x] `pnpm --filter @ecopages/core typecheck`
- [x] `pnpm --filter @ecopages/react typecheck`

## Dependencies
None. Based directly on `release/v0.2.0`.
