### PR TITLE
docs: drop ghtml defaults and add Integration authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ The result is fast static pages, minimal dependencies, and code you can actually
 
 ## Built With
 
-Ecopages runs on [Bun](https://bun.sh/) and [Node.js](https://nodejs.org/), and uses [Ghtml](https://github.com/gurgunday/ghtml) for rendering. Extend it with templating integrations:
+Ecopages runs on [Bun](https://bun.sh/) and [Node.js](https://nodejs.org/). Start with the first-party Ecopages JSX integration, or register another Integration that owns the route file types you use.
 
 Ecopages supports multiple rendering libraries via plug-and-play integrations. Because Ecopages is an SSG framework operating at build-time, you must explicitly install both the integration plugin and its underlying renderer as development dependencies.
 
-- **[KitaJS](https://kitajs.org/html/)** – Fast JSX template (Recommended choice)
+- **Ecopages JSX** – Ecopages-owned JSX routes and optional Radiant hydration (Recommended choice)
+  `pnpm add -D @ecopages/ecopages-jsx @ecopages/jsx @ecopages/radiant`
+- **[KitaJS](https://kitajs.org/html/)** – Fast JSX template
   `pnpm add -D @ecopages/kitajs @kitajs/html`
 - **[Lit](https://lit.dev/)** – Web Components with SSR
   `pnpm add -D @ecopages/lit lit`

--- a/apps/docs/src/content/docs/core/components.mdx
+++ b/apps/docs/src/content/docs/core/components.mdx
@@ -6,150 +6,43 @@ order: 9
 
 # Creating Components in Ecopages
 
-Components are reusable UI units composed into pages and layouts. With **Ecopages JSX**, components are typically `.tsx` files using `eco.component` and JSX in `render`. The examples below use Radiant for client interactivity; the same dependency and lazy-loading patterns apply across integrations.
+Components are reusable UI units composed into Pages and Layouts. The default starter uses Ecopages JSX, so these examples use `.tsx` files and JSX in `render`.
 
-## Basic Component Structure
+## A component with browser behavior
 
-A typical component in Ecopages consists of two files:
+Declare the styles, browser scripts, and child Components a Component needs. Ecopages uses that declaration to collect assets and preserve Integration ownership.
 
-1. A `.ts` file for the component's structure and logic
-2. A `.script.ts` file for additional client-side interactivity (optional)
-3. A `.css` file for styling (optional)
-
-Let's create a simple counter component to demonstrate this structure, we will use the Radiant library from [@ecopages/radiant](https://radiant.ecopages.app/) to add client-side interactivity.
-
-## RadiantCounter.ts
-
-```typescript
+```tsx
 import { eco } from '@ecopages/core';
-import { html } from '@ecopages/core/html';
-import type { RadiantCounterProps } from './radiant-counter.script';
+import type { JsxRenderable } from '@ecopages/jsx';
 
-export const RadiantCounter = eco.component<RadiantCounterProps>({
+type RadiantCounterProps = { count: number };
+
+export const RadiantCounter = eco.component<RadiantCounterProps, JsxRenderable>({
 	dependencies: {
-		scripts: ['./radiant-counter.script.ts'],
 		stylesheets: ['./radiant-counter.css'],
-	},
-	render: ({ count }) => html`
-	<radiant-counter count="${count}">
-		<button type="button" data-ref="decrement" aria-label="Decrement">-</button>
-		<span data-ref="count">${count}</span>
-		<button type="button" data-ref="increment" aria-label="Increment">+</button>
-	</radiant-counter>
-	`,
-});
-```
-
-### radiant-counter.script.ts
-
-```typescript
-import { RadiantElement } from '@ecopages/radiant/core';
-import { customElement } from '@ecopages/radiant/decorators/custom-element';
-import { onEvent } from '@ecopages/radiant/decorators/on-event';
-import { onUpdated } from '@ecopages/radiant/decorators/on-updated';
-import { query } from '@ecopages/radiant/decorators/query';
-import { reactiveProp } from '@ecopages/radiant/decorators/reactive-prop';
-
-export type RadiantCounterProps = {
-	value?: number;
-};
-
-@customElement('radiant-counter')
-export class RadiantCounter extends RadiantElement {
-	@reactiveProp({ type: Number, reflect: true }) declare value: number;
-	@query({ ref: 'count' }) countText!: HTMLElement;
-
-	@onEvent({ ref: 'decrement', type: 'click' })
-	decrement() {
-		if (this.value > 0) this.value--;
-	}
-
-	@onEvent({ ref: 'increment', type: 'click' })
-	increment() {
-		this.value++;
-	}
-
-	@onUpdated('value')
-	updateCount() {
-		this.countText.textContent = this.value.toString();
-		this.dispatchEvent(new Event('change'));
-	}
-
-}
-
-declare global {
-	namespace JSX {
-		interface IntrinsicElements {
-			'radiant-counter': HtmlTag & RadiantCounterProps;
-		}
-	}
-}
-
-```
-
-
-## Key Points
-
-- Use the `eco.component` factory from `@ecopages/core`.
-- Pass dependencies and render function to `eco.component`.
-- Define props using an interface and pass it as a generic type.
-- Use custom elements for client-side interactivity.
-
-## Component Config
-
-The `eco.component` factory automatically handles the configuration attachment. You simply define the dependencies within the factory options.
-
-```typescript
-export const RadiantCounter = eco.component({
-	dependencies: {
-		scripts: ['./radiant-counter.script.ts'],
-		stylesheets: ['./radiant-counter.css'],
-	},
-	render: (props) => { ... }
-});
-```
-
-Mandatory fields in options:
-
-1. `render`: Function that returns the component's HTML.
-2. `dependencies`: (Optional within `eco.component` but recommended if needed) Object specifying scripts, stylesheets, and sub-components.
-
-## Lazy Loading
-
-Ecopages supports lazy loading of component scripts to improve initial page load performance. This is configured per script entry in `dependencies.scripts`.
-
-```typescript
-export const RadiantCounter = eco.component({
-	dependencies: {
 		scripts: [{ src: './radiant-counter.script.ts', lazy: { 'on:interaction': 'mouseenter,focusin' } }],
-		stylesheets: ['./radiant-counter.css'],
 	},
-	render: (props) => { ... }
+	render: ({ count }) => (
+		<radiant-counter count={count}>
+			<button type="button" data-ref="decrement" aria-label="Decrement">-</button>
+			<span data-ref="count">{count}</span>
+			<button type="button" data-ref="increment" aria-label="Increment">+</button>
+		</radiant-counter>
+	),
 });
 ```
 
-When you look at the rendered HTML, you will see that Ecopages automatically wraps your component with a `scripts-injector` custom element. This element handles the loading of your scripts based on the defined triggers (e.g., interaction or visibility).
+Radiant support is enabled by default when you configure `ecopagesJsxPlugin()`. Its SSR output becomes an island only when the Component brings browser behavior.
 
-## CSS in Ecopages Components
+## Use a component in a Page
 
-In Ecopages, CSS for components is typically defined in separate files and loaded through the component's dependencies.
-Please note that `tailwind` and `postcss` are supported by default in Ecopages. Please refer to the configuration section for more details.
+Pass route wrappers through `layout`; list nested or interactive components under `dependencies.components`.
 
-Here's how it works:
-
-1. Separate CSS Files: Each component can have its own CSS file. This promotes modularity and makes styles easier to manage.
-2. CSS File Naming: Usually, the CSS file is named the same as the component file, but with a .css extension. For example, radiant-counter.css for the RadiantCounter component.
-3. Loading CSS: The CSS file is specified in the dependencies.stylesheets array.
-
-## Using Components in Pages
-
-To use components in pages, import them and declare dependencies. Use `layout:` for route wrappers (see [Creating Layouts](/docs/core/layouts)); list interactive or nested components in `dependencies.components`.
-
-```typescript
+```tsx
 import { RadiantCounter } from '@/components/radiant-counter';
 import { BaseLayout } from '@/layouts/base-layout';
 import { eco } from '@ecopages/core';
-import { html } from '@ecopages/core/html';
 
 export default eco.page({
 	layout: BaseLayout,
@@ -160,22 +53,29 @@ export default eco.page({
 	dependencies: {
 		components: [RadiantCounter],
 	},
-	render: () => html`
-		<h1>Ecopages</h1>
-		${RadiantCounter({ count: 5 })}
-	`,
+	render: () => (
+		<>
+			<h1>Ecopages</h1>
+			<RadiantCounter count={5} />
+		</>
+	),
 });
 ```
 
-## Best Practices for Component Creation
+## Lazy browser scripts
 
-1. **Separation of Concerns**: Keep your component's structure (`.ts`) separate from its client-side logic (`.script.ts`).
-2. **Use HTML Templates**: Leverage the `html` template literal for creating your component's structure.
-3. **Custom Elements**: Use custom elements for adding client-side interactivity to your components.
-4. **TypeScript**: Use TypeScript for better type checking and improved developer experience.
-5. **Styling**: Use separate CSS files for styling your components.
-6. **Factory Pattern**: Use `eco.component` to create consistent and correctly typed components.
+Use a lazy declaration when a script should wait for an interaction or visibility trigger.
 
-Interactive components with client scripts are stamped with [island host attributes](/docs/core/island-hosts) on their SSR root so devtools can discover them.
+```ts
+dependencies: {
+	scripts: [{ src: './search.script.ts', lazy: { 'on:interaction': 'focusin' } }],
+}
+```
 
-By following these guidelines and leveraging the power of ghtml components with `@ecopages/core`, you can create robust, reusable, and interactive components that will help you build efficient and maintainable websites with Ecopages.
+Ecopages stamps [island host attributes](/docs/core/island-hosts) on hydratable Component SSR roots so developer tools and client runtimes can discover them.
+
+## Related guides
+
+- [Ecopages JSX](/docs/integrations/ecopages-jsx) — install and configure the default starter Integration
+- [Layouts](/docs/core/layouts) — route-level shared chrome
+- [Island Hosts](/docs/core/island-hosts) — the SSR island contract

--- a/apps/docs/src/content/docs/core/concepts.mdx
+++ b/apps/docs/src/content/docs/core/concepts.mdx
@@ -36,6 +36,7 @@ You can customize this in your `eco.config.ts` file:
 ```typescript
 import path from 'node:path';
 import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
 import { postcssProcessorPlugin } from '@ecopages/postcss-processor';
 import { tailwindV4Preset } from '@ecopages/postcss-processor/presets/tailwind-v4';
 
@@ -50,6 +51,7 @@ const config = await new ConfigBuilder()
 			}),
 		),
 	])
+	.setIntegrations([ecopagesJsxPlugin()])
 	.build();
 ```
 
@@ -68,7 +70,6 @@ To ensure that your components have the necessary scripts and styles, you must e
 ```tsx
 import { BaseLayout } from '@/layouts/base-layout';
 import { eco } from '@ecopages/core';
-import { html } from '@ecopages/core/html';
 
 const HomePage = eco.component({
 	dependencies: {
@@ -79,11 +80,11 @@ const HomePage = eco.component({
 		// Child components to crawl for their own dependencies
 		components: [BaseLayout],
 	},
-	render: () => html`
+	render: () => (
 		<div class="main-content">
 			<h1>Welcome to Ecopages</h1>
 		</div>
-	`,
+	),
 });
 ```
 
@@ -112,7 +113,7 @@ const MyComponent = eco.component({
 	dependencies: {
 		scripts: [{ src: './heavy-script.ts', lazy: { 'on:visible': true } }], // or provide a specific selector string
 	},
-	render: () => html`<div>Heavy Content</div>`,
+	render: () => <div>Heavy Content</div>,
 });
 ```
 
@@ -133,7 +134,7 @@ This capability is provided by the [MDX Integration](/docs/integrations/mdx), wh
 ```typescript
 import Component from '@/components/mdx-component';
 
-const MyPage = () => html`${Component()}`;
+const MyPage = () => Component();
 ```
 
 ## Project Structure
@@ -171,7 +172,7 @@ When fetching data in `staticPaths` or `staticProps`, Ecopages provides differen
 
 For the best performance during static generation, call your data layer functions directly:
 
-```typescript
+```tsx
 import { eco } from '@ecopages/core';
 import { getAllBlogPosts, getBlogPost } from '@/data/blog';
 
@@ -197,7 +198,7 @@ export default eco.page({
 		return { props: { post } };
 	},
 
-	render: ({ post }) => html`...`,
+	render: ({ post }) => <article>{post.title}</article>,
 });
 ```
 

--- a/apps/docs/src/content/docs/core/data-fetching.mdx
+++ b/apps/docs/src/content/docs/core/data-fetching.mdx
@@ -15,13 +15,13 @@ When generating static pages, use the `eco.page` factory to provide data to your
 ### `staticProps`
 Injects custom props into your page component at build time.
 
-```typescript
+```tsx
 import { eco } from '@ecopages/core';
 
 export type PageProps = { title: string; content: string };
 
 export default eco.page<PageProps>({
-    staticProps: async ({ pathname }) => {
+    staticProps: async () => {
         // Fetch data from a database, file, or external API
         const data = await fetch('https://api.example.com/page-data').then(res => res.json());
 
@@ -32,10 +32,12 @@ export default eco.page<PageProps>({
             },
         };
     },
-    render: ({ title, content }) => html`
-        <h1>${title}</h1>
-        <div>${content}</div>
-    `,
+    render: ({ title, content }) => (
+        <>
+            <h1>{title}</h1>
+            <div>{content}</div>
+        </>
+    ),
 });
 ```
 

--- a/apps/docs/src/content/docs/core/dev-toolbar.mdx
+++ b/apps/docs/src/content/docs/core/dev-toolbar.mdx
@@ -24,11 +24,13 @@ pnpm add -D @ecopages/dev-toolbar
 
 ```typescript
 import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
 import { devToolbar } from '@ecopages/dev-toolbar/config';
 
 export default new ConfigBuilder()
   .setRootDir(import.meta.dirname)
   .setDevToolbar(devToolbar())
+  .setIntegrations([ecopagesJsxPlugin()])
   .build();
 ```
 

--- a/apps/docs/src/content/docs/core/includes.mdx
+++ b/apps/docs/src/content/docs/core/includes.mdx
@@ -22,10 +22,12 @@ The extension depends on your chosen integration (e.g. `.tsx` for Ecopages JSX, 
 
 You can configure includes in your `eco.config.ts`:
 
-```typescript
+```tsx
 import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
 
 const config = await new ConfigBuilder()
+	.setIntegrations([ecopagesJsxPlugin()])
 	.build();
 ```
 
@@ -37,19 +39,16 @@ Ecopages resolves `src/includes/html.*` automatically using the registered integ
 
 The HTML template defines the overall structure of your pages. Use `eco.html()` to clearly signal that this component owns the full document shell:
 
-```typescript
+```tsx
 import { eco } from '@ecopages/core';
-import { html } from '@ecopages/core/html';
+import type { HtmlTemplateProps } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
 
-const Html = eco.html<HtmlProps>({
+const Html = eco.html<HtmlTemplateProps<JsxRenderable>, JsxRenderable>({
 	dependencies: {
 		stylesheets: ['./html.css'],
 	},
-	render: ({ head, body, lang = 'en' }) => html`
-	<html lang="${lang}">
-		${head}
-		${body}
-	</html>`
+	render: ({ children, language = 'en' }) => <html lang={language}>{children}</html>,
 });
 
 export default Html;
@@ -59,18 +58,19 @@ export default Html;
 
 The head template manages your document's head section:
 
-```typescript
-import { eco } from '@ecopages/core';
-import { html } from '@ecopages/core/html';
+```tsx
+import { eco, type PageHeadProps } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
 
-const Head = eco.component<HeadProps>({
-	render: ({ title, meta, links, scripts }) => html`	
+const Head = eco.component<PageHeadProps<JsxRenderable>, JsxRenderable>({
+	render: ({ metadata, children }) => (
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		${meta}
-		<title>${title}</title>${links}${scripts}
-	</head>`
+		<title>{metadata.title}</title>
+		{children}
+	</head>
+	)
 });
 
 export default Head;
@@ -81,16 +81,17 @@ export default Head;
 The SEO template handles meta tags for search engines and social sharing:
 
 ```typescript
-import { eco } from '@ecopages/core';
-import { html } from '@ecopages/core/html';
+import { eco, type PageMetadataProps } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
 
-const Seo = eco.component<SeoProps>({
-	render: ({ title, description, image, keywords }) => html`
-	<meta name="description" content="${description}" />
-	<meta name="keywords" content="${keywords?.join(',')}" />
-	<meta property="og:title" content="${title}" />
-	<meta property="og:description" content="${description}" />
-	${image ? html`<meta property="og:image" content="${image}" />` : ''}`
+const Seo = eco.component<PageMetadataProps, JsxRenderable>({
+	render: ({ title, description, image, keywords }) => <>
+		<meta name="description" content={description} />
+		<meta name="keywords" content={keywords?.join(',')} />
+		<meta property="og:title" content={title} />
+		<meta property="og:description" content={description} />
+		{image ? <meta property="og:image" content={image} /> : null}
+	</>
 });
 
 export default Seo;

--- a/apps/docs/src/content/docs/core/island-hosts.mdx
+++ b/apps/docs/src/content/docs/core/island-hosts.mdx
@@ -36,7 +36,7 @@ Integrations that extend the contract (for example React's component key and pro
 | :--- | :--- |
 | React | `buildIslandHostAttributes()` in component SSR |
 | Lit | `finalizeIslandComponentRender()` in the Lit renderer |
-| KitaJS, MDX, Ghtml | `finalizeIslandComponentRender()` via the string-markup renderer path |
+| KitaJS, MDX, string-markup | `finalizeIslandComponentRender()` via the string-markup renderer path |
 | Ecopages JSX | `finalizeIslandComponentRender()` in the Ecopages JSX renderer |
 
 ## Using the helpers in custom integrations

--- a/apps/docs/src/content/docs/core/layouts.mdx
+++ b/apps/docs/src/content/docs/core/layouts.mdx
@@ -12,43 +12,43 @@ Layouts wrap page content with shared chrome — navigation, sidebars, providers
 
 Includes files are mandatory in Ecopages and define the outer document shell. They live under `src/includes` (for example `html.tsx` and `head.tsx` with Ecopages JSX).
 
-### html.ts
+### html.tsx
 
 Defines the overall HTML envelope:
 
-```typescript
+```tsx
 import { eco } from '@ecopages/core';
-import { html } from '@ecopages/core/html';
+import type { HtmlTemplateProps } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
 
-export const Html = eco.html<{ children: string }>({
+export const Html = eco.html<HtmlTemplateProps<JsxRenderable>, JsxRenderable>({
 	dependencies: {
 		stylesheets: ['./html.css'],
 	},
-	render: ({ children }) => html`
-	<html lang="en">
-		!${children}
-	</html>
-`});
+	render: ({ children }) => <html lang="en">{children}</html>,
+});
 ```
 
-### head.ts
+### head.tsx
 
 Defines `<head>` content — title, meta, icons:
 
-```typescript
-import { eco } from '@ecopages/core';
-import { html } from '@ecopages/core/html';
+```tsx
+import { eco, type PageHeadProps } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
 
-export const Head = eco.component<{ title: string; description: string }>({
-	render: ({ title, description }) => html`
+export const Head = eco.component<PageHeadProps<JsxRenderable>, JsxRenderable>({
+	render: ({ metadata, children }) => (
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>${title}</title>
-		<meta name="description" content="${description}" />
+		<title>{metadata.title}</title>
+		<meta name="description" content={metadata.description} />
 		<link rel="icon" href="/favicon.ico" />
+		{children}
 	</head>
-`});
+	),
+});
 ```
 
 Includes are applied automatically. Pages and route layouts render **inside** this shell — they do not replace it.

--- a/apps/docs/src/content/docs/core/routing.mdx
+++ b/apps/docs/src/content/docs/core/routing.mdx
@@ -80,8 +80,12 @@ Use `app.add(handler)` for handlers created with `defineApiHandler`. See [Define
 Set the canonical base URL in `eco.config.ts`:
 
 ```typescript
+import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
+
 const config = await new ConfigBuilder()
 	.setBaseUrl('https://example.com')
+	.setIntegrations([ecopagesJsxPlugin()])
 	.build();
 ```
 

--- a/apps/docs/src/content/docs/ecosystem/image-processor.mdx
+++ b/apps/docs/src/content/docs/ecosystem/image-processor.mdx
@@ -34,6 +34,7 @@ Add the image processor to your Ecopages configuration:
 ```typescript
 import path from 'node:path';
 import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
 import { imageProcessorPlugin } from '@ecopages/image-processor';
 
 const appRoot = process.cwd();
@@ -59,6 +60,7 @@ export default await new ConfigBuilder()
 			},
 		}),
 	])
+	.setIntegrations([ecopagesJsxPlugin()])
 	.build();
 ```
 

--- a/apps/docs/src/content/docs/ecosystem/postcss-processor.mdx
+++ b/apps/docs/src/content/docs/ecosystem/postcss-processor.mdx
@@ -44,6 +44,7 @@ This preset includes the standard Tailwind CSS v3 stack: `tailwindcss`, `tailwin
 
 ```typescript
 import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
 import { postcssProcessorPlugin } from '@ecopages/postcss-processor';
 import { tailwindV3Preset } from '@ecopages/postcss-processor/presets/tailwind-v3';
 
@@ -69,6 +70,7 @@ This preset supports Tailwind CSS v4, utilizing `@tailwindcss/postcss`. It inclu
 ```typescript
 import path from 'node:path';
 import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
 import { postcssProcessorPlugin } from '@ecopages/postcss-processor';
 import { tailwindV4Preset } from '@ecopages/postcss-processor/presets/tailwind-v4';
 
@@ -83,6 +85,7 @@ const config = await new ConfigBuilder()
 			}),
 		),
 	])
+	.setIntegrations([ecopagesJsxPlugin()])
 	.build();
 
 export default config;
@@ -146,6 +149,7 @@ For advanced use cases, you can customize the processor with transformation hook
 
 ```typescript
 import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
 import { postcssProcessorPlugin } from '@ecopages/postcss-processor';
 
 const config = await new ConfigBuilder()
@@ -161,6 +165,7 @@ const config = await new ConfigBuilder()
 			plugins: {/* custom plugins */},
 		}),
 	])
+	.setIntegrations([ecopagesJsxPlugin()])
 	.build();
 
 export default config;

--- a/apps/docs/src/content/docs/integrations/authoring.mdx
+++ b/apps/docs/src/content/docs/integrations/authoring.mdx
@@ -1,0 +1,64 @@
+---
+title: 'Authoring an Integration'
+description: 'Create a minimal Ecopages Integration that renders trusted HTML strings.'
+order: 7
+---
+
+# Authoring an Integration
+
+An Integration owns a set of file extensions and the renderer that turns its Components into HTML. This minimal example is useful for understanding the boundary without bringing in JSX, a template library, or browser runtime behavior.
+
+Important: this renderer accepts **trusted HTML strings**. Template-string interpolation is not escaped. Use a renderer with an escaping model, such as Ecopages JSX, whenever values may contain untrusted input.
+
+## Define the renderer
+
+`StringMarkupRenderer` implements the document-shell and foreign-child orchestration for string-returning Components. Your renderer only supplies its Integration name.
+
+```ts
+import { StringMarkupRenderer } from '@ecopages/core/route-renderer/orchestration/string-markup-renderer';
+
+export class AcmeStringRenderer extends StringMarkupRenderer {
+	name = 'acme-string';
+}
+```
+
+## Define the Integration
+
+Use a distinct suffix so this Integration has unambiguous ownership. This example claims `.acme.ts` route and include files.
+
+```ts
+import { defineIntegration } from '@ecopages/core/plugins/define-integration';
+import { AcmeStringRenderer } from './acme-string-renderer';
+
+export const acmeStringPlugin = defineIntegration({
+	name: 'acme-string',
+	extensions: ['.acme.ts'],
+	renderer: AcmeStringRenderer,
+});
+```
+
+## Register it
+
+```ts
+import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { acmeStringPlugin } from './acme-string-integration';
+
+export default await new ConfigBuilder()
+	.setRootDir(import.meta.dirname)
+	.setIntegrations([acmeStringPlugin()])
+	.build();
+```
+
+## Author a Page
+
+```ts
+import { eco } from '@ecopages/core';
+
+export default eco.page({
+	render: () => '<main><h1>Hello from a custom Integration</h1></main>',
+});
+```
+
+The same Integration must own the Page, Layout, and Html files it composes. When an application uses multiple Integrations, declare nested Components in `dependencies.components` so Ecopages can resolve Foreign Children through their owning renderer.
+
+For a production JSX integration with automatic escaping and optional Radiant hydration, use [Ecopages JSX](/docs/integrations/ecopages-jsx).

--- a/apps/docs/src/content/docs/integrations/lit.mdx
+++ b/apps/docs/src/content/docs/integrations/lit.mdx
@@ -109,11 +109,10 @@ This wrapper ensures that the script is loaded when needed and provides a typed 
 
 To use Lit components in your pages, import the wrapper and include it in your page using `eco.page`.
 
-```typescript
+```tsx
 import { LitCounter } from '@/components/lit-counter';
 import { BaseLayout } from '@/layouts/base-layout';
 import { eco } from '@ecopages/core';
-import { html } from '@ecopages/core/html';
 
 export default eco.page({
 	metadata: () => ({
@@ -123,14 +122,12 @@ export default eco.page({
 	dependencies: {
 		components: [BaseLayout, LitCounter],
 	},
-	render: () =>
-		html`${BaseLayout({
-			class: 'main-content',
-			children: html`
-				<h1>Home</h1>
-				${LitCounter({ count: 8 })}
-			`,
-		})}`,
+	render: () => (
+		<BaseLayout class="main-content">
+			<h1>Home</h1>
+			<LitCounter count={8} />
+		</BaseLayout>
+	),
 });
 ```
 

--- a/apps/docs/src/content/docs/integrations/overview.mdx
+++ b/apps/docs/src/content/docs/integrations/overview.mdx
@@ -72,3 +72,7 @@ Hydratable components across integrations share the [Island Hosts](/docs/core/is
 		</p>
 	</RuiAlertDescription>
 </RuiAlert>
+
+## Build an Integration
+
+To understand the smallest renderer boundary, follow [Authoring an Integration](/docs/integrations/authoring). The guide builds a dependency-free string renderer and explains when production applications should choose Ecopages JSX instead.

--- a/apps/docs/src/content/docs/plugins/custom-processor.mdx
+++ b/apps/docs/src/content/docs/plugins/custom-processor.mdx
@@ -234,10 +234,12 @@ Register your processor in `eco.config.ts`:
 
 ```typescript
 import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
 import { customProcessorPlugin } from './custom-processor';
 
 const config = await new ConfigBuilder()
 	.setProcessors([customProcessorPlugin()])
+	.setIntegrations([ecopagesJsxPlugin()])
 	.build();
 ```
 

--- a/apps/docs/src/content/docs/plugins/source-transforms.mdx
+++ b/apps/docs/src/content/docs/plugins/source-transforms.mdx
@@ -38,6 +38,7 @@ Register transforms in `eco.config.ts`:
 
 ```typescript
 import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
 
 const config = await new ConfigBuilder()
 	.setRootDir(process.cwd())
@@ -51,6 +52,7 @@ const config = await new ConfigBuilder()
 			},
 		},
 	])
+	.setIntegrations([ecopagesJsxPlugin()])
 	.build();
 ```
 

--- a/apps/docs/src/content/docs/reference/eco-namespace.mdx
+++ b/apps/docs/src/content/docs/reference/eco-namespace.mdx
@@ -45,7 +45,7 @@ export const Counter = eco.component({
 		stylesheets: ['./counter.css'],
 		scripts: [{ src: './counter.script.ts', lazy: { 'on:interaction': 'mouseenter,focusin' } }],
 	},
-	render: ({ count }) => html`<my-counter count=${count}></my-counter>`,
+	render: ({ count }) => <my-counter count={count}></my-counter>,
 });
 ```
 

--- a/apps/docs/src/content/docs/server/caching.mdx
+++ b/apps/docs/src/content/docs/server/caching.mdx
@@ -18,10 +18,10 @@ You can define the caching behavior for any page using the `cache` property in t
 
 By default, pages are cached indefinitely. This is perfect for content that rarely changes.
 
-```typescript
+```tsx
 export default eco.page({
 	cache: 'static',
-	render: () => html`<h1>Hello World</h1>`,
+	render: () => <h1>Hello World</h1>,
 });
 ```
 
@@ -31,10 +31,10 @@ These pages are generated once and served from the cache until the server restar
 
 Dynamic pages are never cached. They are rendered fresh for every request. Use this for personalized content or real-time data.
 
-```typescript
+```tsx
 export default eco.page({
 	cache: 'dynamic',
-	render: () => html`<h1>Current Time: ${new Date().toISOString()}</h1>`,
+	render: () => <h1>Current Time: {new Date().toISOString()}</h1>,
 });
 ```
 
@@ -53,13 +53,13 @@ ISR allows you to cache pages for a specific duration ("revalidate" time).
 2.  **Subsequent Requests**: The cached page is served immediately.
 3.  **After Revalidation Time**: The _next_ request still gets the cached (stale) version, but it triggers a background regeneration. Future requests will see the updated content.
 
-```typescript
+```tsx
 export default eco.page({
 	cache: {
 		revalidate: 60, // Seconds
 		tags: ['blog', 'posts'],
 	},
-	render: () => html`<h1>Latest Updates</h1>`,
+	render: () => <h1>Latest Updates</h1>,
 });
 ```
 
@@ -71,12 +71,16 @@ You can configure global cache settings in your `eco.config.ts` file provided by
 
 ```typescript
 // eco.config.ts
+import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
+
 const config = await new ConfigBuilder()
 	.setCacheConfig({
 		enabled: true,
 		defaultStrategy: 'static',
 		maxEntries: 1000,
 	})
+	.setIntegrations([ecopagesJsxPlugin()])
 	.build();
 ```
 

--- a/apps/docs/src/content/docs/server/routing-patterns.mdx
+++ b/apps/docs/src/content/docs/server/routing-patterns.mdx
@@ -25,9 +25,11 @@ The examples below assume the following shared setup. You can copy this into you
 ```typescript
 // eco.config.ts
 import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
 
 export default await new ConfigBuilder()
   .setBaseUrl('http://localhost:3000')
+  .setIntegrations([ecopagesJsxPlugin()])
   .build();
 
 // src/db.ts

--- a/apps/docs/src/content/docs/server/server-api.mdx
+++ b/apps/docs/src/content/docs/server/server-api.mdx
@@ -133,7 +133,7 @@ You can use `server` for advanced debugging, runtime methods, or accessing serve
 
 During static site generation, the server can still handle API requests, making it possible to generate static content from API responses:
 
-```typescript
+```tsx
 import { eco } from '@ecopages/core';
 
 export default eco.page({
@@ -145,7 +145,7 @@ export default eco.page({
 			props: { data },
 		};
 	},
-	render: ({ data }) => html`...`
+	render: ({ data }) => <pre>{JSON.stringify(data)}</pre>
 });
 ```
 
@@ -211,8 +211,12 @@ console.log(data); // { message: 'Hello World' }
 Server configuration can be customized in your `eco.config.ts`:
 
 ```typescript 
+import { ConfigBuilder } from '@ecopages/core/config-builder';
+import { ecopagesJsxPlugin } from '@ecopages/ecopages-jsx';
+
 const config = await new ConfigBuilder() 
 	.setBaseUrl('http://localhost:3000') 
 	// ... other config
+	.setIntegrations([ecopagesJsxPlugin()])
 	.build(); 
 ```

--- a/examples/docs-starter/tsconfig.json
+++ b/examples/docs-starter/tsconfig.json
@@ -17,7 +17,6 @@
 		"strict": true,
 		"target": "ES2021",
 		"useDefineForClassFields": true,
-		"types": ["ecopages-content-processor"],
 		"verbatimModuleSyntax": true
 	},
 	"include": ["modules.d.ts", "src", "eco.config.ts", "node_modules/@types/ecopages-content-processor"]


### PR DESCRIPTION
## Summary
- Drop ghtml as the documented default. Examples register Ecopages JSX via `setIntegrations`.
- Add the Integration authoring guide for a trusted-string renderer on `StringMarkupRenderer`.
- Drop the `ecopages-content-processor` types entry from docs-starter tsconfig.

Stacked on the core ghtml removal PR.

## Test plan
- [x] Docs pages for components, concepts, includes, layouts, and integrations overview render
- [x] Authoring an Integration is linked from the integrations overview
- [x] Root README no longer lists ghtml as the built-in renderer

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>