### PR TITLE
fix(core): browser vendor resolution and dev runtime cache

### DIFF
--- a/apps/docs/src/content/docs/core/routing.mdx
+++ b/apps/docs/src/content/docs/core/routing.mdx
@@ -99,6 +99,7 @@ Important:
 - If the `500.*` template is missing or throws, the response falls back to plain-text `Internal Server Error`. The custom page is never retried.
 - In **development**, the thrown error is passed as page props (`message`, `stack`) so the custom 500 page can show the real failure. In **production**, those props are omitted so stacks are not serialized into HTML. The original error is always logged server-side.
 - Like `404.*`, the file is also a normal route at `/500`, so you can open it directly to preview the design (that direct visit is a 200 and has no error props unless you trigger a render failure).
+- Semantic error templates render outside the normal page-request middleware pipeline. They receive a safe empty `pageLocals` object instead of request-scoped `locals`. Do not use `cache: 'dynamic'`, `middleware`, or `requires` on `404.*` / `500.*` templates.
 
 ```tsx
 import { eco, type Error500TemplateProps } from '@ecopages/core';

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -17,6 +17,12 @@ All notable changes to `@ecopages/core` are documented here.
 - Removed dev HMR entrypoint disk cache, grouped cold-graph prewarm, and `ECOPAGES_DEV_COLD_CLIENT_GRAPH*` env vars. Dev client modules are transpiled per source file on demand with in-memory caching and lazy `/assets/vendors` prebundles.
 - Removed `ECOPAGES_DEV_PREWARM_ALL_STATIC_ROUTES`. Dev SSR prewarm only renders processor-declared pathnames from `collectDevPrewarmPlan()`.
 
+### Bug Fixes
+
+- Browser vendor prebundles now prefer ESM `module` / `import` entries for third-party packages (legacy `browser` export conditions are omitted) while keeping browser-first resolution for `@ecopages/core`.
+- Semantic `404.*` / `500.*` templates now receive safe empty `locals` / `pageLocals` instead of the throwing locals proxy.
+- Development rendered HTML cache keys now include browser-runtime asset generation so rebuilt bootstrap/vendor script URLs cannot go stale.
+
 ### Features
 
 - Page HTML cache in watch mode uses Cache Strategy admission on a bounded memory store: static pages may be retained, dynamic pages never are. Set `cache.enabled: false` to disable watch-mode HTML caching entirely. Source-path edits invalidate only registered HTML keys; shared or unmapped dependencies clear the full page cache.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -300,6 +300,10 @@
 			"types": "./src/plugins/tsconfig-import-resolver.ts",
 			"default": "./src/plugins/tsconfig-import-resolver.ts"
 		},
+		"./plugins/package-specifier": {
+			"types": "./src/plugins/package-specifier.ts",
+			"default": "./src/plugins/package-specifier.ts"
+		},
 		"./plugins/jsx-import-source.utils": {
 			"types": "./src/plugins/jsx-import-source.utils.ts",
 			"default": "./src/plugins/jsx-import-source.utils.ts"

--- a/packages/core/src/adapters/shared/http/fs-server-response-matcher.test.ts
+++ b/packages/core/src/adapters/shared/http/fs-server-response-matcher.test.ts
@@ -42,27 +42,32 @@ function createRouteRendererFactoryWithStub404(
 	realFactory: PageRendererResolver,
 	error404TemplatePath: string,
 	options?: { executeError?: Error },
-): PageRendererResolver {
+): { factory: PageRendererResolver; execute: ReturnType<typeof vi.fn> } {
+	const execute = options?.executeError
+		? vi.fn(async () => {
+				throw options.executeError;
+			})
+		: vi.fn(async () => ({
+				body: '<h1>404 - Page Not Found</h1>',
+			}));
+
 	const stub404Renderer = {
-		execute: options?.executeError
-			? vi.fn(async () => {
-					throw options.executeError;
-				})
-			: vi.fn(async () => ({
-					body: '<h1>404 - Page Not Found</h1>',
-				})),
+		execute,
 		loadPageModule: vi.fn(async () => ({
 			default: () => null,
 		})),
 	};
 
 	return {
-		getPageRenderer(filePath: string) {
-			if (filePath === error404TemplatePath) {
-				return stub404Renderer;
-			}
+		execute,
+		factory: {
+			getPageRenderer(filePath: string) {
+				if (filePath === error404TemplatePath) {
+					return stub404Renderer;
+				}
 
-			return realFactory.getPageRenderer(filePath);
+				return realFactory.getPageRenderer(filePath);
+			},
 		},
 	};
 }
@@ -151,7 +156,7 @@ function createRouteRendererFactoryWithMissing500Template(
 	};
 }
 
-const routeRendererFactoryForNoMatchTests = createRouteRendererFactoryWithStub404(
+const { factory: routeRendererFactoryForNoMatchTests } = createRouteRendererFactoryWithStub404(
 	routeRendererFactory,
 	appConfig.absolutePaths.error404TemplatePath,
 );
@@ -410,7 +415,7 @@ describe('FileSystemResponseMatcher', () => {
 				INDEX_TEMPLATE_FILE,
 				HttpError.NotFound('Unknown content entry'),
 			);
-			const factoryWithStub404 = createRouteRendererFactoryWithStub404(
+			const { factory: factoryWithStub404, execute: execute404 } = createRouteRendererFactoryWithStub404(
 				throwingFactory,
 				appConfig.absolutePaths.error404TemplatePath,
 			);
@@ -437,6 +442,11 @@ describe('FileSystemResponseMatcher', () => {
 			expect(response.status).toBe(404);
 			expect(response.headers.get('Content-Type')).toBe('text/html');
 			expect(await response.text()).toContain('<h1>404 - Page Not Found</h1>');
+			expect(execute404).toHaveBeenCalledWith({
+				file: appConfig.absolutePaths.error404TemplatePath,
+				props: undefined,
+				locals: {},
+			});
 		});
 
 		it('should return custom HTML 500 when a matched route render throws', async () => {
@@ -516,6 +526,7 @@ describe('FileSystemResponseMatcher', () => {
 						message: 'page render failed',
 						stack: renderError.stack,
 					},
+					locals: {},
 				});
 			} finally {
 				process.env.NODE_ENV = previousNodeEnv;
@@ -560,6 +571,7 @@ describe('FileSystemResponseMatcher', () => {
 				expect(execute).toHaveBeenCalledWith({
 					file: appConfig.absolutePaths.error500TemplatePath,
 					props: undefined,
+					locals: {},
 				});
 			} finally {
 				process.env.NODE_ENV = previousNodeEnv;
@@ -642,7 +654,7 @@ describe('FileSystemResponseMatcher', () => {
 
 		it('should return custom HTML 500 when the custom 404 template render throws', async () => {
 			const templateError = new Error('404 template render failed');
-			const throwing404Factory = createRouteRendererFactoryWithStub404(
+			const { factory: throwing404Factory } = createRouteRendererFactoryWithStub404(
 				routeRendererFactory,
 				appConfig.absolutePaths.error404TemplatePath,
 				{ executeError: templateError },

--- a/packages/core/src/adapters/shared/http/fs-server-response-matcher.ts
+++ b/packages/core/src/adapters/shared/http/fs-server-response-matcher.ts
@@ -8,6 +8,7 @@ import type { CacheStrategy, RenderResult } from '../../../services/cache/cache.
 import type { EcoPageComponent } from '../../../eco/eco.types.ts';
 import type { EcoPageFile } from '../../../types/public-types.ts';
 import { PageRequestCacheCoordinator } from '../../../services/cache/page-request-cache-coordinator.service.ts';
+import { getBrowserRuntimeAssetGeneration } from '../../../services/assets/browser-runtime-asset-generation.ts';
 import { ServerUtils } from '../../../utils/server-utils.module.ts';
 import type { FileRouteMiddleware, RequestLocals, RouteRendererBody } from '../../../types/public-types.ts';
 import { FileRouteMiddlewarePipeline } from './file-route-middleware-pipeline.ts';
@@ -69,7 +70,9 @@ export class FileSystemResponseMatcher {
 		this.router = router;
 		this.routeRendererFactory = routeRendererFactory;
 		this.fileSystemResponseFactory = fileSystemResponseFactory;
-		this.pageRequestCacheCoordinator = new PageRequestCacheCoordinator(cacheService, defaultCacheStrategy);
+		this.pageRequestCacheCoordinator = new PageRequestCacheCoordinator(cacheService, defaultCacheStrategy, () =>
+			getBrowserRuntimeAssetGeneration(this.appConfig),
+		);
 		this.fileRouteMiddlewarePipeline = new FileRouteMiddlewarePipeline(cacheService);
 	}
 
@@ -244,6 +247,7 @@ export class FileSystemResponseMatcher {
 		const result = await routeRenderer.execute({
 			file: templatePath,
 			props,
+			locals: {},
 		});
 
 		return createHtmlResponse(result.body);

--- a/packages/core/src/build/browser/browser-runtime-manifest.test.ts
+++ b/packages/core/src/build/browser/browser-runtime-manifest.test.ts
@@ -5,6 +5,8 @@ import {
 	createBrowserRuntimeManifest,
 	getBrowserRuntimeSpecifierMap,
 	mergeBrowserRuntimeManifests,
+	resolveBrowserRuntimePublicPath,
+	resolveRuntimeSpecifierPublicPath,
 } from './browser-runtime-manifest.ts';
 
 test('createBrowserRuntimeManifest indexes runtime assets by specifier', () => {
@@ -47,6 +49,26 @@ test('createBrowserRuntimeManifest deduplicates identical declarations', () => {
 	]);
 
 	assert.equal(manifest.assets.length, 1);
+});
+
+test('createBrowserRuntimeManifest deduplicates equivalent declarations from distinct owners', () => {
+	const manifest = createBrowserRuntimeManifest([
+		{
+			specifier: 'react',
+			owner: '@ecopages/react',
+			importPath: 'react',
+			publicPath: '/assets/vendors/react.js',
+		},
+		{
+			specifier: 'react',
+			owner: 'react-runtime-alias-plugin',
+			importPath: 'react',
+			publicPath: '/assets/vendors/react.js',
+		},
+	]);
+
+	assert.equal(manifest.assets.length, 1);
+	assert.equal(manifest.bySpecifier.get('react')?.owner, '@ecopages/react');
 });
 
 test('createBrowserRuntimeManifest rejects conflicting declarations', () => {
@@ -118,4 +140,51 @@ test('getBrowserRuntimeSpecifierMap returns concrete public URLs for rewriting',
 		['react', '/assets/vendors/react.js'],
 		['react-dom/client', '/assets/vendors/react-dom-client.js'],
 	]);
+});
+
+test('resolveBrowserRuntimePublicPath only maps explicitly configured specifiers', () => {
+	const manifest = createBrowserRuntimeManifest([
+		{
+			specifier: '@acme/ui',
+			owner: '@ecopages/react',
+			importPath: '@acme/ui',
+			publicPath: '/assets/vendors/acme-ui.js',
+		},
+	]);
+
+	assert.equal(resolveBrowserRuntimePublicPath('@acme/ui', manifest), '/assets/vendors/acme-ui.js');
+	assert.equal(resolveBrowserRuntimePublicPath('@acme/ui/button', manifest), undefined);
+	assert.equal(resolveBrowserRuntimePublicPath('@other/pkg', manifest), undefined);
+});
+
+test('resolveBrowserRuntimePublicPath keeps configured specifiers separate', () => {
+	const manifest = createBrowserRuntimeManifest([
+		{
+			specifier: 'react',
+			owner: '@ecopages/react',
+			importPath: 'react',
+			publicPath: '/assets/vendors/react.js',
+		},
+		{
+			specifier: 'react-dom',
+			owner: '@ecopages/react',
+			importPath: 'react-dom',
+			publicPath: '/assets/vendors/react-dom.js',
+		},
+	]);
+
+	assert.equal(resolveBrowserRuntimePublicPath('react/jsx-runtime', manifest), undefined);
+	assert.equal(resolveBrowserRuntimePublicPath('react-dom/client', manifest), undefined);
+	assert.equal(resolveBrowserRuntimePublicPath('react-dom', manifest), '/assets/vendors/react-dom.js');
+});
+
+test('resolveRuntimeSpecifierPublicPath works against a bare specifier map', () => {
+	const map = new Map([
+		['@acme/ui', '/assets/vendors/acme-ui.js'],
+		['react', '/assets/vendors/react.js'],
+	]);
+
+	assert.equal(resolveRuntimeSpecifierPublicPath('@acme/ui/button', map), undefined);
+	assert.equal(resolveRuntimeSpecifierPublicPath('react/jsx-runtime', map), undefined);
+	assert.equal(resolveRuntimeSpecifierPublicPath('@other/pkg', map), undefined);
 });

--- a/packages/core/src/build/browser/browser-runtime-manifest.ts
+++ b/packages/core/src/build/browser/browser-runtime-manifest.ts
@@ -50,7 +50,6 @@ function normalizeDeclaration(declaration: BrowserRuntimeAssetDeclaration): Brow
 
 function hasCompatibleRuntimeAsset(existing: BrowserRuntimeAsset, incoming: BrowserRuntimeAsset): boolean {
 	return (
-		existing.owner === incoming.owner &&
 		existing.importPath === incoming.importPath &&
 		existing.publicPath === incoming.publicPath &&
 		existing.mode === incoming.mode &&
@@ -102,4 +101,20 @@ export function mergeBrowserRuntimeManifests(
 
 export function getBrowserRuntimeSpecifierMap(manifest: BrowserRuntimeManifest): ReadonlyMap<string, string> {
 	return new Map(manifest.assets.map((asset) => [asset.specifier, asset.publicPath]));
+}
+
+/** Resolves a runtime public URL for an exact specifier. */
+export function resolveRuntimeSpecifierPublicPath(
+	specifier: string,
+	publicPathsBySpecifier: ReadonlyMap<string, string>,
+): string | undefined {
+	return publicPathsBySpecifier.get(specifier);
+}
+
+/** Resolves a manifest-owned runtime public URL for an exact specifier. */
+export function resolveBrowserRuntimePublicPath(
+	specifier: string,
+	manifest: BrowserRuntimeManifest,
+): string | undefined {
+	return manifest.bySpecifier.get(specifier)?.publicPath;
 }

--- a/packages/core/src/build/browser/browser-runtime-plugin-helpers.test.ts
+++ b/packages/core/src/build/browser/browser-runtime-plugin-helpers.test.ts
@@ -18,8 +18,8 @@ test('buildSpecifierFilter returns null for an empty map', () => {
 test('buildSpecifierFilter matches a single specifier exactly', () => {
 	const filter = buildSpecifierFilter(new Map([['react', '/vendor/react.js']]))!;
 	assert.equal(filter.test('react'), true);
+	assert.equal(filter.test('react/jsx-runtime'), false);
 	assert.equal(filter.test('react-dom'), false);
-	assert.equal(filter.test('react/extra'), false);
 	assert.equal(filter.test('xreact'), false);
 });
 
@@ -32,6 +32,7 @@ test('buildSpecifierFilter matches any of multiple specifiers', () => {
 	)!;
 	assert.equal(filter.test('react'), true);
 	assert.equal(filter.test('react-dom'), true);
+	assert.equal(filter.test('react-dom/client'), false);
 	assert.equal(filter.test('vue'), false);
 });
 

--- a/packages/core/src/build/browser/browser-runtime-plugin-helpers.ts
+++ b/packages/core/src/build/browser/browser-runtime-plugin-helpers.ts
@@ -5,7 +5,7 @@
  * `createBrowserRuntimePlugin` needs to:
  *
  * 1. Escape each specifier for inclusion in a regex filter.
- * 2. Build a `RegExp` whose alternation matches any of those specifiers.
+ * 2. Build a `RegExp` whose alternation matches registered specifiers.
  *
  * These utilities are extracted here so the plugin does not duplicate
  * the same code path.
@@ -21,11 +21,9 @@ export function escapeRegExp(value: string): string {
 }
 
 /**
- * Builds a `RegExp` whose alternation matches any of the keys in
- * `specifierMap`.
+ * Builds a `RegExp` that matches registered specifiers exactly.
  *
- * Returns `null` for an empty map so callers can short-circuit and
- * avoid registering a no-op `onResolve` / `onLoad` filter.
+ * Returns `null` for an empty map so callers can short-circuit registration.
  */
 export function buildSpecifierFilter(specifierMap: ReadonlyMap<string, string>): RegExp | null {
 	if (specifierMap.size === 0) {
@@ -33,5 +31,5 @@ export function buildSpecifierFilter(specifierMap: ReadonlyMap<string, string>):
 	}
 
 	const alternation = Array.from(specifierMap.keys()).map(escapeRegExp).join('|');
-	return new RegExp(`^(${alternation})$`);
+	return new RegExp(`^(?:${alternation})$`);
 }

--- a/packages/core/src/build/browser/browser-runtime-plugin.test.ts
+++ b/packages/core/src/build/browser/browser-runtime-plugin.test.ts
@@ -6,10 +6,11 @@ import path from 'node:path';
 import { test } from 'vitest';
 import { createBrowserRuntimeManifest } from './browser-runtime-manifest.ts';
 import {
-	BROWSER_RUNTIME_IMPORT_REWRITE_MAP,
+	BROWSER_RUNTIME_MANIFEST,
 	DEFAULT_BROWSER_RUNTIME_PLUGIN_NAME,
 	createBrowserRuntimePlugin,
 	getBrowserRuntimeImportRewriteMap,
+	getBrowserRuntimeManifestFromPlugin,
 } from './browser-runtime-plugin.ts';
 import type { EcoBuildOnLoadResult, EcoBuildOnResolveResult } from '../contracts/build-types.ts';
 
@@ -79,7 +80,7 @@ test('createBrowserRuntimePlugin honors a custom name', () => {
 	assert.equal(plugin.name, 'custom-runtime-plugin');
 });
 
-test('createBrowserRuntimePlugin exposes the specifier map under the canonical symbol', () => {
+test('createBrowserRuntimePlugin exposes the manifest and derived specifier map', () => {
 	const plugin = createBrowserRuntimePlugin({ manifest });
 	assert.ok(plugin);
 	const map = getBrowserRuntimeImportRewriteMap(plugin);
@@ -88,7 +89,8 @@ test('createBrowserRuntimePlugin exposes the specifier map under the canonical s
 		['react', '/assets/vendors/react.js'],
 		['react-dom/client', '/assets/vendors/react-dom.js'],
 	]);
-	assert.equal((plugin as Record<symbol, unknown>)[BROWSER_RUNTIME_IMPORT_REWRITE_MAP], map);
+	assert.equal(getBrowserRuntimeManifestFromPlugin(plugin), manifest);
+	assert.equal((plugin as Record<symbol, unknown>)[BROWSER_RUNTIME_MANIFEST], manifest);
 });
 
 test('createBrowserRuntimePlugin in full mode registers alias, publicPath, and onLoad hooks', () => {
@@ -253,4 +255,27 @@ test('createBrowserRuntimePlugin onLoad returns undefined for non-absolute paths
 	setupPlugin(plugin, callbacks);
 	assert.equal(callbacks.loadCallbacks.length, 1);
 	assert.equal(await callbacks.loadCallbacks[0]?.({ path: 'virtual:entry' }), undefined);
+});
+
+test('createBrowserRuntimePlugin leaves unconfigured package subpaths unchanged', async () => {
+	const scopedManifest = createBrowserRuntimeManifest([
+		{
+			specifier: '@acme/ui',
+			owner: '@ecopages/react',
+			importPath: '@acme/ui',
+			publicPath: '/assets/vendors/acme-ui.js',
+		},
+	]);
+	const tempDir = mkdtempSync(path.join(tmpdir(), 'ecopages-subpath-rewrite-'));
+	const filePath = path.join(tempDir, 'entry.tsx');
+	writeFileSync(filePath, "import { Button } from '@acme/ui/button';\n", 'utf-8');
+
+	try {
+		const callbacks = captureCallbacks();
+		const plugin = createBrowserRuntimePlugin({ manifest: scopedManifest });
+		setupPlugin(plugin, callbacks);
+		assert.equal(await callbacks.loadCallbacks[0]?.({ path: filePath }), undefined);
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
 });

--- a/packages/core/src/build/browser/browser-runtime-plugin.ts
+++ b/packages/core/src/build/browser/browser-runtime-plugin.ts
@@ -11,13 +11,9 @@
  * - `onLoad` for JS/TS files → AST-walking import/export rewrite against the
  *   manifest specifier set, with a `code.includes(specifier)` fast path
  *
- * The plugin object carries the manifest's `specifier → publicPath` map
- * under `BROWSER_RUNTIME_IMPORT_REWRITE_MAP` so
- * `collectBrowserRuntimeImportRewriteMap` and the post-build rewriter can
- * read it without re-walking the manifest.
- *
- * This is the single source of truth for browser-runtime plugin behavior.
- * Per-bundler bridges can treat it as a single plugin.
+ * The plugin object carries the manifest under `BROWSER_RUNTIME_MANIFEST` so
+ * post-build rewriters can resolve exact and subpath imports without rebuilding
+ * the map by hand.
  */
 
 import path from 'node:path';
@@ -25,7 +21,12 @@ import { existsSync, readFileSync } from 'node:fs';
 
 import { parseModuleSource } from '../../cache/module-parse-cache.ts';
 import type { EcoBuildLoader, EcoBuildPlugin } from '../contracts/build-types.ts';
-import { getBrowserRuntimeSpecifierMap, type BrowserRuntimeManifest } from './browser-runtime-manifest.ts';
+import {
+	getBrowserRuntimeSpecifierMap,
+	mergeBrowserRuntimeManifests,
+	resolveBrowserRuntimePublicPath,
+	type BrowserRuntimeManifest,
+} from './browser-runtime-manifest.ts';
 import { buildSpecifierFilter } from './browser-runtime-plugin-helpers.ts';
 
 type Edit = {
@@ -35,11 +36,9 @@ type Edit = {
 };
 
 /**
- * Symbol used to attach the manifest's `specifier → publicPath` map to a
- * plugin instance. Consumers read it via `getBrowserRuntimeImportRewriteMap`
- * or `collectBrowserRuntimeImportRewriteMap`.
+ * Symbol used to attach the browser-runtime manifest to a plugin instance.
  */
-export const BROWSER_RUNTIME_IMPORT_REWRITE_MAP = Symbol.for('ecopages.browserRuntimeImportRewriteMap');
+export const BROWSER_RUNTIME_MANIFEST = Symbol.for('ecopages.browserRuntimeManifest');
 
 /**
  * Default name used by `createBrowserRuntimePlugin` when the caller
@@ -74,7 +73,7 @@ export type CreateBrowserRuntimePluginOptions = {
 };
 
 type BrowserRuntimePlugin = EcoBuildPlugin & {
-	[BROWSER_RUNTIME_IMPORT_REWRITE_MAP]?: ReadonlyMap<string, string>;
+	[BROWSER_RUNTIME_MANIFEST]?: BrowserRuntimeManifest;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -101,14 +100,14 @@ function inferLoaderFromPath(filePath: string): EcoBuildLoader {
 function queueReplacement(options: {
 	code: string;
 	source: unknown;
-	specifierMap: ReadonlyMap<string, string>;
+	manifest: BrowserRuntimeManifest;
 	edits: Edit[];
 }): void {
 	if (!isRecord(options.source) || typeof options.source.value !== 'string') {
 		return;
 	}
 
-	const mappedPath = options.specifierMap.get(options.source.value);
+	const mappedPath = resolveBrowserRuntimePublicPath(options.source.value, options.manifest);
 	if (!mappedPath || typeof options.source.start !== 'number' || typeof options.source.end !== 'number') {
 		return;
 	}
@@ -129,10 +128,10 @@ function queueReplacement(options: {
  */
 export function rewriteBrowserRuntimeImports(
 	code: string,
-	specifierMap: ReadonlyMap<string, string>,
+	manifest: BrowserRuntimeManifest,
 	filePath = 'browser-runtime-imports.js',
 ): string {
-	if (specifierMap.size === 0) {
+	if (manifest.assets.length === 0) {
 		return code;
 	}
 
@@ -151,12 +150,12 @@ export function rewriteBrowserRuntimeImports(
 				node.type === 'ExportNamedDeclaration' ||
 				node.type === 'ExportAllDeclaration'
 			) {
-				queueReplacement({ code, source: node.source, specifierMap, edits });
+				queueReplacement({ code, source: node.source, manifest, edits });
 			}
 
 			if (node.type === 'ImportExpression' && isRecord(node.source)) {
 				if (node.source.type === 'StringLiteral' || node.source.type === 'Literal') {
-					queueReplacement({ code, source: node.source, specifierMap, edits });
+					queueReplacement({ code, source: node.source, manifest, edits });
 				}
 			}
 
@@ -189,29 +188,39 @@ export function rewriteBrowserRuntimeImports(
 	return rewritten;
 }
 
+function importMightReferenceRuntimeRoots(code: string, rootSpecifiers: readonly string[]): boolean {
+	return rootSpecifiers.some((specifier) => code.includes(specifier));
+}
+
+export function getBrowserRuntimeManifestFromPlugin(plugin: EcoBuildPlugin): BrowserRuntimeManifest | undefined {
+	return (plugin as BrowserRuntimePlugin)[BROWSER_RUNTIME_MANIFEST];
+}
+
+/**
+ * Returns the exact specifier → publicPath map derived from the plugin manifest.
+ */
 export function getBrowserRuntimeImportRewriteMap(plugin: EcoBuildPlugin): ReadonlyMap<string, string> | undefined {
-	return (plugin as BrowserRuntimePlugin)[BROWSER_RUNTIME_IMPORT_REWRITE_MAP];
+	const manifest = getBrowserRuntimeManifestFromPlugin(plugin);
+	return manifest ? getBrowserRuntimeSpecifierMap(manifest) : undefined;
+}
+
+export function collectBrowserRuntimeManifests(plugins: EcoBuildPlugin[] | undefined): BrowserRuntimeManifest[] {
+	const manifests: BrowserRuntimeManifest[] = [];
+
+	for (const plugin of plugins ?? []) {
+		const manifest = getBrowserRuntimeManifestFromPlugin(plugin);
+		if (manifest) {
+			manifests.push(manifest);
+		}
+	}
+
+	return manifests;
 }
 
 export function collectBrowserRuntimeImportRewriteMap(
 	plugins: EcoBuildPlugin[] | undefined,
 ): ReadonlyMap<string, string> {
-	const merged = new Map<string, string>();
-
-	for (const plugin of plugins ?? []) {
-		const specifierMap = getBrowserRuntimeImportRewriteMap(plugin);
-		if (!specifierMap) {
-			continue;
-		}
-
-		for (const [specifier, publicPath] of specifierMap.entries()) {
-			if (!merged.has(specifier)) {
-				merged.set(specifier, publicPath);
-			}
-		}
-	}
-
-	return merged;
+	return getBrowserRuntimeSpecifierMap(mergeBrowserRuntimeManifests(...collectBrowserRuntimeManifests(plugins)));
 }
 
 /**
@@ -236,14 +245,13 @@ export function createBrowserRuntimePlugin(options: CreateBrowserRuntimePluginOp
 	const rewriteImports = options.rewriteImports ?? true;
 	const matchPublicPaths = options.matchPublicPaths ?? true;
 	const publicPathSet = new Set(specifierMap.values());
-
-	const specifierKeys = Array.from(specifierMap.keys());
+	const rootSpecifiers = manifest.assets.map((asset) => asset.specifier);
 
 	const plugin: BrowserRuntimePlugin = {
 		name: options.name ?? DEFAULT_BROWSER_RUNTIME_PLUGIN_NAME,
 		setup(build) {
 			build.onResolve({ filter: specifierFilter }, (args) => {
-				const mappedPath = specifierMap.get(args.path);
+				const mappedPath = resolveBrowserRuntimePublicPath(args.path, manifest);
 				if (!mappedPath) {
 					return undefined;
 				}
@@ -280,11 +288,11 @@ export function createBrowserRuntimePlugin(options: CreateBrowserRuntimePluginOp
 					 * any manifest-owned specifiers. This avoids expensive oxc-parser calls
 					 * on every JS/TS file in the dependency graph.
 					 */
-					if (!specifierKeys.some((specifier) => code.includes(specifier))) {
+					if (!importMightReferenceRuntimeRoots(code, rootSpecifiers)) {
 						return undefined;
 					}
 
-					const rewritten = rewriteBrowserRuntimeImports(code, specifierMap, args.path);
+					const rewritten = rewriteBrowserRuntimeImports(code, manifest, args.path);
 
 					if (rewritten === code) {
 						return undefined;
@@ -300,6 +308,6 @@ export function createBrowserRuntimePlugin(options: CreateBrowserRuntimePluginOp
 		},
 	};
 
-	plugin[BROWSER_RUNTIME_IMPORT_REWRITE_MAP] = specifierMap;
+	plugin[BROWSER_RUNTIME_MANIFEST] = manifest;
 	return plugin;
 }

--- a/packages/core/src/build/rolldown/rolldown-adapter-helpers.ts
+++ b/packages/core/src/build/rolldown/rolldown-adapter-helpers.ts
@@ -15,10 +15,8 @@ import path from 'node:path';
 import type { InputOptions, OutputOptions, RolldownPlugin } from 'rolldown';
 import { isBarePackageImportSpecifier } from '../../plugins/tsconfig-import-resolver.ts';
 import type { EcoBuildPlugin } from '../contracts/build-types.ts';
-import {
-	collectBrowserRuntimeImportRewriteMap,
-	rewriteBrowserRuntimeImports,
-} from '../browser/browser-runtime-plugin.ts';
+import { collectBrowserRuntimeManifests, rewriteBrowserRuntimeImports } from '../browser/browser-runtime-plugin.ts';
+import { mergeBrowserRuntimeManifests } from '../browser/browser-runtime-manifest.ts';
 import { createServerSideCssShimPlugin } from './server-side-css-shim-plugin.ts';
 import { createRolldownPluginBridge } from './rolldown-plugin-bridge.ts';
 import {
@@ -461,14 +459,18 @@ export function rewriteBrowserRuntimeImportsInOutputs(
 		return result;
 	}
 
-	const specifierMap = collectBrowserRuntimeImportRewriteMap(plugins);
-	if (specifierMap.size === 0) {
+	const manifests = collectBrowserRuntimeManifests(plugins);
+	const manifest = mergeBrowserRuntimeManifests(...manifests);
+	if (manifest.assets.length === 0) {
 		return result;
 	}
 
 	const moduleRequireFromContext = createRequire(path.join(contextRoot, 'package.json'));
 	const fs = moduleRequireFromContext('node:fs') as typeof import('node:fs');
-	const cacheFingerprint = `${Array.from(specifierMap.entries()).sort().join('|')}`;
+	const cacheFingerprint = manifest.assets
+		.map((asset) => `${asset.specifier}->${asset.publicPath}`)
+		.sort()
+		.join('|');
 
 	for (const output of result.outputs) {
 		if (!/\.(?:[cm]?js)$/u.test(output.path)) {
@@ -481,7 +483,7 @@ export function rewriteBrowserRuntimeImportsInOutputs(
 			continue;
 		}
 
-		const rewritten = rewriteBrowserRuntimeImports(code, specifierMap, output.path);
+		const rewritten = rewriteBrowserRuntimeImports(code, manifest, output.path);
 		if (rewritten !== code) {
 			fs.writeFileSync(output.path, rewritten);
 		}

--- a/packages/core/src/dev/transform-server/dev-transform-import-rewriter.ts
+++ b/packages/core/src/dev/transform-server/dev-transform-import-rewriter.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { fileSystem } from '@ecopages/file-system';
 import { cachedParseSync } from '../../cache/module-parse-cache.ts';
 import { isBarePackageImportSpecifier, resolveProjectModulePath } from '../../plugins/tsconfig-import-resolver.ts';
+import { resolveRuntimeSpecifierPublicPath } from '../../build/browser/browser-runtime-manifest.ts';
 import { resolveDevTransformModuleUrl } from './dev-transform-url.ts';
 
 /**
@@ -160,7 +161,7 @@ async function resolveImportSpecifier(options: {
 	resolveVendorUrl: (specifier: string) => Promise<string>;
 	dependencies: Set<string>;
 }): Promise<string | undefined> {
-	const runtimeUrl = options.runtimeSpecifierMap.get(options.specifier);
+	const runtimeUrl = resolveRuntimeSpecifierPublicPath(options.specifier, options.runtimeSpecifierMap);
 	if (runtimeUrl) {
 		return runtimeUrl;
 	}

--- a/packages/core/src/dev/transform-server/dev-transform-vendor-registry.test.ts
+++ b/packages/core/src/dev/transform-server/dev-transform-vendor-registry.test.ts
@@ -73,6 +73,30 @@ describe('DevTransformVendorRegistry', () => {
 		expect(code).toMatch(/eco/);
 	});
 
+	it('does not alias package subpaths to a root runtime vendor', async () => {
+		const rootDir = createTempRoot('dev-transform-vendor-subpath');
+		fs.mkdirSync(path.join(rootDir, 'src'), { recursive: true });
+		fs.writeFileSync(
+			path.join(rootDir, 'package.json'),
+			JSON.stringify({ name: 'dev-transform-vendor-subpath', type: 'module' }, null, 2),
+			'utf8',
+		);
+
+		const config = await new ConfigBuilder().setRootDir(rootDir).setIntegrations([]).build();
+		installBuildRuntime(config);
+		const registry = new DevTransformVendorRegistry({
+			appConfig: config,
+			getRuntimeSpecifierMap: () => new Map([['@acme/ui', '/assets/vendors/acme-ui.development.js']]),
+		});
+
+		const vendorsDir = path.join(config.absolutePaths.distDir, 'assets', 'vendors');
+		fs.mkdirSync(vendorsDir, { recursive: true });
+		const vendorPath = path.join(vendorsDir, 'acme-ui.development.js');
+		fs.writeFileSync(vendorPath, 'export const shared = 1;');
+
+		expect(registry.resolveKnownVendorUrl('@acme/ui/button')).toBeUndefined();
+	});
+
 	it('reports an actionable error when a bare import resolves to a server-only entry', async () => {
 		const rootDir = createTempRoot('dev-transform-vendor-server-only');
 		fs.mkdirSync(path.join(rootDir, 'src'), { recursive: true });

--- a/packages/core/src/dev/transform-server/dev-transform-vendor-registry.ts
+++ b/packages/core/src/dev/transform-server/dev-transform-vendor-registry.ts
@@ -6,16 +6,25 @@ import { RESOLVED_ASSETS_VENDORS_DIR } from '../../config/constants.ts';
 import { getAppBrowserBuildPlugins } from '../../build/build-adapter.ts';
 import type { EcoBuildPlugin } from '../../build/contracts/build-types.ts';
 import { resolveBarePackageBrowserEntry } from '../../plugins/tsconfig-import-resolver.ts';
+import { toPackageRootSpecifier } from '../../plugins/package-specifier.ts';
+import { resolveRuntimeSpecifierPublicPath } from '../../build/browser/browser-runtime-manifest.ts';
 import { BrowserBundleService } from '../../services/assets/browser-bundle.service.ts';
 import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
 
-const BROWSER_VENDOR_CONDITIONS = ['browser', 'module', 'import', 'default'] as const;
+const BROWSER_FIRST_VENDOR_CONDITIONS = ['browser', 'module', 'import', 'default'] as const;
+const MODULE_FIRST_VENDOR_CONDITIONS = ['module', 'import', 'default'] as const;
 const BROWSER_NODE_BUILTIN_GUARD_MARKER = '[browser-build] Node builtin';
 
 type VendorEntry = {
 	url: string;
 	filePath: string;
 };
+
+function getVendorBundleConditions(specifier: string): readonly string[] {
+	return toPackageRootSpecifier(specifier) === '@ecopages/core'
+		? BROWSER_FIRST_VENDOR_CONDITIONS
+		: MODULE_FIRST_VENDOR_CONDITIONS;
+}
 
 export type DevTransformVendorRegistryOptions = {
 	appConfig: EcoPagesAppConfig;
@@ -45,7 +54,7 @@ export class DevTransformVendorRegistry {
 	}
 
 	resolveKnownVendorUrl(specifier: string): string | undefined {
-		return this.getRuntimeSpecifierMap().get(specifier);
+		return resolveRuntimeSpecifierPublicPath(specifier, this.getRuntimeSpecifierMap());
 	}
 
 	async resolveVendorUrl(specifier: string): Promise<string> {
@@ -149,7 +158,7 @@ export class DevTransformVendorRegistry {
 			externalPackages: false,
 			treeshaking: true,
 			splitting: false,
-			conditions: [...BROWSER_VENDOR_CONDITIONS],
+			conditions: [...getVendorBundleConditions(specifier)],
 			excludeAppBuildPlugins: getAppBrowserBuildPlugins(this.appConfig).map((plugin) => plugin.name),
 			plugins: [...vendorPlugins],
 		});

--- a/packages/core/src/plugins/package-specifier.test.ts
+++ b/packages/core/src/plugins/package-specifier.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { isSubpathOfPackageRoot, toPackageRootSpecifier } from './package-specifier.ts';
+
+test('toPackageRootSpecifier normalizes scoped and unscoped subpaths', () => {
+	assert.equal(toPackageRootSpecifier('@acme/ui'), '@acme/ui');
+	assert.equal(toPackageRootSpecifier('@acme/ui/button'), '@acme/ui');
+	assert.equal(toPackageRootSpecifier('lodash/debounce'), 'lodash');
+	assert.equal(toPackageRootSpecifier('./local'), './local');
+	assert.equal(toPackageRootSpecifier('node:fs'), 'node:fs');
+});
+
+test('isSubpathOfPackageRoot identifies package subpaths only', () => {
+	assert.equal(isSubpathOfPackageRoot('@acme/ui/button', '@acme/ui'), true);
+	assert.equal(isSubpathOfPackageRoot('@acme/ui', '@acme/ui'), false);
+	assert.equal(isSubpathOfPackageRoot('react-dom/client', 'react'), false);
+});

--- a/packages/core/src/plugins/package-specifier.ts
+++ b/packages/core/src/plugins/package-specifier.ts
@@ -1,0 +1,40 @@
+/**
+ * Normalizes bare npm import specifiers to their package root.
+ *
+ * @example
+ * toPackageRootSpecifier('@scope/pkg/sub/file') -> '@scope/pkg'
+ * toPackageRootSpecifier('lodash/debounce') -> 'lodash'
+ */
+export function toPackageRootSpecifier(specifier: string): string {
+	if (
+		specifier.startsWith('.') ||
+		specifier.startsWith('/') ||
+		specifier.startsWith('node:') ||
+		specifier.includes('://')
+	) {
+		return specifier;
+	}
+
+	if (specifier.startsWith('@')) {
+		const [scope, name, ...rest] = specifier.split('/');
+		if (!scope || !name) {
+			return specifier;
+		}
+
+		return rest.length > 0 ? `${scope}/${name}` : specifier;
+	}
+
+	const [name] = specifier.split('/');
+	return name ?? specifier;
+}
+
+/**
+ * Returns true when `specifier` is a subpath import of `packageRoot`.
+ */
+export function isSubpathOfPackageRoot(specifier: string, packageRoot: string): boolean {
+	if (specifier === packageRoot) {
+		return false;
+	}
+
+	return specifier.startsWith(`${packageRoot}/`);
+}

--- a/packages/core/src/plugins/tsconfig-import-resolver.browser-entry.test.ts
+++ b/packages/core/src/plugins/tsconfig-import-resolver.browser-entry.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test } from 'vitest';
+import { resolveBarePackageBrowserEntry } from './tsconfig-import-resolver.ts';
+
+const tempRoots: string[] = [];
+
+function createLegacyDualEntryFixture(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'browser-entry-fixture-'));
+	tempRoots.push(root);
+
+	const packageDir = path.join(root, 'node_modules', 'dual-entry-pkg');
+	const distDir = path.join(packageDir, 'dist');
+	fs.mkdirSync(distDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(packageDir, 'package.json'),
+		JSON.stringify(
+			{
+				name: 'dual-entry-pkg',
+				main: './dist/main.cjs',
+				module: './dist/module.mjs',
+				browser: './dist/browser.umd.js',
+			},
+			null,
+			2,
+		),
+	);
+	fs.writeFileSync(path.join(distDir, 'main.cjs'), 'module.exports = {};');
+	fs.writeFileSync(path.join(distDir, 'module.mjs'), 'export default {};');
+	fs.writeFileSync(path.join(distDir, 'browser.umd.js'), 'module.exports = {};');
+
+	return root;
+}
+
+function createExportsDualEntryFixture(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'browser-exports-fixture-'));
+	tempRoots.push(root);
+
+	const packageDir = path.join(root, 'node_modules', 'exports-dual-pkg');
+	const distDir = path.join(packageDir, 'dist');
+	fs.mkdirSync(distDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(packageDir, 'package.json'),
+		JSON.stringify(
+			{
+				name: 'exports-dual-pkg',
+				exports: {
+					'.': {
+						browser: './dist/browser.umd.js',
+						import: './dist/module.mjs',
+						default: './dist/main.cjs',
+					},
+				},
+			},
+			null,
+			2,
+		),
+	);
+	fs.writeFileSync(path.join(distDir, 'main.cjs'), 'module.exports = {};');
+	fs.writeFileSync(path.join(distDir, 'module.mjs'), 'export default {};');
+	fs.writeFileSync(path.join(distDir, 'browser.umd.js'), 'module.exports = {};');
+
+	return root;
+}
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test('resolveBarePackageBrowserEntry prefers module over browser for third-party packages', () => {
+	const root = createLegacyDualEntryFixture();
+	const resolved = resolveBarePackageBrowserEntry(root, 'dual-entry-pkg');
+	assert.ok(resolved);
+	assert.match(resolved, /module\.mjs$/);
+});
+
+test('resolveBarePackageBrowserEntry prefers import over browser exports for third-party packages', () => {
+	const root = createExportsDualEntryFixture();
+	const resolved = resolveBarePackageBrowserEntry(root, 'exports-dual-pkg');
+	assert.ok(resolved);
+	assert.match(resolved, /module\.mjs$/);
+});

--- a/packages/core/src/plugins/tsconfig-import-resolver.ts
+++ b/packages/core/src/plugins/tsconfig-import-resolver.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import path from 'node:path';
 import { ResolverFactory, type ResolverFactory as ResolverFactoryType } from 'oxc-resolver';
+import { toPackageRootSpecifier } from './package-specifier.ts';
 
 const RESOLVABLE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.mdx'] as const;
 
@@ -135,24 +136,51 @@ function getResolverFactory(projectRoot: string): ResolverFactoryType | undefine
 	return resolver;
 }
 
-const BROWSER_PACKAGE_CONDITION_NAMES = ['browser', 'module', 'import', 'default'] as const;
-const BROWSER_PACKAGE_MAIN_FIELDS = ['browser', 'module', 'main'] as const;
+const BROWSER_FIRST_CONDITION_NAMES = ['browser', 'module', 'import', 'default'] as const;
+/**
+ * Omit `browser` so package `exports` cannot select a legacy UMD facade when both
+ * `browser` and `import` conditions are published. Legacy `mainFields.browser`
+ * remains available after `module` for packages without `exports`.
+ */
+const MODULE_FIRST_CONDITION_NAMES = ['module', 'import', 'default'] as const;
+const BROWSER_FIRST_MAIN_FIELDS = ['browser', 'module', 'main'] as const;
+const MODULE_FIRST_MAIN_FIELDS = ['module', 'browser', 'main'] as const;
+
+/**
+ * Package roots that ship an explicit browser facade and must keep browser-first
+ * resolution during vendor prebundles.
+ *
+ * @remarks
+ * Prefer expanding this set only for dual packages whose `"browser"` / `exports.browser`
+ * entry is the intentional client facade (for example `@ecopages/core`).
+ */
+const BROWSER_FIRST_PACKAGE_ROOTS = new Set<string>(['@ecopages/core']);
 
 const browserPackageResolvers = new Map<string, ResolverFactoryType>();
 
-function getBrowserPackageResolver(projectRoot: string): ResolverFactoryType {
+function usesBrowserFirstPackageResolution(specifier: string): boolean {
+	const packageRoot = toPackageRootSpecifier(specifier);
+	return BROWSER_FIRST_PACKAGE_ROOTS.has(packageRoot);
+}
+
+function getBrowserPackageResolver(
+	projectRoot: string,
+	mainFields: readonly string[],
+	conditionNames: readonly string[],
+): ResolverFactoryType {
 	const normalizedRoot = path.resolve(projectRoot);
-	const cached = browserPackageResolvers.get(normalizedRoot);
+	const cacheKey = `${normalizedRoot}\0${mainFields.join(',')}\0${conditionNames.join(',')}`;
+	const cached = browserPackageResolvers.get(cacheKey);
 	if (cached) {
 		return cached;
 	}
 
 	const resolver = new ResolverFactory({
-		conditionNames: [...BROWSER_PACKAGE_CONDITION_NAMES],
-		mainFields: [...BROWSER_PACKAGE_MAIN_FIELDS],
+		conditionNames: [...conditionNames],
+		mainFields: [...mainFields],
 		extensions: [...RESOLVABLE_EXTENSIONS],
 	});
-	browserPackageResolvers.set(normalizedRoot, resolver);
+	browserPackageResolvers.set(cacheKey, resolver);
 	return resolver;
 }
 
@@ -160,12 +188,17 @@ function getBrowserPackageResolver(projectRoot: string): ResolverFactoryType {
  * Resolves a bare npm package entry for browser vendor prebundles.
  *
  * @remarks
- * Prefer package `"browser"` / `"exports.browser"` over Node `"import"` entries.
- * `createRequire().resolve()` is wrong here — it selects the server facade for
- * dual packages such as `@ecopages/core`.
+ * Framework-owned dual packages such as `@ecopages/core` keep browser-first
+ * `mainFields` and `conditionNames` so vendor prebundles pick the browser facade.
+ * Third-party packages prefer ESM (`module` / `import`) and omit the `browser`
+ * export condition so legacy UMD `exports.browser` entries cannot win during
+ * Rolldown bundling.
  */
 export function resolveBarePackageBrowserEntry(projectRoot: string, specifier: string): string | undefined {
-	const result = getBrowserPackageResolver(projectRoot).sync(projectRoot, specifier);
+	const browserFirst = usesBrowserFirstPackageResolution(specifier);
+	const mainFields = browserFirst ? BROWSER_FIRST_MAIN_FIELDS : MODULE_FIRST_MAIN_FIELDS;
+	const conditionNames = browserFirst ? BROWSER_FIRST_CONDITION_NAMES : MODULE_FIRST_CONDITION_NAMES;
+	const result = getBrowserPackageResolver(projectRoot, mainFields, conditionNames).sync(projectRoot, specifier);
 	if (result.error || !result.path) {
 		return undefined;
 	}

--- a/packages/core/src/route-renderer/orchestration/route-pipeline/route-prepared-options.builder.test.ts
+++ b/packages/core/src/route-renderer/orchestration/route-pipeline/route-prepared-options.builder.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { LocalsAccessError } from '../../../errors/locals-access-error.ts';
+import type { EcoPagesAppConfig } from '../../../types/internal-types.ts';
+import type {
+	EcoComponent,
+	EcoPageComponent,
+	HtmlTemplateProps,
+	RouteRendererOptions,
+} from '../../../types/public-types.ts';
+import { buildPreparedRenderOptions } from './route-prepared-options.builder.ts';
+
+describe('buildPreparedRenderOptions static locals guard', () => {
+	it('keeps the throwing proxy for ordinary static pages', () => {
+		const Page = (() => '<main>Page</main>') as unknown as EcoPageComponent<unknown>;
+		const HtmlTemplate = (() => '<html></html>') as EcoComponent<HtmlTemplateProps>;
+		const appConfig = {
+			cache: { defaultStrategy: 'static' },
+		} as EcoPagesAppConfig;
+
+		const result = buildPreparedRenderOptions({
+			routeOptions: {
+				file: '/app/pages/index.tsx',
+				params: {},
+				query: {},
+			} as RouteRendererOptions,
+			resolvedInputs: {
+				Page,
+				HtmlTemplate,
+				Layouts: [],
+				props: {},
+				metadata: { title: 'Page', description: 'Page' },
+				integrationSpecificProps: {},
+			},
+			resolvedDependencies: [],
+			allDependencies: [],
+			appConfig,
+		});
+
+		expect(() => Reflect.get(result.pageLocals as object, 'sessionUser')).toThrow(LocalsAccessError);
+	});
+});

--- a/packages/core/src/route-renderer/orchestration/route-pipeline/route-prepared-options.builder.ts
+++ b/packages/core/src/route-renderer/orchestration/route-pipeline/route-prepared-options.builder.ts
@@ -45,7 +45,6 @@ export function buildPreparedRenderOptions<C = unknown>(input: {
 		resolvedDependencies,
 		allDependencies,
 		pageBrowserGraph,
-		appConfig,
 	} = input;
 	const { Page, HtmlTemplate, Layouts, Layout, layoutEntries, props, metadata, integrationSpecificProps } =
 		resolvedInputs;
@@ -59,15 +58,9 @@ export function buildPreparedRenderOptions<C = unknown>(input: {
 		query: routeOptions.query || {},
 	};
 	const cacheStrategy = (Page as EcoPageComponent<any>).cache;
-	const defaultCacheStrategy = appConfig.cache?.defaultStrategy ?? 'static';
-	const effectiveCacheStrategy = cacheStrategy ?? defaultCacheStrategy;
-	const localsAvailable = effectiveCacheStrategy === 'dynamic' && routeOptions.locals !== undefined;
-
-	const pageLocals = localsAvailable
-		? routeOptions.locals!
-		: (createPageLocalsProxy(routeOptions.file) as RouteRendererOptions['locals']);
-
-	const locals = localsAvailable ? routeOptions.locals : undefined;
+	const pageLocals =
+		routeOptions.locals ?? (createPageLocalsProxy(routeOptions.file) as RouteRendererOptions['locals']);
+	const locals = routeOptions.locals;
 	const preparedOptions: IntegrationRendererRenderOptions<C> = {
 		...routeOptions,
 		resolvedPageDependencyComponents,

--- a/packages/core/src/route-renderer/orchestration/route-pipeline/route-prepared-options.semantic-error.test.ts
+++ b/packages/core/src/route-renderer/orchestration/route-pipeline/route-prepared-options.semantic-error.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { LocalsAccessError } from '../../../errors/locals-access-error.ts';
+import type { EcoPagesAppConfig } from '../../../types/internal-types.ts';
+import type {
+	EcoComponent,
+	EcoPageComponent,
+	HtmlTemplateProps,
+	RouteRendererOptions,
+} from '../../../types/public-types.ts';
+import { buildPreparedRenderOptions } from './route-prepared-options.builder.ts';
+
+describe('buildPreparedRenderOptions semantic error templates', () => {
+	it('uses safe empty locals when the matcher passes locals: {}', () => {
+		const Page = (() => '<main>Not found</main>') as unknown as EcoPageComponent<unknown>;
+		const HtmlTemplate = (() => '<html></html>') as EcoComponent<HtmlTemplateProps>;
+		const appConfig = {
+			cache: { defaultStrategy: 'static' },
+		} as EcoPagesAppConfig;
+
+		const result = buildPreparedRenderOptions({
+			routeOptions: {
+				file: '/app/pages/404.tsx',
+				params: {},
+				query: {},
+				locals: {},
+			} as RouteRendererOptions,
+			resolvedInputs: {
+				Page,
+				HtmlTemplate,
+				Layouts: [],
+				props: {},
+				metadata: { title: 'Not found', description: 'Not found' },
+				integrationSpecificProps: {},
+			},
+			resolvedDependencies: [],
+			allDependencies: [],
+			appConfig,
+		});
+
+		expect(result.locals).toEqual({});
+		expect(result.pageLocals).toEqual({});
+		expect(() => Reflect.get(result.pageLocals as object, 'sessionUser')).not.toThrow(LocalsAccessError);
+	});
+});

--- a/packages/core/src/route-renderer/orchestration/route-pipeline/route-render-orchestrator.prepare-render-options.test.ts
+++ b/packages/core/src/route-renderer/orchestration/route-pipeline/route-render-orchestrator.prepare-render-options.test.ts
@@ -1040,7 +1040,6 @@ describe('RouteRenderOrchestrator prepareRenderOptions', () => {
 				file: '/app/pages/index.tsx',
 				params: {},
 				query: {},
-				locals: { hidden: true },
 			} as unknown as RouteRendererOptions,
 			createFlowAdapter({
 				resolvePageModule: async () => ({

--- a/packages/core/src/services/assets/asset-processing-service/asset-processing.service.test.ts
+++ b/packages/core/src/services/assets/asset-processing-service/asset-processing.service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { fileSystem } from '@ecopages/file-system';
 import { AssetProcessingService } from './asset-processing.service';
 import type { AssetDefinition } from './assets.types';
+import { getBrowserRuntimeAssetGeneration } from '../browser-runtime-asset-generation';
 
 const Config = {
 	absolutePaths: {
@@ -632,6 +633,53 @@ test('AssetProcessingService - invalidateCacheForFile removes specific file from
 
 	await service.processDependencies([dependency], 'key2');
 	expect(processMock).toHaveBeenCalledTimes(2);
+});
+
+test('AssetProcessingService advances the browser runtime generation when a runtime source changes', async () => {
+	const previousNodeEnv = process.env.NODE_ENV;
+	process.env.NODE_ENV = 'development';
+	fileSystem.exists = vi.fn(() => true);
+	fileSystem.hash = vi
+		.fn()
+		.mockReturnValueOnce('source-v1')
+		.mockReturnValueOnce('source-v1')
+		.mockReturnValue('source-v2');
+
+	try {
+		const config = { ...Config } as any;
+		const service = new AssetProcessingService(config);
+		const processMock = vi
+			.fn()
+			.mockResolvedValueOnce({
+				filepath: '/test/dist/assets/vendors/runtime-v1.js',
+				kind: 'script',
+				inline: false,
+				packageRole: 'runtime',
+			})
+			.mockResolvedValueOnce({
+				filepath: '/test/dist/assets/vendors/runtime-v2.js',
+				kind: 'script',
+				inline: false,
+				packageRole: 'runtime',
+			});
+		service.registerProcessor('script', 'file', { process: processMock });
+
+		const dependency: AssetDefinition = {
+			kind: 'script',
+			source: 'file',
+			filepath: '/test/src/runtime.ts',
+			packageRole: 'runtime',
+		};
+
+		await service.processDependencies([dependency], 'runtime-generation');
+		expect(getBrowserRuntimeAssetGeneration(config)).toBe(0);
+
+		await service.processDependencies([dependency], 'runtime-generation');
+		expect(getBrowserRuntimeAssetGeneration(config)).toBe(1);
+		expect(processMock).toHaveBeenCalledTimes(2);
+	} finally {
+		process.env.NODE_ENV = previousNodeEnv;
+	}
 });
 
 test('AssetProcessingService - skips missing file dependencies', async () => {

--- a/packages/core/src/services/assets/asset-processing-service/asset-processing.service.ts
+++ b/packages/core/src/services/assets/asset-processing-service/asset-processing.service.ts
@@ -15,6 +15,7 @@ import { isHmrAware } from './processor.interface.ts';
 import { ProcessorRegistry } from './processor.registry.ts';
 import { processUngroupedDependency } from './ungrouped-dependency-processing.ts';
 import { materializeContentScriptAsset } from './materialize-content-script-asset.ts';
+import { bumpBrowserRuntimeAssetGeneration } from '../browser-runtime-asset-generation.ts';
 import {
 	ContentScriptProcessor,
 	ContentStylesheetProcessor,
@@ -298,7 +299,7 @@ export class AssetProcessingService {
 
 		const sourceHash = this.getFileSourceHash(dep);
 		if (dep.source === 'file' && sourceHash === undefined) {
-			this.cache.delete(depKey);
+			this.invalidateCachedAsset(depKey);
 			return null;
 		}
 
@@ -308,12 +309,12 @@ export class AssetProcessingService {
 		}
 
 		if (cached.sourceHash !== sourceHash) {
-			this.cache.delete(depKey);
+			this.invalidateCachedAsset(depKey);
 			return null;
 		}
 
 		if (cached.asset.filepath && !fileSystem.exists(cached.asset.filepath)) {
-			this.cache.delete(depKey);
+			this.invalidateCachedAsset(depKey);
 			return null;
 		}
 
@@ -350,10 +351,30 @@ export class AssetProcessingService {
 	 * Stores one processed asset in the dependency cache.
 	 */
 	private setCachedAsset(dep: AssetDefinition, depKey: string, asset: ProcessedAsset): void {
+		const previous = this.cache.get(depKey)?.asset;
+		const tracksBrowserRuntimeGeneration = dep.packageRole === 'runtime' || dep.packageRole === 'page-script';
+
 		this.cache.set(depKey, {
 			asset,
 			sourceHash: this.getFileSourceHash(dep),
 		});
+
+		if (tracksBrowserRuntimeGeneration && previous !== undefined && previous.filepath !== asset.filepath) {
+			void bumpBrowserRuntimeAssetGeneration(this.config);
+		}
+	}
+
+	/**
+	 * Removes a cached asset and advances the development HTML cache generation
+	 * when the removed asset can determine browser runtime URLs.
+	 */
+	private invalidateCachedAsset(depKey: string): void {
+		const cached = this.cache.get(depKey);
+		this.cache.delete(depKey);
+
+		if (cached?.asset.packageRole === 'runtime' || cached?.asset.packageRole === 'page-script') {
+			void bumpBrowserRuntimeAssetGeneration(this.config);
+		}
 	}
 
 	private getFileSourceHash(dep: AssetDefinition): string | undefined {
@@ -368,21 +389,33 @@ export class AssetProcessingService {
 	 * Clears all cached processed assets.
 	 */
 	clearCache(): void {
+		const invalidatesBrowserRuntime = Array.from(this.cache.values()).some(
+			({ asset }) => asset.packageRole === 'runtime' || asset.packageRole === 'page-script',
+		);
 		this.cache.clear();
+		if (invalidatesBrowserRuntime) {
+			void bumpBrowserRuntimeAssetGeneration(this.config);
+		}
 	}
 
 	/**
 	 * Removes cached assets that were produced from the given file path.
 	 */
 	invalidateCacheForFile(filepath: string): void {
+		let invalidatesBrowserRuntime = false;
 		for (const [key, value] of this.cache.entries()) {
 			if (
 				value.asset.filepath === filepath ||
 				value.asset.sourceFilepath === filepath ||
 				value.asset.bundledSourceFilepaths?.includes(filepath)
 			) {
+				invalidatesBrowserRuntime ||=
+					value.asset.packageRole === 'runtime' || value.asset.packageRole === 'page-script';
 				this.cache.delete(key);
 			}
+		}
+		if (invalidatesBrowserRuntime) {
+			void bumpBrowserRuntimeAssetGeneration(this.config);
 		}
 	}
 

--- a/packages/core/src/services/assets/browser-runtime-asset-generation.test.ts
+++ b/packages/core/src/services/assets/browser-runtime-asset-generation.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
+import { PageRequestCacheCoordinator } from '../cache/page-request-cache-coordinator.service.ts';
+import {
+	bumpBrowserRuntimeAssetGeneration,
+	getBrowserRuntimeAssetGeneration,
+} from './browser-runtime-asset-generation.ts';
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+afterEach(() => {
+	process.env.NODE_ENV = originalNodeEnv;
+});
+
+describe('browser runtime asset generation', () => {
+	it('includes generation in development cache keys and advances on bump', async () => {
+		process.env.NODE_ENV = 'development';
+		const appConfig = { rootDir: '/tmp/eco-runtime-gen' } as EcoPagesAppConfig;
+
+		expect(getBrowserRuntimeAssetGeneration(appConfig)).toBe(0);
+
+		const coordinator = new PageRequestCacheCoordinator(null, 'static', () =>
+			getBrowserRuntimeAssetGeneration(appConfig),
+		);
+		expect(coordinator.buildCacheKey({ pathname: '/' })).toBe('/#__eco_rt=0');
+
+		await bumpBrowserRuntimeAssetGeneration(appConfig);
+		expect(getBrowserRuntimeAssetGeneration(appConfig)).toBe(1);
+		expect(coordinator.buildCacheKey({ pathname: '/' })).toBe('/#__eco_rt=1');
+	});
+
+	it('does not append generation outside development', () => {
+		process.env.NODE_ENV = 'production';
+		const appConfig = { rootDir: '/tmp/eco-runtime-gen-prod' } as EcoPagesAppConfig;
+		const coordinator = new PageRequestCacheCoordinator(null, 'static', () =>
+			getBrowserRuntimeAssetGeneration(appConfig),
+		);
+
+		expect(coordinator.buildCacheKey({ pathname: '/' })).toBe('/');
+	});
+});

--- a/packages/core/src/services/assets/browser-runtime-asset-generation.ts
+++ b/packages/core/src/services/assets/browser-runtime-asset-generation.ts
@@ -1,0 +1,33 @@
+import type { EcoPagesAppConfig } from '../../types/internal-types.ts';
+import { clearAppPageCache } from '../cache/page-cache-service.ts';
+import { isDevelopmentRuntime } from '../../utils/runtime.ts';
+
+const generationByAppConfig = new WeakMap<EcoPagesAppConfig, number>();
+
+/**
+ * Returns the current browser-runtime asset generation for one app.
+ *
+ * @remarks
+ * Development HTML caches include this generation so rebuilt bootstrap and
+ * vendor URLs cannot leave stale script references behind.
+ */
+export function getBrowserRuntimeAssetGeneration(appConfig: EcoPagesAppConfig): number {
+	return generationByAppConfig.get(appConfig) ?? 0;
+}
+
+/**
+ * Bumps browser-runtime asset generation and clears rendered HTML cache entries.
+ *
+ * @remarks
+ * Only call this when a previously cached runtime/page-script asset filepath changes.
+ * First inserts must not bump generation or cold start thrash-clears the HTML cache.
+ */
+export async function bumpBrowserRuntimeAssetGeneration(appConfig: EcoPagesAppConfig): Promise<void> {
+	if (!isDevelopmentRuntime()) {
+		return;
+	}
+
+	const nextGeneration = getBrowserRuntimeAssetGeneration(appConfig) + 1;
+	generationByAppConfig.set(appConfig, nextGeneration);
+	await clearAppPageCache(appConfig);
+}

--- a/packages/core/src/services/cache/page-request-cache-coordinator.service.test.ts
+++ b/packages/core/src/services/cache/page-request-cache-coordinator.service.test.ts
@@ -3,13 +3,16 @@ import { PageRequestCacheCoordinator } from './page-request-cache-coordinator.se
 import type { PageCacheService } from './page-cache-service.js';
 
 describe('PageRequestCacheCoordinator', () => {
-	it('should build cache keys with query parameters', () => {
-		const service = new PageRequestCacheCoordinator(null, 'static');
-
-		expect(service.buildCacheKey({ pathname: '/blog' })).toBe('/blog');
-		expect(service.buildCacheKey({ pathname: '/blog', query: { page: '2', tag: 'eco' } })).toBe(
-			'/blog?page=2&tag=eco',
-		);
+	it('should include browser-runtime generation in development cache keys', () => {
+		const previousNodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'development';
+		try {
+			const service = new PageRequestCacheCoordinator(null, 'static', () => 7);
+			expect(service.buildCacheKey({ pathname: '/blog' })).toBe('/blog#__eco_rt=7');
+			expect(service.buildCacheKey({ pathname: '/blog', query: { page: '2' } })).toBe('/blog?page=2#__eco_rt=7');
+		} finally {
+			process.env.NODE_ENV = previousNodeEnv;
+		}
 	});
 
 	it('should bypass the cache service for dynamic pages', async () => {

--- a/packages/core/src/services/cache/page-request-cache-coordinator.service.ts
+++ b/packages/core/src/services/cache/page-request-cache-coordinator.service.ts
@@ -5,6 +5,7 @@ import {
 	isRequestPipelineMetricsEnabled,
 	serializeRequestPipelineMetricsHeader,
 } from '../../diagnostics/request-pipeline-metrics.ts';
+import { isDevelopmentRuntime } from '../../utils/runtime.ts';
 
 type CacheStatus = 'hit' | 'miss' | 'stale' | 'expired' | 'disabled';
 
@@ -18,10 +19,16 @@ type CacheStatus = 'hit' | 'miss' | 'stale' | 'expired' | 'disabled';
 export class PageRequestCacheCoordinator {
 	private cacheService: PageCacheService | null;
 	private defaultCacheStrategy: CacheStrategy;
+	private readonly getRuntimeAssetGeneration?: () => number;
 
-	constructor(cacheService: PageCacheService | null, defaultCacheStrategy: CacheStrategy) {
+	constructor(
+		cacheService: PageCacheService | null,
+		defaultCacheStrategy: CacheStrategy,
+		getRuntimeAssetGeneration?: () => number,
+	) {
 		this.cacheService = cacheService;
 		this.defaultCacheStrategy = defaultCacheStrategy;
+		this.getRuntimeAssetGeneration = getRuntimeAssetGeneration;
 	}
 
 	/**
@@ -39,6 +46,11 @@ export class PageRequestCacheCoordinator {
 			const queryString = new URLSearchParams(input.query).toString();
 			key += `?${queryString}`;
 		}
+
+		if (this.getRuntimeAssetGeneration && isDevelopmentRuntime()) {
+			key += `#__eco_rt=${this.getRuntimeAssetGeneration()}`;
+		}
+
 		return key;
 	}
 

--- a/packages/core/src/types/public-types.ts
+++ b/packages/core/src/types/public-types.ts
@@ -743,8 +743,9 @@ export type EcoHtmlComponent<T = EcoPagesElement> = EcoComponent<HtmlTemplatePro
 
 /**
  * Props type for the semantic `404.*` page template.
- * @remarks `message` and `stack` are declared for future error context. The
- * runtime does not currently pass these props when rendering the custom 404 page.
+ * @remarks Semantic error templates receive safe empty `pageLocals` rather than
+ * request-scoped locals. The runtime does not currently pass `message` / `stack`
+ * when rendering the custom 404 page.
  */
 export interface Error404TemplateProps extends Omit<HtmlTemplateProps, 'children'> {
 	message: string;
@@ -756,7 +757,8 @@ export interface Error404TemplateProps extends Omit<HtmlTemplateProps, 'children
  * @remarks In development, the page-pipeline passes `message` and `stack` from the
  * thrown error when rendering this page after a failure. In production those
  * fields are omitted so stacks are not serialized into HTML. Direct visits to
- * `/500` also omit them.
+ * `/500` also omit them. Semantic error templates receive safe empty
+ * `pageLocals` rather than request-scoped locals.
  */
 export interface Error500TemplateProps extends Omit<HtmlTemplateProps, 'children'> {
 	message?: string;

--- a/packages/integrations/react/README.md
+++ b/packages/integrations/react/README.md
@@ -254,6 +254,8 @@ Auto-discovery runs at plugin setup when **both** are true:
 
 Without `router`, only explicit `runtimeModules` entries are vendored.
 
+Semantic `404.*` / `500.*` templates render outside the page-request middleware pipeline. Do not use `cache: 'dynamic'`, `middleware`, or `requires` on those files; they receive safe empty `pageLocals` instead of request-scoped locals.
+
 #### Discovery modes
 
 | Mode                               | Trigger                                          | Layout roots scanned                                       | npm packages collected                                      |
@@ -341,9 +343,11 @@ Manual entries **override** auto-discovered entries for the same specifier.
 | Symptom                                    | Likely cause                                                                     | Fix                                                                                                  |
 | ------------------------------------------ | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `No QueryClient set` after SPA navigation  | Provider library bundled per page chunk                                          | Ensure `router` is enabled; add `runtimeProvider: true` on the provider layout; rebuild vendors      |
+| Duplicate React context / Tone init logs   | Provider package is bundled through multiple client entrypoints                  | Import through the package root and register that root in `runtimeModules`                           |
 | Wrong packages vendored (slow dev startup) | Shell layout scanned as discovery root                                           | Set `runtimeProvider: true` only on provider roots; keep shell layouts unflagged                     |
 | Package not discovered                     | Layout outside `layouts/` / `components/`, or import not reachable from `render` | Move layout file or add explicit `runtimeModules` entry                                              |
 | `@/` alias not followed                    | Missing or invalid tsconfig paths                                                | Add `compilerOptions.paths`; ensure `include` globs are valid JSON (not broken by comment stripping) |
+| Stale bootstrap script hash in dev         | Rendered HTML cached before runtime vendors/bootstrap scripts changed            | Rebuild or touch a route file; development HTML cache keys include browser-runtime generation        |
 
 #### Tests
 

--- a/packages/integrations/react/src/bundling/discover-layout-runtime-modules.ts
+++ b/packages/integrations/react/src/bundling/discover-layout-runtime-modules.ts
@@ -10,6 +10,7 @@ import {
 	isBarePackageImportSpecifier,
 	resolveProjectModulePath,
 } from '@ecopages/core/plugins/tsconfig-import-resolver';
+import { toPackageRootSpecifier } from '@ecopages/core/plugins/package-specifier';
 import { analyzeReachability } from '../client-graph/reachability-analyzer.ts';
 import { REACT_RUNTIME_SPECIFIERS } from './runtime-alias-map.ts';
 
@@ -74,16 +75,7 @@ export function isProviderRuntimeModulePath(filePath: string, source: string): b
  * Normalizes import specifiers to the package entry used for browser vendors.
  */
 export function normalizeRuntimePackageSpecifier(specifier: string): string {
-	if (specifier.startsWith('@')) {
-		const parts = specifier.split('/');
-		if (parts.length >= 2) {
-			return `${parts[0]}/${parts[1]}`;
-		}
-
-		return specifier;
-	}
-
-	return specifier.split('/')[0] ?? specifier;
+	return toPackageRootSpecifier(specifier);
 }
 
 function isAutoRuntimeExcludedPackage(packageRoot: string): boolean {

--- a/packages/integrations/react/src/bundling/runtime-modules.test.ts
+++ b/packages/integrations/react/src/bundling/runtime-modules.test.ts
@@ -62,4 +62,21 @@ describe('resolveReactPluginRuntimeModules', () => {
 			},
 		]);
 	});
+
+	it('preserves subpath runtime module declarations', () => {
+		expect(
+			resolveReactPluginRuntimeModules([
+				{
+					specifier: '@acme/ui/button',
+					outputName: 'acme-ui',
+				},
+			]),
+		).toEqual([
+			{
+				specifier: '@acme/ui/button',
+				outputName: 'acme-ui',
+				externals: [],
+			},
+		]);
+	});
 });

--- a/packages/integrations/react/src/client-graph/specifier-classification.ts
+++ b/packages/integrations/react/src/client-graph/specifier-classification.ts
@@ -3,6 +3,7 @@
  */
 
 import { loadTsconfigPathPrefixes, matchesTsconfigPathPrefix } from '@ecopages/core/plugins/tsconfig-import-resolver';
+import { toPackageRootSpecifier } from '@ecopages/core/plugins/package-specifier';
 import { dirname, resolve } from 'node:path';
 import type { RequestedExportRules } from './boundary-cache.ts';
 
@@ -56,18 +57,7 @@ export function isServerOnlySpecifier(specifier: string): boolean {
  * @returns The root package name, preserving scoped npm organizations.
  */
 export function toModuleBaseSpecifier(specifier: string): string {
-	if (!isBareSpecifier(specifier) || specifier.startsWith('node:')) {
-		return specifier;
-	}
-
-	if (specifier.startsWith('@')) {
-		const [scope, name] = specifier.split('/');
-		if (!scope || !name) return specifier;
-		return `${scope}/${name}`;
-	}
-
-	const [name] = specifier.split('/');
-	return name ?? specifier;
+	return toPackageRootSpecifier(specifier);
 }
 
 /**

--- a/packages/integrations/react/src/plugin/react.types.ts
+++ b/packages/integrations/react/src/plugin/react.types.ts
@@ -109,6 +109,10 @@ export type ReactPluginOptions = {
 	 * });
 	 * ```
 	 *
+	 * Manual entries override auto-discovered entries for the same specifier.
+	 * Subpath imports such as `@acme/ui/button` dedupe to the registered package
+	 * root vendor URL when `@acme/ui` is configured here or auto-discovered.
+	 *
 	 * @example Advanced vendor config
 	 * ```ts
 	 * runtimeModules: [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@
  * Opt-in suites: `scripts/vitest-optional-includes.ts` + `e2e/README.md`.
  */
 import { defineConfig, configDefaults } from 'vitest/config';
-import { getOptionalVitestIncludes } from './scripts/vitest-optional-includes';
+import { getOptionalVitestIncludes } from './scripts/vitest-optional-includes.ts';
 
 const isBunRuntime = typeof process.versions.bun === 'string';
 


### PR DESCRIPTION
## Summary

- Prefer ESM `module` / `import` entries for third-party browser vendor prebundles while keeping browser-first resolution for `@ecopages/core`.
- Attach browser runtime manifests to plugins so import rewriting and post-build output rewriting share one specifier map; dedupe equivalent manifest entries across owners.
- Invalidate development rendered HTML when runtime or page-script asset paths change so bootstrap/vendor URLs cannot go stale.
- Pass safe empty `locals` / `pageLocals` to semantic `404.*` / `500.*` templates instead of the throwing proxy.
- Add a shared package-root specifier helper and document the supported workspace vendor pattern (root import + `runtimeModules`).

## Test plan

- [x] `pnpm test:all` (local)
- [x] Focused vitest coverage for manifest rewrite, vendor resolution, asset generation, and semantic error templates