### PR TITLE
fix(build): bundle ws for CommonJS named-export interop

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -80,7 +80,7 @@ Use this package README as the top-level map, then drill into the focused subsys
 
 - `src/config/README.md`: config finalization and app-owned runtime/build state
 - `src/plugins/README.md`: integration and processor authoring contracts
-- `src/build/README.md`: build adapter, executor, and development build coordination
+- `src/build/README.md`: build adapter, executor, development build coordination, and standalone Node server packaging
 - `src/services/README.md`: cross-cutting runtime services and orchestration helpers
 - `src/adapters/README.md`: Bun, Node, and shared adapter boundaries
 - `src/dev/README.md`: dev transform server and on-demand client delivery

--- a/packages/core/src/build/README.md
+++ b/packages/core/src/build/README.md
@@ -56,7 +56,7 @@ build/
 - `runtime/build-request-policy.ts`: server/browser request constructors and plugin collision rules.
 - `runtime/build-request-identity.ts` / `cache/cache-keys.ts`: canonical request identity and shared cache fingerprints.
 - `contracts/build-types.ts`: the `EcoBuildPlugin` contract used by integrations and processors.
-- `rolldown/rolldown-build-adapter.ts`: the production `BuildAdapter`. Wraps the bundler, normalizes Node output imports, and exposes a normalized `BuildResult`.
+- `rolldown/rolldown-build-adapter.ts`: the production `BuildAdapter`. Wraps the bundler, normalizes Node output imports, and exposes a normalized `BuildResult`. App dependencies remain bare imports; Core-owned runtime packages that need CommonJS named-export interop are bundled, while other Core dependencies resolve to `file:` URLs. Generated server bundles therefore do not require app-level framework dependencies.
 - `rolldown/rolldown-plugin-bridge.ts`: `EcoBuildPlugin[]` → bundler-plugin translation.
 - `runtime/serialized-build-executor.ts`: FIFO queue primitive.
 - `cache/server-entry-build-cache.ts`: production server-entry bundle cache (`.eco/.server-entry/.build-cache.json` + `dist/.server/manifest.json`).

--- a/packages/core/src/build/rolldown/rolldown-adapter-helpers.ts
+++ b/packages/core/src/build/rolldown/rolldown-adapter-helpers.ts
@@ -39,6 +39,8 @@ const nodeBuiltinSpecifiers = new Set(builtinModules);
 
 let corePackageNames: Set<string> | undefined;
 
+const CORE_RUNTIME_BUNDLED_PACKAGES = new Set<string>(['ws']);
+
 /**
  * Returns the set of packages declared as direct dependencies in core's own
  * `package.json` (all dependency fields combined).
@@ -128,12 +130,12 @@ function getAppRootRequire(cache: Map<string, NodeJS.Require>, contextRoot: stri
  *    TypeScript or JSX file (source packages); pre-compiled packages are left
  *    external so the app's own resolver handles them at runtime.
  * 3. **Everything else** (undeclared transitives) — split into two sub-cases:
- *    - A **direct dependency of core** that resolves to a compiled JS file
- *      (e.g. `oxc-parser`, `rolldown`, `ws`): externalized so the
- *      `runtime-build-output-normalizer` can rewrite the import to an
- *      absolute `file://` URL after the build. "Direct" means declared in
- *      core's own `package.json`; transitives that merely *resolve through*
- *      core's `require` are excluded.
+ *    - A **direct dependency of core** that resolves to a compiled JS file:
+ *      externalized so the `runtime-build-output-normalizer` can rewrite the
+ *      import to an absolute `file://` URL after the build. Runtime packages
+ *      that require CommonJS named-export interop (currently `ws`) are
+ *      bundled instead. "Direct" means declared in core's own `package.json`;
+ *      transitives that merely *resolve through* core's `require` are excluded.
  *    - **Everything else** (true transitives like `lexical`, `@lexical/react`):
  *      bundled unconditionally. pnpm strict hoisting means these packages
  *      are unreachable as bare specifiers from output directories such as
@@ -160,6 +162,9 @@ function shouldBundlePackageImport(
 	}
 
 	if (isCoreDeclaredPackageImport(id)) {
+		if (CORE_RUNTIME_BUNDLED_PACKAGES.has(getPackageName(id))) {
+			return true;
+		}
 		const coreResolvedPath = tryResolveModule(id, corePackageRequire);
 		if (coreResolvedPath && !/\.(?:[cm]?ts|tsx|jsx)$/u.test(coreResolvedPath)) {
 			return false;
@@ -167,6 +172,12 @@ function shouldBundlePackageImport(
 	}
 
 	return true;
+}
+
+function getPackageName(specifier: string): string {
+	return specifier.startsWith('@')
+		? specifier.split('/').slice(0, 2).join('/')
+		: (specifier.split('/')[0] ?? specifier);
 }
 
 function createExternalMatcher(

--- a/packages/core/src/build/rolldown/rolldown-build-adapter.test.ts
+++ b/packages/core/src/build/rolldown/rolldown-build-adapter.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -208,6 +208,35 @@ describe('RolldownBuildAdapter', () => {
 		const code = readFileSync(firstOutput.path, 'utf-8');
 		expect(code).not.toMatch(/from ['"]oxc-parser['"]/);
 		expect(code).toContain(expectedRuntimeUrl);
+	});
+
+	test('externalPackages bundles Core runtime dependencies with CommonJS named exports', async () => {
+		const entrypoint = writeFixture(
+			'entry.ts',
+			"import { WebSocketServer } from 'ws';\nexport { WebSocketServer };\n",
+		);
+		const adapter = new RolldownBuildAdapter();
+		const outdir = path.join(workDir, 'dist');
+		const localRequire = createRequire(import.meta.url);
+		const nodeModulesDir = path.join(workDir, 'node_modules');
+		mkdirSync(nodeModulesDir, { recursive: true });
+		symlinkSync(path.dirname(localRequire.resolve('ws')), path.join(nodeModulesDir, 'ws'), 'dir');
+		const result = await adapter.build({
+			entrypoints: [entrypoint],
+			outdir,
+			target: 'node',
+			format: 'esm',
+			externalPackages: true,
+			root: workDir,
+		});
+
+		assert.equal(result.success, true);
+		assert.ok(result.outputs.length > 0, 'at least one output file');
+		const firstOutput = result.outputs[0]!;
+		const code = readFileSync(firstOutput.path, 'utf-8');
+		expect(code).not.toMatch(/from ['"]ws['"]/);
+		expect(code).not.toMatch(/from ['"]file:.*\/ws\/index\.js['"]/);
+		expect(code).toContain('WebSocketServer');
 	});
 
 	test('externalPackages does not externalize plugin-owned virtual modules', async () => {

--- a/packages/core/src/build/rolldown/runtime-build-output-normalizer.ts
+++ b/packages/core/src/build/rolldown/runtime-build-output-normalizer.ts
@@ -8,20 +8,6 @@ const corePackageRequire = createRequire(new URL('../../../package.json', import
 const appDeclaredPackageCache = new Map<string, Set<string>>();
 const appWorkspacePackageCache = new Map<string, Set<string>>();
 
-/**
- * Core-owned packages that are part of the Node adapter's runtime surface and
- * should therefore be preserved as bare specifiers in bundled output.
- *
- * Only list packages whose bare-specifier form will be resolvable from the
- * app's Node.js runtime (i.e. they ship alongside the framework and do not
- * need to be in the app's own package.json).
- *
- * Build-time tools (e.g. oxc-parser, rolldown) deliberately omitted — their
- * imports in server-side output must be rewritten to absolute file: URLs so
- * the bundler does not embed them in app code.
- */
-const CORE_RUNTIME_BARE_SPECIFIER_PACKAGES = new Set<string>(['ws']);
-
 function tryResolveRuntimeImport(specifier: string, resolver: NodeJS.Require): string | undefined {
 	try {
 		return resolver.resolve(specifier);
@@ -164,24 +150,11 @@ export function isDeclaredAppPackageImport(specifier: string, rootDir: string): 
  * Whether the given bare specifier should be left as-is (not rewritten to a
  * file URL) in bundled output.
  *
- * Two categories qualify:
- * 1. **App-declared packages** — present in the app's own package.json; the
- *    app's resolver will find them at runtime.
- * 2. **Core runtime surface packages** — a curated subset of the framework's
- *    own dependencies that are part of its public Node adapter surface (e.g.
- *    `ws`). These ship alongside the framework and are resolvable from the
- *    bundled output's location even when the app has not declared them.
- *
- * Build-time packages declared by core (e.g. `oxc-parser`, `rolldown`) are
- * intentionally *not* included here — their imports must still be rewritten
- * to absolute `file:` URLs so they are not left as bare specifiers in app
- * output.
+ * Only app-declared packages qualify: their resolver can find them from a
+ * generated server bundle. Core dependencies remain file URLs because a
+ * bundle in `dist/.server` is not inside Core's Node.js resolution chain.
  */
 function isDeclaredInResolutionChain(specifier: string, rootDir: string): boolean {
-	const packageName = getPackageNameFromSpecifier(specifier);
-	if (CORE_RUNTIME_BARE_SPECIFIER_PACKAGES.has(packageName)) {
-		return true;
-	}
 	return isDeclaredAppPackageImport(specifier, rootDir);
 }
 


### PR DESCRIPTION
## Summary
- Bundle Core's `ws` dependency into generated server output instead of externalizing it as a bare specifier or `file:` URL
- Remove the special-case bare-specifier allowlist from the runtime output normalizer
- Add a regression test for `externalPackages` bundling `ws` with CommonJS named exports

## Test plan
- [x] `vitest run --project shared-core packages/core/src/build/rolldown/rolldown-build-adapter.test.ts` (17 passed)
- [ ] Verify standalone `ecopages start` works for apps that do not declare `ws`