### PR TITLE
feat(docs): tighten chrome and compose CodeTabs with RuiTabs

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -6,7 +6,7 @@ It encompasses valuable information detailing its usage and provides a thorough 
 
 The aim is to offer users a clear understanding of how to effectively utilize ecopages and leverage its capabilities to their full extent.
 
-The docs shell uses `@ecopages/radiant-ui` for its responsive navigation, breadcrumb, tabs, alerts, buttons, and cycle theme toggle (`system` / `light` / `dark`). Sidebar and table-of-contents navigation listeners are registered only in the browser, so server rendering does not retain document listeners between pages.
+The docs shell uses `@ecopages/radiant-ui` for its responsive navigation, breadcrumb, tabs, alerts, buttons, and cycle theme toggle (`system` / `light` / `dark`). The docs sidebar is uncontrolled with `mobileDefaultOpen={false}`, so entering the mobile breakpoint closes the drawer without a page-level `rui-sidebar-mobile-change` listener. Table-of-contents navigation listeners are registered only in the browser, so server rendering does not retain document listeners between pages.
 Each MDX document imports the interactive components it renders, so client assets are scoped to the pages that use them.
 
 ## Local development

--- a/apps/docs/src/components/code-tabs/code-tabs.css
+++ b/apps/docs/src/components/code-tabs/code-tabs.css
@@ -2,18 +2,6 @@ radiant-code-tabs {
 	@apply block w-full min-w-0 max-w-full my-8;
 }
 
-.home-code-tabs {
-	@apply mt-8 block max-w-100;
-}
-
-radiant-code-tabs .rui-tabs__list {
-	@apply min-w-0 flex-nowrap overflow-x-auto;
-}
-
-radiant-code-tabs .rui-tabs__tab {
-	@apply shrink-0 text-xs;
-}
-
 .code-tabs__tab-label {
 	@apply inline-flex min-w-0 items-center gap-1.5;
 }
@@ -47,7 +35,7 @@ radiant-code-tabs .rui-tabs__panel {
 }
 
 .code-tabs__code {
-	@apply block w-full max-w-full min-w-0 text-[13px];
+	@apply block w-full max-w-full min-w-0 text-sm;
 
 	&:has([data-rehype-pretty-code-figure]) {
 		@apply flex min-h-0 w-full max-w-full flex-col overflow-y-hidden p-0;
@@ -63,11 +51,11 @@ radiant-code-tabs .rui-tabs__panel {
 }
 
 .code-tabs__copy {
-	@apply absolute right-1.5 top-1.5 z-10 inline-flex h-8 items-center justify-center rounded-sm border border-border bg-background px-2 text-sm text-on-background opacity-0 transition-opacity;
+	@apply absolute right-1.5 top-1.5 z-10 opacity-0;
 
 	&:hover,
 	&:focus-visible {
-		@apply border-primary/40 text-primary opacity-100;
+		@apply opacity-100;
 	}
 
 	.code-tabs__body:hover &,

--- a/apps/docs/src/components/code-tabs/code-tabs.script.tsx
+++ b/apps/docs/src/components/code-tabs/code-tabs.script.tsx
@@ -1,7 +1,7 @@
 import type { JsxCustomElementAttributes } from '@ecopages/jsx';
 import { unsafeHtml } from '@ecopages/jsx/jsx-runtime';
 import { RuiButton } from '@ecopages/radiant-ui/button';
-import { RuiTabs } from '@ecopages/radiant-ui/tabs';
+import { RuiTab, RuiTabList, RuiTabPanel, RuiTabPanels, RuiTabs } from '@ecopages/radiant-ui/tabs';
 import { RadiantElement, customElement, onEvent, prop, state } from '@ecopages/radiant';
 import { renderTabLabel } from './code-tab-icons';
 
@@ -92,21 +92,28 @@ export class RadiantCodeTabs extends RadiantElement {
 		return normalizedName ? `radiant-code-tabs-${normalizedName}` : this.instanceId;
 	}
 
-	private getTabId(tabId: string): string {
-		return `${this.getIdBase()}-tab-${tabId}`;
+	/**
+	 * @remarks `RuiTab` uses this as both `data-tab-value` and the HTML id suffix.
+	 * Prefixing keeps multiple code-tab hosts on one page from colliding.
+	 */
+	private tabDomId(tabId: string): string {
+		return `${this.getIdBase()}--${tabId}`;
 	}
 
-	private getPanelId(tabId: string): string {
-		return `${this.getIdBase()}-panel-${tabId}`;
+	private tabIdFromDomId(domId: string): string {
+		const prefix = `${this.getIdBase()}--`;
+		return domId.startsWith(prefix) ? domId.slice(prefix.length) : domId;
 	}
 
 	@onEvent({ selector: 'rui-tabs', type: 'rui-change' })
 	onTabChange(event: Event): void {
 		const detail = (event as CustomEvent<{ value?: string }>).detail;
-		if (detail?.value) {
-			this.selectedKey = detail.value;
-			this.dispatchEvent(new CustomEvent('change', { detail: { selectedKey: detail.value }, bubbles: true }));
+		if (!detail?.value) {
+			return;
 		}
+
+		this.selectedKey = this.tabIdFromDomId(detail.value);
+		this.dispatchEvent(new CustomEvent('change', { detail: { selectedKey: this.selectedKey }, bubbles: true }));
 	}
 
 	override render() {
@@ -120,43 +127,21 @@ export class RadiantCodeTabs extends RadiantElement {
 		const tabListLabel = this.label || 'Code examples';
 
 		return (
-			<RuiTabs variant="boxed" value={selectedKey} label={tabListLabel}>
-				<div class="rui-tabs__list code-tabs__list" role="tablist" aria-label={tabListLabel}>
-					{tabs.map((tab, index) => {
-						const isSelected = tab.id === selectedKey;
-
-						return (
-							<button
-								type="button"
-								class="rui-tabs__tab code-tabs__tab"
-								role="tab"
-								id={this.getTabId(tab.id)}
-								data-tab-value={tab.id}
-								data-tab-index={String(index)}
-								aria-controls={this.getPanelId(tab.id)}
-								aria-selected={isSelected}
-								tabIndex={isSelected ? 0 : -1}
-							>
-								{renderTabLabel({
-									id: tab.id,
-									label: tab.label,
-									code: tabClipboardText(tab),
-								})}
-							</button>
-						);
-					})}
-				</div>
-				<div class="rui-tabs__panels">
+			<RuiTabs variant="boxed" value={this.tabDomId(selectedKey)} label={tabListLabel}>
+				<RuiTabList aria-label={tabListLabel}>
 					{tabs.map((tab) => (
-						<div
-							class="rui-tabs__panel code-tabs__panel"
-							role="tabpanel"
-							id={this.getPanelId(tab.id)}
-							data-tab-value={tab.id}
-							aria-labelledby={this.getTabId(tab.id)}
-							tabIndex={0}
-							hidden={tab.id !== selectedKey}
-						>
+						<RuiTab id={this.tabDomId(tab.id)} selected={tab.id === selectedKey}>
+							{renderTabLabel({
+								id: tab.id,
+								label: tab.label,
+								code: tabClipboardText(tab),
+							})}
+						</RuiTab>
+					))}
+				</RuiTabList>
+				<RuiTabPanels>
+					{tabs.map((tab) => (
+						<RuiTabPanel id={this.tabDomId(tab.id)} selected={tab.id === selectedKey}>
 							<div class="code-tabs__body">
 								<span class="code-tabs__code">{isRichTab(tab) ? unsafeHtml(tab.html) : tab.code}</span>
 								<RuiButton
@@ -169,9 +154,9 @@ export class RadiantCodeTabs extends RadiantElement {
 									<span aria-hidden="true">Copy</span>
 								</RuiButton>
 							</div>
-						</div>
+						</RuiTabPanel>
 					))}
-				</div>
+				</RuiTabPanels>
 				<span class="code-tabs__status" aria-live="polite">
 					{this.copyStatus}
 				</span>

--- a/apps/docs/src/components/code-tabs/code-tabs.test.browser.ts
+++ b/apps/docs/src/components/code-tabs/code-tabs.test.browser.ts
@@ -66,7 +66,9 @@ describe('RadiantCodeTabs', () => {
 		expect(visibleSelectedPanels[0]?.textContent).toContain('echo bash');
 		expect(changeSpy).toHaveBeenCalledTimes(1);
 		expect(changeSpy.mock.calls[0]?.[0]).toMatchObject({ detail: { selectedKey: 'bash' } });
-		expect(document.activeElement?.getAttribute('data-tab-index')).toBe('2');
+		expect(document.activeElement?.getAttribute('data-tab-value')).toBe(
+			'radiant-code-tabs-image-processor-install--bash',
+		);
 	});
 
 	it('copies the active tab code and exposes transient status feedback', async () => {
@@ -120,14 +122,14 @@ describe('RadiantCodeTabs', () => {
 
 		await vi.waitFor(() => {
 			expect(codeTabs.querySelector<HTMLButtonElement>('[role="tab"]')?.id).toBe(
-				'radiant-code-tabs-image-processor-install-tab-js',
+				'tab-radiant-code-tabs-image-processor-install--js',
 			);
 		});
 
 		const activeTab = codeTabs.querySelector<HTMLButtonElement>('[role="tab"][aria-selected="true"]');
 		const panel = codeTabs.querySelector<HTMLDivElement>('[role="tabpanel"]');
-		expect(activeTab?.id).toBe('radiant-code-tabs-image-processor-install-tab-js');
-		expect(panel?.id).toBe('radiant-code-tabs-image-processor-install-panel-js');
+		expect(activeTab?.id).toBe('tab-radiant-code-tabs-image-processor-install--js');
+		expect(panel?.id).toBe('panel-radiant-code-tabs-image-processor-install--js');
 		expect(activeTab?.getAttribute('aria-controls')).toBe(panel?.id ?? null);
 		expect(panel?.getAttribute('aria-labelledby')).toBe(activeTab?.id ?? null);
 	});

--- a/apps/docs/src/components/copy-for-llm/copy-for-llm.css
+++ b/apps/docs/src/components/copy-for-llm/copy-for-llm.css
@@ -3,9 +3,6 @@ radiant-copy-for-llm {
 }
 
 .docs-copy-for-llm {
-	@apply inline-flex h-8 shrink-0 cursor-pointer items-center justify-center gap-2 rounded-sm border border-border bg-background px-3 text-sm text-on-background transition-all;
-	@apply hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background;
-
 	&[data-copied='true'] {
 		@apply text-primary;
 
@@ -20,10 +17,6 @@ radiant-copy-for-llm {
 
 	&[data-copy-error='true'] {
 		@apply border-secondary/60 text-secondary;
-	}
-
-	&:disabled {
-		@apply opacity-70;
 	}
 }
 

--- a/apps/docs/src/components/copy-for-llm/copy-for-llm.script.tsx
+++ b/apps/docs/src/components/copy-for-llm/copy-for-llm.script.tsx
@@ -4,6 +4,7 @@ import { onEvent } from '@ecopages/radiant/decorators/on-event';
 import { prop } from '@ecopages/radiant/decorators/prop';
 import { state } from '@ecopages/radiant/decorators/state';
 import type { JsxCustomElementAttributes } from '@ecopages/jsx';
+import { RuiButton } from '@ecopages/radiant-ui/button';
 import { copyForLlmCheckIcon, copyForLlmSparkleIcon } from './copy-for-llm-icons';
 
 export type CopyForLlmProps = {
@@ -93,8 +94,10 @@ export class RadiantCopyForLlm extends RadiantElement {
 
 	override render() {
 		return (
-			<button
+			<RuiButton
 				type="button"
+				size="sm"
+				variant="outline"
 				class="docs-copy-for-llm"
 				aria-label={this.label}
 				data-testid="copy-for-llm"
@@ -110,7 +113,7 @@ export class RadiantCopyForLlm extends RadiantElement {
 					{copyForLlmCheckIcon}
 				</span>
 				<span class="docs-copy-for-llm__label">{this.label}</span>
-			</button>
+			</RuiButton>
 		);
 	}
 }

--- a/apps/docs/src/components/copy-for-llm/copy-for-llm.test.browser.ts
+++ b/apps/docs/src/components/copy-for-llm/copy-for-llm.test.browser.ts
@@ -49,6 +49,13 @@ describe('RadiantCopyForLlm', () => {
 		vi.useRealTimers();
 	});
 
+	it('renders as a small RuiButton', async () => {
+		const { button } = await createCopyForLlm();
+
+		expect(button.classList.contains('rui-button')).toBe(true);
+		expect(button.classList.contains('rui-button--sm')).toBe(true);
+	});
+
 	it('copies markdown and shows the copied state', async () => {
 		const { button } = await createCopyForLlm();
 		button.click();

--- a/apps/docs/src/components/header/header.css
+++ b/apps/docs/src/components/header/header.css
@@ -3,14 +3,10 @@
 	@apply bg-background-accent border-b border-border;
 
 	&__inner {
-		@apply h-16 px-6 md:px-8 py-3 max-w-7xl w-full mx-auto flex items-center justify-between;
+		@apply h-16 px-4 md:px-8 py-3 max-w-7xl w-full mx-auto flex items-center justify-between;
 
 		&-left {
-			@apply flex items-center gap-4;
-
-			.version {
-				@apply text-xs font-heading font-medium tracking-tight bg-background text-on-background/90 px-2 py-0.5 rounded border border-border;
-			}
+			@apply flex min-w-0 items-center gap-2 md:gap-4;
 		}
 	}
 }

--- a/apps/docs/src/components/header/header.tsx
+++ b/apps/docs/src/components/header/header.tsx
@@ -1,4 +1,6 @@
 import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+import { RuiChip } from '@ecopages/radiant-ui/chip';
 import { Burger } from '@/components/burger';
 import { Logo } from '@/components/logo/logo';
 import { Navigation, type NavigationProps } from '@/components/navigation';
@@ -9,7 +11,7 @@ export type HeaderProps = {
 	showBurger?: boolean;
 };
 
-export const Header = eco.component<HeaderProps>({
+export const Header = eco.component<HeaderProps, JsxRenderable>({
 	dependencies: {
 		stylesheets: ['./header.css'],
 		components: [Navigation, Logo, Burger],
@@ -21,7 +23,9 @@ export const Header = eco.component<HeaderProps>({
 					<div class="header__inner-left">
 						{showBurger ? <Burger class="md:hidden" /> : null}
 						<Logo href="/" target="_self" title="Ecopages" />
-						<p class="version">v {rootJson.version}</p>
+						<RuiChip variant="default" class="max-md:hidden">
+							{rootJson.version}
+						</RuiChip>
 					</div>
 					<Navigation {...navigation} />
 				</div>

--- a/apps/docs/src/components/logo/logo.tsx
+++ b/apps/docs/src/components/logo/logo.tsx
@@ -9,7 +9,7 @@ export const Logo = eco.component<LogoProps, JsxRenderable>({
 	dependencies: {
 		stylesheets: ['./logo.css'],
 	},
-	render: ({ children = 'ecopages', href, target, title }) => {
+	render: ({ children = 'Ecopages', href, target, title }) => {
 		return (
 			<a
 				href={href}
@@ -17,7 +17,7 @@ export const Logo = eco.component<LogoProps, JsxRenderable>({
 				title={title}
 				class="flex gap-1 items-center text-2xl font-semibold font-heading"
 			>
-				<svg height="32" viewBox="0 0 35 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<svg height="32" viewBox="0 0 35 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
 					<path
 						d="M8.95038 19.0355C8.73635 19.7972 10.4934 24.8245 18.2298 23.3884C25.3299 22.0704 24.7298 10.8884 18.2298 13.8884C14.2596 15.7208 12.2883 33.409 22.2298 31.8884C29.9216 30.7119 28.75 6.88572 31.434 1.38842C28.4393 4.49823 5.89504 5.06009 2.22981 17.8884C1.27183 21.2414 3.22979 26.8884 8.95036 28.3884L2.22981 38.3884"
 						stroke="currentColor"

--- a/apps/docs/src/components/navigation/navigation.tsx
+++ b/apps/docs/src/components/navigation/navigation.tsx
@@ -10,6 +10,7 @@ export type NavigationProps = {
 		target?: '_blank' | '_self';
 		rel?: string;
 		'aria-label'?: string;
+		class?: string;
 	}[];
 };
 
@@ -22,8 +23,8 @@ export const Navigation = eco.component<NavigationProps, JsxRenderable>({
 		return (
 			<nav class="navigation" aria-label="Site">
 				<ul>
-					{items.map(({ label, href, target = '_self', rel, 'aria-label': ariaLabel }) => (
-						<li>
+					{items.map(({ label, href, target = '_self', rel, 'aria-label': ariaLabel, class: className }) => (
+						<li class={className}>
 							<RuiButton
 								href={href}
 								target={target}

--- a/apps/docs/src/layouts/base-layout/base-layout.tsx
+++ b/apps/docs/src/layouts/base-layout/base-layout.tsx
@@ -29,6 +29,7 @@ export const BaseLayout = eco.component<BaseLayoutProps, JsxRenderable>({
 											{
 												label: 'Docs',
 												href: '/docs/getting-started/introduction',
+												class: 'max-md:hidden',
 											},
 										]
 									: []),

--- a/apps/docs/src/layouts/docs-layout/docs-layout.css
+++ b/apps/docs/src/layouts/docs-layout/docs-layout.css
@@ -10,6 +10,14 @@
 	@apply min-h-svh h-svh min-w-0;
 	--rui-sidebar-background: var(--color-background);
 
+	.rui-sidebar-provider__site-header-inner {
+		@apply px-4 md:px-8;
+	}
+
+	.rui-sidebar-provider__site-header-start {
+		@apply min-w-0 gap-2 md:gap-4;
+	}
+
 	.docs-layout__content {
 		@apply min-w-0 flex-1 overflow-y-auto px-6 py-8 md:px-10 lg:px-12 md:py-10;
 	}

--- a/apps/docs/src/layouts/docs-layout/docs-layout.script.ts
+++ b/apps/docs/src/layouts/docs-layout/docs-layout.script.ts
@@ -5,11 +5,8 @@ import '@ecopages/radiant-ui/sidebar';
 import '@ecopages/radiant-ui/toc';
 
 const docsContentSelector = '.docs-layout__content';
-const docsSidebarId = 'docs-sidebar';
 
 type DocsNavigationEvent = CustomEvent<{ url: URL }>;
-type SidebarMobileChangeEvent = CustomEvent<{ mobile: boolean }>;
-type SidebarControl = HTMLElement & { setOpen(next: boolean): void };
 
 function scrollDocsToTop(): void {
 	document.querySelector<HTMLElement>(docsContentSelector)?.scrollTo({ top: 0, left: 0, behavior: 'instant' });
@@ -22,17 +19,4 @@ document.addEventListener('eco:after-swap', (event) => {
 	}
 
 	scrollDocsToTop();
-});
-
-document.addEventListener('rui-sidebar-mobile-change', (event) => {
-	const sidebar = event.target;
-	if (
-		!(sidebar instanceof HTMLElement) ||
-		sidebar.id !== docsSidebarId ||
-		!(event as SidebarMobileChangeEvent).detail.mobile
-	) {
-		return;
-	}
-
-	(sidebar as SidebarControl).setOpen(false);
 });

--- a/apps/docs/src/layouts/docs-layout/docs-layout.tsx
+++ b/apps/docs/src/layouts/docs-layout/docs-layout.tsx
@@ -79,7 +79,9 @@ const DocsSiteHeader = () => (
 				triggerLabel="Open documentation navigation"
 			/>
 			<Logo href="/" target="_self" title="Ecopages" />
-			<RuiChip variant="default">v {rootJson.version}</RuiChip>
+			<RuiChip variant="default" class="max-md:hidden">
+				{rootJson.version}
+			</RuiChip>
 		</div>
 		<nav class="rui-sidebar-provider__site-header-nav" aria-label="Site">
 			<RuiButton

--- a/apps/docs/src/pages/index.css
+++ b/apps/docs/src/pages/index.css
@@ -23,16 +23,11 @@
 
 	radiant-code-tabs,
 	rui-tabs,
-	.rui-tabs__panels,
 	.rui-tabs__panel,
 	.code-tabs__body,
 	.code-tabs__code,
 	.home-code-block {
 		@apply flex min-h-0 flex-1 flex-col;
-	}
-
-	rui-tabs {
-		@apply rounded-none;
 	}
 
 	radiant-code-tabs {
@@ -117,9 +112,9 @@
 }
 
 .home-code-block[data-rehype-pretty-code-figure] {
-	@apply my-0 border-0 rounded-sm rounded-b-none border border-border bg-background-accent overflow-x-auto;
+	@apply my-0 overflow-x-auto rounded-none border-0 bg-background-accent;
 
 	pre code {
-		@apply font-mono text-[0.875em] leading-relaxed;
+		@apply font-mono text-sm leading-relaxed;
 	}
 }

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -90,6 +90,7 @@ export default eco.page<{}, JsxRenderable>({
 						</RuiHeading>
 
 						<CodeTabs
+							name="home-package-managers"
 							label="Package managers"
 							tabs={[
 								{
@@ -122,6 +123,7 @@ export default eco.page<{}, JsxRenderable>({
 
 					<div class="home-hero__code">
 						<CodeTabs
+							name="home-starter-files"
 							label="Starter files"
 							tabs={[
 								{

--- a/examples/docs-starter/src/components/copy-for-llm/copy-for-llm.css
+++ b/examples/docs-starter/src/components/copy-for-llm/copy-for-llm.css
@@ -3,9 +3,6 @@ radiant-copy-for-llm {
 }
 
 .docs-copy-for-llm {
-	@apply inline-flex h-8 shrink-0 cursor-pointer items-center justify-center gap-2 rounded-sm border border-border bg-background px-3 text-sm text-on-background transition-all;
-	@apply hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background;
-
 	&[data-copied='true'] {
 		@apply text-primary;
 
@@ -20,10 +17,6 @@ radiant-copy-for-llm {
 
 	&[data-copy-error='true'] {
 		@apply border-secondary/60 text-secondary;
-	}
-
-	&:disabled {
-		@apply opacity-70;
 	}
 }
 

--- a/examples/docs-starter/src/components/copy-for-llm/copy-for-llm.script.tsx
+++ b/examples/docs-starter/src/components/copy-for-llm/copy-for-llm.script.tsx
@@ -4,6 +4,7 @@ import { onEvent } from '@ecopages/radiant/decorators/on-event';
 import { prop } from '@ecopages/radiant/decorators/prop';
 import { state } from '@ecopages/radiant/decorators/state';
 import type { JsxCustomElementAttributes } from '@ecopages/jsx';
+import { RuiButton } from '@ecopages/radiant-ui/button';
 import { copyForLlmCheckIcon, copyForLlmSparkleIcon } from './copy-for-llm-icons';
 
 export type CopyForLlmProps = {
@@ -93,8 +94,10 @@ export class RadiantCopyForLlm extends RadiantElement {
 
 	override render() {
 		return (
-			<button
+			<RuiButton
 				type="button"
+				size="sm"
+				variant="outline"
 				class="docs-copy-for-llm"
 				aria-label={this.label}
 				data-testid="copy-for-llm"
@@ -110,7 +113,7 @@ export class RadiantCopyForLlm extends RadiantElement {
 					{copyForLlmCheckIcon}
 				</span>
 				<span class="docs-copy-for-llm__label">{this.label}</span>
-			</button>
+			</RuiButton>
 		);
 	}
 }

--- a/examples/docs-starter/src/layouts/docs-layout/docs-layout.css
+++ b/examples/docs-starter/src/layouts/docs-layout/docs-layout.css
@@ -5,6 +5,14 @@
 .docs-layout {
 	@apply min-h-svh h-svh min-w-0;
 
+	.rui-sidebar-provider__site-header-inner {
+		@apply px-4 md:px-8;
+	}
+
+	.rui-sidebar-provider__site-header-start {
+		@apply min-w-0 gap-2 md:gap-4;
+	}
+
 	.docs-layout__content {
 		@apply min-w-0 flex-1 overflow-y-auto px-6 py-6 md:px-10 md:py-10 lg:px-12;
 	}

--- a/examples/docs-starter/src/layouts/docs-layout/docs-layout.tsx
+++ b/examples/docs-starter/src/layouts/docs-layout/docs-layout.tsx
@@ -95,6 +95,7 @@ export const DocsLayout = eco.layout<JsxRenderable>({
 							collapsible="off"
 							defaultWidth={250}
 							mobileBreakpoint={768}
+							mobileDefaultOpen={false}
 							label="Documentation navigation"
 							matchActive
 							scrollActiveOnMount


### PR DESCRIPTION
## Summary
- Tighten docs and starter header chrome: version chip without a `v` prefix, hide Docs on small screens, denser header padding/gap, and close the mobile sidebar via `mobileDefaultOpen` instead of a page listener.
- Render Copy for LLM as a small outline `RuiButton` in the docs app and docs-starter.
- Compose CodeTabs from boxed `RuiTab` primitives, prefix tab DOM ids to avoid collisions, and keep homepage code at `text-sm`.

## Test plan
- [x] Homepage and docs headers at `md+`: version chip, Docs link, padding, and logo look correct.
- [x] Below `md`: Docs link and version chip are hidden; mobile sidebar starts closed and can still be opened.
- [x] Copy for LLM is a small outline RuiButton and still copies / shows copied / error states.
- [x] Homepage CodeTabs look like boxed RuiTabs; switching tabs works when two hosts share the page.