### PR TITLE
fix(core): preserve grouped page-browser asset order

### DIFF
--- a/packages/core/src/route-renderer/orchestration/page-browser-graph/page-browser-graph.service.test.ts
+++ b/packages/core/src/route-renderer/orchestration/page-browser-graph/page-browser-graph.service.test.ts
@@ -598,6 +598,59 @@ test('does not commit an in-flight graph after one of its watch paths changes', 
 	expect(builds).toBe(2);
 });
 
+test('preserves processed grouped-asset order for a route', async () => {
+	const routeFile = '/app/pages/docs/index.tsx';
+	const dependencyInstanceKey = createPageDependencyInstanceKey({});
+	const firstDependency: AssetDefinition = {
+		kind: 'script',
+		source: 'content',
+		content: 'console.log("first")',
+		name: 'first',
+		groupedBundle: { id: 'docs', entryName: 'first' },
+	};
+	const secondDependency: AssetDefinition = {
+		kind: 'script',
+		source: 'content',
+		content: 'console.log("second")',
+		name: 'second',
+		groupedBundle: { id: 'docs', entryName: 'second' },
+	};
+	const contribution = { dependencies: [firstDependency, secondDependency] };
+	const groupedBuildPlan = {
+		integrationName: 'react',
+		planKey: createGroupedGraphBuildPlanKey('react', [{ routeFile, dependencyInstanceKey }]),
+		instances: [{ routeFile, dependencyInstanceKey, contribution }],
+	};
+	const assetProcessingService = {
+		processDependencies: vi.fn(async (): Promise<ProcessedAsset[]> => [
+			{
+				kind: 'script',
+				inline: false,
+				filepath: '/assets/second.js',
+				groupedBundle: secondDependency.groupedBundle,
+			},
+			{
+				kind: 'script',
+				inline: false,
+				filepath: '/assets/first.js',
+				groupedBundle: firstDependency.groupedBundle,
+			},
+		]),
+		getHmrManager: vi.fn(() => ({ isEnabled: () => false })),
+	} as unknown as AssetProcessingService;
+	const service = new PageBrowserGraphService(appConfig, assetProcessingService);
+
+	const result = await service.resolvePageBrowserGraph({
+		routeFile,
+		dependencyInstanceKey,
+		integrationName: 'react',
+		collectContribution: async () => contribution,
+		groupedBuildPlan,
+	});
+
+	expect(result?.entryAssets.map((asset) => asset.filepath)).toEqual(['/assets/second.js', '/assets/first.js']);
+});
+
 test('processes grouped assets once for a large set of static dependency instances', async () => {
 	const routeFile = '/app/pages/docs/[...slug]/index.tsx';
 	const instances = Array.from({ length: 1_000 }, (_, index) => {

--- a/packages/core/src/route-renderer/orchestration/page-browser-graph/page-browser-graph.service.ts
+++ b/packages/core/src/route-renderer/orchestration/page-browser-graph/page-browser-graph.service.ts
@@ -34,6 +34,31 @@ function getGroupedBundleAssetKey(groupedBundle: { id: string; entryName: string
 	return `${groupedBundle.id}:${groupedBundle.entryName}`;
 }
 
+type IndexedGroupedAsset = {
+	asset: ProcessedAsset;
+	index: number;
+};
+
+function indexGroupedAssetsByBundleKey(processedAssets: ProcessedAsset[]): Map<string, IndexedGroupedAsset[]> {
+	const assetsByBundleKey = new Map<string, IndexedGroupedAsset[]>();
+
+	for (const [index, asset] of processedAssets.entries()) {
+		if (!asset.groupedBundle) {
+			continue;
+		}
+
+		const bundleKey = getGroupedBundleAssetKey(asset.groupedBundle);
+		const assets = assetsByBundleKey.get(bundleKey);
+		if (assets) {
+			assets.push({ asset, index });
+		} else {
+			assetsByBundleKey.set(bundleKey, [{ asset, index }]);
+		}
+	}
+
+	return assetsByBundleKey;
+}
+
 type GroupedPageBrowserAssetsResult = {
 	assetsByRoute: Map<string, ProcessedAsset[]>;
 	dependencyPaths: ReadonlySet<string>;
@@ -326,15 +351,13 @@ export class PageBrowserGraphService {
 			`${input.integrationName}:grouped-page-browser-graph`,
 		);
 		const groupedAssetsByRoute = new Map<string, ProcessedAsset[]>();
+		const groupedAssetsByBundleKey = indexGroupedAssetsByBundleKey(processedGroupedDependencies);
 
 		for (const [routeFile, groupedAssetKeys] of groupedAssetKeysByRoute) {
-			const matchedAssets = processedGroupedDependencies.filter((asset) => {
-				if (!asset.groupedBundle) {
-					return false;
-				}
-
-				return groupedAssetKeys.has(getGroupedBundleAssetKey(asset.groupedBundle));
-			});
+			const matchedAssets = [...groupedAssetKeys]
+				.flatMap((assetKey) => groupedAssetsByBundleKey.get(assetKey) ?? [])
+				.sort((left, right) => left.index - right.index)
+				.map(({ asset }) => asset);
 
 			if (groupedAssetKeys.size > 0 && matchedAssets.length === 0) {
 				appLogger.warn(


### PR DESCRIPTION
## Summary
- Index grouped page-browser assets by bundle key instead of filtering the full processed list per route.
- Keep processed asset order when matching a route's grouped bundle keys.

Independent of the ghtml removal stack.

## Test plan
- [x] `page-browser-graph.service` unit tests pass, including the new order-preservation case
- [x] Grouped browser graphs still emit shared assets without cross-route leakage