### PR TITLE
feat(ecopages): add interactive init with template manifest

### DIFF
--- a/apps/docs/src/content/docs/reference/cli-reference.mdx
+++ b/apps/docs/src/content/docs/reference/cli-reference.mdx
@@ -43,7 +43,7 @@ Ecopages supports app lifecycle and scaffolding commands.
 Scaffolds a new Ecopages project.
 
 - Requires a target directory and supports selecting a template.
-- Example: `ecopages init my-app --template starter-jsx`.
+- Example: `ecopages init my-app --template jsx`.
 
 ### `dev`
 
@@ -149,7 +149,7 @@ Used to determine where the server listens.
 	defaultSelectedKey="npm"
 />
 
-### Initialize a starter app
+### Initialize a template app
 
 <CodeTabs
 	name="cli-reference-init"

--- a/packages/ecopages/README.md
+++ b/packages/ecopages/README.md
@@ -6,10 +6,16 @@ It provides scaffolding and development commands to streamline your workflow. It
 
 ## Quick Start
 
-Initialize a new project from the default template:
+Initialize a new project from the interactive template picker:
 
 ```bash
-bunx ecopages init my-app
+bunx ecopages init
+```
+
+For a deterministic invocation, select a template explicitly:
+
+```bash
+bunx ecopages init my-app --template react
 cd my-app
 bun install
 bun dev
@@ -17,18 +23,29 @@ bun dev
 
 ## Commands
 
-| Command                      | Description                                | Equivalent (Bun)                |
-| :--------------------------- | :----------------------------------------- | :------------------------------ |
-| `ecopages init <dir>`        | Scaffolds a new project                    | N/A                             |
-| `ecopages dev [entry]`       | Starts the dev server                      | `bun run [entry] --dev`         |
-| `ecopages dev:watch [entry]` | Dev server + hard restarts on file changes | `bun --watch run [entry] --dev` |
-| `ecopages dev:hot [entry]`   | Dev server + HMR (no hard restarts)        | `bun --hot run [entry] --dev`   |
-| `ecopages build [entry]`     | Creates a production build                 | `bun run [entry] --build`       |
-| `ecopages start [entry]`     | Starts the production server               | `bun run [entry]`               |
-| `ecopages preview [entry]`   | Previews the production build locally      | `bun run [entry] --preview`     |
+| Command               | Description                                         | Equivalent (Bun)                |
+| :-------------------- | :-------------------------------------------------- | :------------------------------ |
+| `ecopages init [dir]` | Scaffolds a new project (interactive without `dir`) | N/A                             |
+| `ecopages dev`        | Starts the dev server                               | `bun run [entry] --dev`         |
+| `ecopages dev:watch`  | Dev server + hard restarts on file changes          | `bun --watch run [entry] --dev` |
+| `ecopages dev:hot`    | Dev server + HMR (no hard restarts)                 | `bun --hot run [entry] --dev`   |
+| `ecopages build`      | Creates a production build                          | `bun run [entry] --build`       |
+| `ecopages start`      | Starts the production server                        | `bun run [entry]`               |
+| `ecopages preview`    | Previews the production build locally               | `bun run [entry] --preview`     |
 
 > [!NOTE]
-> `[entry]` defaults to `app.ts` if not provided.
+> The entry file defaults to `app.ts`. Override it with `--entry-file`.
+
+### Templates
+
+Official templates are versioned with the CLI release. Use `--template <id>` for an official template or `--from <source>` for a community Git template. Community sources support giget provider notation and GitHub, GitLab, Bitbucket, and SourceHut repository URLs.
+
+```bash
+ecopages init my-site --template jsx
+ecopages init my-site --from github:acme/my-template#v1.0.0
+```
+
+The official template IDs are `jsx`, `react`, `lit-jsx`, `radiant`, `blog-jsx`, `blog-react`, `docs-starter`, `react-better-auth`, and `llm-wiki`.
 
 ## Environment & Runtime Options
 

--- a/packages/ecopages/bin/brand.js
+++ b/packages/ecopages/bin/brand.js
@@ -1,0 +1,42 @@
+import { styleText } from 'node:util';
+
+/**
+ * Terminal mark rasterized from `assets/brand/logo-on-light.svg`.
+ * @remarks Half-blocks keep rows flush; a thin stroke leaves the spiral's inner gaps open.
+ */
+const BRAND_MARK_LINES = [
+	'                ▄▄▄▄',
+	'        ▄▄▄▄█▀▀▀▀▄█',
+	'    ▄▄▀▀▀        ██',
+	' ▄█▀      ▄▄▄▄   █',
+	'▄█       █▀  ██  █',
+	'█▄  ▀█▄ ██  ▄█  ██',
+	' █▄   ▀▀██▀▀▀   █',
+	'  ▀▀█▄  ▀█    ▄█▀',
+	'  ▄█▀     ▀▀▀▀▀',
+	' █▀',
+	'▀',
+];
+
+export function formatBrandBanner(version, stream = process.stdout) {
+	const markWidth = Math.max(...BRAND_MARK_LINES.map((line) => [...line].length));
+	const versionLabel = stream.hasColors?.() ? styleText('dim', version) : version;
+	const labels = ['ecopages', versionLabel];
+	const labelStart = Math.max(0, Math.floor((BRAND_MARK_LINES.length - labels.length) / 2));
+
+	return BRAND_MARK_LINES.map((line, index) => {
+		const padded = `${line}${' '.repeat(markWidth - [...line].length)}`;
+		const label = labels[index - labelStart];
+		return label === undefined ? padded : `${padded}  ${label}`;
+	}).join('\n');
+}
+
+export function withBrandBanner(version, text) {
+	if (!process.stdout.isTTY) return text;
+	return `${formatBrandBanner(version)}\n\n${text}`;
+}
+
+export function printBrandBanner(version) {
+	if (!process.stderr.isTTY) return;
+	process.stderr.write(`${formatBrandBanner(version, process.stderr)}\n\n`);
+}

--- a/packages/ecopages/bin/cli.js
+++ b/packages/ecopages/bin/cli.js
@@ -6,7 +6,6 @@ import { parseArgs } from 'node:util';
 import { Logger } from '@ecopages/logger';
 import { createLaunchPlan } from './launch-plan.js';
 import { withBrandBanner } from './brand.js';
-import { runInitCommand } from './init.js';
 
 const logger = new Logger('[ecopages:cli]', { debug: process.env.ECOPAGES_LOGGER_DEBUG === 'true' });
 
@@ -229,9 +228,11 @@ export async function runCli(rawArgs = process.argv.slice(2)) {
 
 	try {
 		switch (commandName) {
-			case 'init':
+			case 'init': {
+				const { runInitCommand } = await import('./init.js');
 				await runInitCommand(commandArgs, logger);
 				return;
+			}
 			case 'dev':
 				await runServerCommand(commandArgs, {
 					name: 'dev',

--- a/packages/ecopages/bin/cli.js
+++ b/packages/ecopages/bin/cli.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-import { downloadTemplate } from 'giget';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { spawn } from 'node:child_process';
-import { join } from 'node:path';
 import { parseArgs } from 'node:util';
 import { Logger } from '@ecopages/logger';
 import { createLaunchPlan } from './launch-plan.js';
+import { withBrandBanner } from './brand.js';
+import { runInitCommand } from './init.js';
 
 const logger = new Logger('[ecopages:cli]', { debug: process.env.ECOPAGES_LOGGER_DEBUG === 'true' });
 
@@ -46,27 +46,12 @@ const sharedServerOptionDefinitions = {
 	},
 };
 
-const initOptionDefinitions = {
-	template: {
-		type: 'string',
-	},
-	repo: {
-		type: 'string',
-	},
-	help: {
-		type: 'boolean',
-		short: 'h',
-	},
-};
-
 function getMainHelpText() {
 	return [
-		`ecopages ${pkg.version}`,
-		'',
 		'Usage: ecopages <command> [options]',
 		'',
 		'Commands:',
-		'  init <dir>              Initialize a new project from a template',
+		'  init [dir]              Initialize a new project from a template',
 		'  dev                     Start the development server',
 		'  dev:watch               Start the development server with watch mode',
 		'  dev:hot                 Start the development server with hot reload',
@@ -117,19 +102,6 @@ function getBuildCommandHelpText() {
 	].join('\n');
 }
 
-function getInitCommandHelpText() {
-	return [
-		'Usage: ecopages init <dir> [options]',
-		'',
-		'Initialize a new project from a template.',
-		'',
-		'Options:',
-		'      --template <template>               Template name from ecopages/examples/',
-		'      --repo <repo>                       GitHub repo in user/repo form',
-		'  -h, --help                              Show help',
-	].join('\n');
-}
-
 function parseCommandArguments(rawArgs, options) {
 	return parseArgs({
 		args: rawArgs,
@@ -165,25 +137,6 @@ function parseServerCommandArgs(rawArgs, commandName, description, mode = 'serve
 			reactFastRefresh: values['react-fast-refresh'],
 			runtime: values.runtime,
 		},
-	};
-}
-
-function parseInitCommandArgs(rawArgs) {
-	const { values, positionals } = parseCommandArguments(rawArgs, initOptionDefinitions);
-
-	if (values.help) {
-		console.log(getInitCommandHelpText());
-		return { help: true };
-	}
-
-	if (positionals.length !== 1) {
-		throw new Error('The `init` command requires exactly one target directory argument.');
-	}
-
-	return {
-		dir: positionals[0],
-		template: values.template ?? 'starter-jsx',
-		repo: values.repo ?? 'ecopages/ecopages',
 	};
 }
 
@@ -246,44 +199,6 @@ async function runEntryCommand(args, options = {}, entryFile = 'app.ts', launchM
 	runLaunchPlan(launchPlan);
 }
 
-async function runInitCommand(rawArgs) {
-	const parsed = parseInitCommandArgs(rawArgs);
-
-	if (parsed.help) {
-		return;
-	}
-
-	const { dir, template, repo } = parsed;
-
-	if (existsSync(dir)) {
-		logger.error(`Target directory already exists: ${dir}`);
-		process.exit(1);
-	}
-
-	logger.info(`Creating target directory '${dir}'...`);
-
-	try {
-		await downloadTemplate(`github:${repo}/examples/${template}`, {
-			dir,
-			force: true,
-		});
-
-		const pkgPath = join(dir, 'package.json');
-		if (existsSync(pkgPath)) {
-			const projectPkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-			projectPkg.name = dir;
-			writeFileSync(pkgPath, JSON.stringify(projectPkg, null, 2) + '\n');
-			logger.info(`Renamed project to '${dir}'`);
-		}
-
-		logger.info('Project initialized! Run `bun install && bun dev` to start.');
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		logger.error(`Failed to fetch template: ${message}`);
-		process.exit(1);
-	}
-}
-
 async function runServerCommand(rawArgs, definition) {
 	const parsed = parseServerCommandArgs(rawArgs, definition.name, definition.description, definition.mode);
 
@@ -303,7 +218,7 @@ export async function runCli(rawArgs = process.argv.slice(2)) {
 	const [commandName, ...commandArgs] = rawArgs;
 
 	if (!commandName || commandName === '--help' || commandName === '-h') {
-		console.log(getMainHelpText());
+		console.log(withBrandBanner(pkg.version, getMainHelpText()));
 		return;
 	}
 
@@ -315,7 +230,7 @@ export async function runCli(rawArgs = process.argv.slice(2)) {
 	try {
 		switch (commandName) {
 			case 'init':
-				await runInitCommand(commandArgs);
+				await runInitCommand(commandArgs, logger);
 				return;
 			case 'dev':
 				await runServerCommand(commandArgs, {

--- a/packages/ecopages/bin/cli.test.ts
+++ b/packages/ecopages/bin/cli.test.ts
@@ -1,11 +1,22 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { runCli } from './cli.js';
 import * as giget from 'giget';
 import * as fs from 'node:fs';
 import * as launchPlan from './launch-plan.js';
+import path from 'node:path';
+import * as prompts from '@clack/prompts';
 
 vi.mock('giget', () => ({
 	downloadTemplate: vi.fn(),
+}));
+
+vi.mock('@clack/prompts', () => ({
+	log: { step: vi.fn() },
+	isCancel: vi.fn(() => false),
+	cancel: vi.fn(),
+	text: vi.fn(),
+	select: vi.fn(),
+	confirm: vi.fn(),
 }));
 
 vi.mock('node:fs', async (importOriginal) => {
@@ -13,7 +24,7 @@ vi.mock('node:fs', async (importOriginal) => {
 	return {
 		...actual,
 		existsSync: vi.fn((path) => actual.existsSync(path)),
-		writeFileSync: vi.fn(),
+		writeFileSync: actual.writeFileSync,
 	};
 });
 
@@ -46,7 +57,19 @@ describe('CLI Commands', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 
-		vi.mocked(fs.existsSync).mockImplementation((filePath) => filePath === 'app.ts' || filePath === 'server.ts');
+		vi.mocked(fs.existsSync).mockImplementation(
+			(filePath) =>
+				filePath === 'app.ts' || filePath === 'server.ts' || String(filePath).endsWith('package.json'),
+		);
+		vi.mocked(giget.downloadTemplate).mockImplementation(async (_source, options) => {
+			const targetDir = String(options?.dir);
+			fs.mkdirSync(targetDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(targetDir, 'package.json'),
+				'{"name":"template","dependencies":{"runtime":"workspace:*"},"devDependencies":{"ecopages":"workspace:*"},"peerDependencies":{"peer":"workspace:*"},"optionalDependencies":{"optional":"workspace:*"}}\n',
+			);
+			return { dir: targetDir, source: String(_source) } as never;
+		});
 		vi.mocked(launchPlan.createLaunchPlan).mockResolvedValue({
 			runtime: 'node',
 			command: 'node',
@@ -56,20 +79,103 @@ describe('CLI Commands', () => {
 		} as any);
 	});
 
+	afterEach(() => {
+		for (const targetDir of ['my-new-project', 'my-dir', 'interactive-app', 'remote-app', 'failed-app']) {
+			fs.rmSync(targetDir, { recursive: true, force: true });
+		}
+	});
+
 	it('runs init command with default template and repo', async () => {
 		await runCli(['init', 'my-new-project']);
-		expect(giget.downloadTemplate).toHaveBeenCalledWith('github:ecopages/ecopages/examples/starter-jsx', {
+		expect(giget.downloadTemplate).toHaveBeenCalledWith('github:ecopages/ecopages/templates/jsx#v0.2.0-rc.0', {
 			dir: 'my-new-project',
+			force: true,
+		});
+		const generatedManifest = JSON.parse(fs.readFileSync('my-new-project/package.json', 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		expect(generatedManifest.name).toBe('my-new-project');
+		for (const blockName of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+			expect(Object.values((generatedManifest[blockName] ?? {}) as Record<string, string>)).toEqual([
+				'0.2.0-rc.0',
+			]);
+		}
+	});
+
+	it('runs init command with an official template', async () => {
+		await runCli(['init', 'my-dir', '--template', 'lit-jsx']);
+		expect(giget.downloadTemplate).toHaveBeenCalledWith('github:ecopages/ecopages/templates/lit-jsx#v0.2.0-rc.0', {
+			dir: 'my-dir',
 			force: true,
 		});
 	});
 
-	it('runs init command with custom template and repo', async () => {
-		await runCli(['init', 'my-dir', '--template', 'starter-lit', '--repo', 'custom/repo']);
-		expect(giget.downloadTemplate).toHaveBeenCalledWith('github:custom/repo/examples/starter-lit', {
-			dir: 'my-dir',
+	it('runs the interactive init flow when no directory is provided', async () => {
+		const originalTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+		Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
+		vi.mocked(prompts.text)
+			.mockResolvedValueOnce('interactive-app' as never)
+			.mockResolvedValueOnce('github:custom/template#v1.0.0' as never);
+		vi.mocked(prompts.select).mockResolvedValueOnce('react' as never);
+		vi.mocked(prompts.confirm).mockResolvedValueOnce(false as never);
+
+		try {
+			await runCli(['init']);
+
+			expect(giget.downloadTemplate).toHaveBeenCalledWith(
+				'github:ecopages/ecopages/templates/react#v0.2.0-rc.0',
+				{
+					dir: 'interactive-app',
+					force: true,
+				},
+			);
+		} finally {
+			if (originalTtyDescriptor) Object.defineProperty(process.stdin, 'isTTY', originalTtyDescriptor);
+			else Reflect.deleteProperty(process.stdin, 'isTTY');
+		}
+	});
+
+	it('normalizes a GitHub community source without rewriting its dependencies', async () => {
+		await runCli(['init', 'remote-app', '--from', 'https://github.com/custom/template/tree/main/site']);
+
+		expect(giget.downloadTemplate).toHaveBeenCalledWith('github:custom/template/site#main', {
+			dir: 'remote-app',
 			force: true,
 		});
+	});
+
+	it('rejects conflicting template sources and the removed repo option', async () => {
+		const exitSpy = mockProcessExit();
+
+		await expect(
+			runCli(['init', 'conflict-app', '--template', 'react', '--from', 'github:owner/repo']),
+		).rejects.toThrow('process.exit:1');
+		await expect(runCli(['init', 'legacy-app', '--repo', 'owner/repo'])).rejects.toThrow('process.exit:1');
+
+		exitSpy.mockRestore();
+	});
+
+	it('requires a directory for non-interactive init', async () => {
+		const exitSpy = mockProcessExit();
+
+		await expect(runCli(['init', '--no-interactive'])).rejects.toThrow('process.exit:1');
+
+		exitSpy.mockRestore();
+	});
+
+	it('cleans up a partial target when community download fails', async () => {
+		const exitSpy = mockProcessExit();
+		vi.mocked(giget.downloadTemplate).mockImplementationOnce(async (_source, options) => {
+			const targetDir = String(options?.dir);
+			fs.mkdirSync(targetDir, { recursive: true });
+			throw new Error('download failed');
+		});
+
+		await expect(runCli(['init', 'failed-app', '--from', 'github:owner/repo'])).rejects.toThrow('process.exit:1');
+		expect(fs.existsSync('failed-app')).toBe(false);
+
+		exitSpy.mockRestore();
 	});
 
 	it('runs dev command and passes defaults to launch plan', async () => {

--- a/packages/ecopages/bin/git-template-source.js
+++ b/packages/ecopages/bin/git-template-source.js
@@ -1,0 +1,88 @@
+const GIT_PROVIDER_PREFIX = /^(github|gitlab|bitbucket|sourcehut):/u;
+
+const HOST_PROVIDER = {
+	'github.com': 'github',
+	'gitlab.com': 'gitlab',
+	'bitbucket.org': 'bitbucket',
+	'git.sr.ht': 'sourcehut',
+};
+
+function repositoryName(value) {
+	return value.replace(/\.git$/u, '');
+}
+
+function withSubpath(repository, subpath) {
+	return subpath.length > 0 ? `${repository}/${subpath.join('/')}` : repository;
+}
+
+/**
+ * Normalizes a Git provider URL or giget source into a giget template source.
+ */
+export function normalizeGitSource(source) {
+	if (GIT_PROVIDER_PREFIX.test(source)) {
+		return source;
+	}
+
+	let url;
+	try {
+		url = new URL(source);
+	} catch {
+		throw new Error(`Unsupported template source '${source}'. Use a Git provider URL or giget source.`);
+	}
+
+	const hostProvider = HOST_PROVIDER[url.hostname];
+	if (!hostProvider) {
+		throw new Error(
+			`Unsupported template host '${url.hostname}'. Supported hosts are GitHub, GitLab, Bitbucket, and SourceHut.`,
+		);
+	}
+
+	const parts = url.pathname
+		.replace(/^\/+|\/+$/gu, '')
+		.split('/')
+		.filter(Boolean);
+
+	if (hostProvider === 'github' && parts.length >= 2) {
+		const [owner, repositoryPart, marker, ref, ...subpath] = parts;
+		const repository = `${owner}/${repositoryName(repositoryPart)}`;
+		if (marker === 'tree' || marker === 'blob') {
+			if (!ref) throw new Error(`Template URL '${source}' is missing a Git ref.`);
+			return `github:${withSubpath(repository, subpath)}#${ref}`;
+		}
+		return `github:${repository}`;
+	}
+
+	if (hostProvider === 'gitlab') {
+		const markerIndex = parts.indexOf('-');
+		const treeIndex = parts.findIndex((part) => part === 'tree' || part === 'blob');
+		if (markerIndex > 0 && treeIndex > markerIndex && parts[treeIndex + 1]) {
+			const repository = parts.slice(0, markerIndex).map(repositoryName).join('/');
+			const ref = parts[treeIndex + 1];
+			const subpath = parts.slice(treeIndex + 2);
+			return `gitlab:${withSubpath(repository, subpath)}#${ref}`;
+		}
+		if (parts.length >= 2) return `gitlab:${parts.join('/')}`;
+	}
+
+	if (hostProvider === 'bitbucket' && parts.length >= 2) {
+		const [workspace, repositoryPart, marker, ref, ...subpath] = parts;
+		const repository = `${workspace}/${repositoryName(repositoryPart)}`;
+		if (marker === 'src' && ref) {
+			return `bitbucket:${withSubpath(repository, subpath)}#${ref}`;
+		}
+		return `bitbucket:${repository}`;
+	}
+
+	if (hostProvider === 'sourcehut' && parts.length >= 2) {
+		const treeIndex = parts.findIndex((part) => part === 'tree' || part === 'blob');
+		if (treeIndex > 1 && parts[treeIndex + 1]) {
+			const repository = parts.slice(0, treeIndex).map(repositoryName).join('/');
+			const ref = parts[treeIndex + 1];
+			const subpath = parts.slice(treeIndex + 2);
+			return `sourcehut:${withSubpath(repository, subpath)}#${ref}`;
+		}
+		return `sourcehut:${parts.join('/')}`;
+	}
+
+	throw new Error(`Unsupported template URL '${source}'. Include a repository and optional Git ref.`);
+}

--- a/packages/ecopages/bin/git-template-source.test.ts
+++ b/packages/ecopages/bin/git-template-source.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeGitSource } from './git-template-source.js';
+
+describe('normalizeGitSource', () => {
+	it('passes through giget provider sources', () => {
+		expect(normalizeGitSource('github:owner/repo#v1.0.0')).toBe('github:owner/repo#v1.0.0');
+	});
+
+	it('normalizes GitHub tree URLs with a subpath', () => {
+		expect(normalizeGitSource('https://github.com/custom/template/tree/main/site')).toBe(
+			'github:custom/template/site#main',
+		);
+	});
+
+	it('normalizes GitLab tree URLs', () => {
+		expect(normalizeGitSource('https://gitlab.com/group/project/-/tree/main/app')).toBe(
+			'gitlab:group/project/app#main',
+		);
+	});
+
+	it('normalizes Bitbucket src URLs', () => {
+		expect(normalizeGitSource('https://bitbucket.org/team/repo/src/main/site')).toBe(
+			'bitbucket:team/repo/site#main',
+		);
+	});
+
+	it('rejects unsupported hosts', () => {
+		expect(() => normalizeGitSource('https://example.com/owner/repo')).toThrow('Unsupported template host');
+	});
+});

--- a/packages/ecopages/bin/init.js
+++ b/packages/ecopages/bin/init.js
@@ -1,0 +1,341 @@
+import { downloadTemplate } from 'giget';
+import * as prompts from '@clack/prompts';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { basename, join } from 'node:path';
+import { parseArgs } from 'node:util';
+import { printBrandBanner, withBrandBanner } from './brand.js';
+import { normalizeGitSource } from './git-template-source.js';
+
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
+const templateManifest = JSON.parse(readFileSync(new URL('../templates.json', import.meta.url), 'utf-8'));
+const officialTemplates = [...templateManifest.templates].sort((left, right) => left.order - right.order);
+const defaultOfficialTemplate = officialTemplates.find((template) => template.default) ?? officialTemplates[0];
+
+const initOptionDefinitions = {
+	template: {
+		type: 'string',
+	},
+	repo: {
+		type: 'string',
+	},
+	from: {
+		type: 'string',
+	},
+	interactive: {
+		type: 'boolean',
+	},
+	'no-interactive': {
+		type: 'boolean',
+	},
+	install: {
+		type: 'boolean',
+	},
+	'no-install': {
+		type: 'boolean',
+	},
+	start: {
+		type: 'boolean',
+	},
+	'no-start': {
+		type: 'boolean',
+	},
+	help: {
+		type: 'boolean',
+		short: 'h',
+	},
+};
+
+function getInitCommandHelpText() {
+	return [
+		'Usage: ecopages init [dir] [options]',
+		'',
+		'Initialize a new project from a template.',
+		'',
+		'With no directory in a TTY, starts the interactive project creator.',
+		'',
+		'Options:',
+		'      --template <id>                     Official template ID',
+		'      --from <source>                     Community Git template source',
+		'      --interactive                       Force interactive mode',
+		'      --no-interactive                    Disable interactive mode',
+		'      --install                           Install dependencies',
+		'      --no-install                        Skip dependency installation',
+		'      --start                             Install and start the dev server',
+		'      --no-start                          Do not start the dev server',
+		'  -h, --help                              Show help',
+	].join('\n');
+}
+
+function parseExclusiveBoolean(enable, disable, enableFlag, disableFlag) {
+	if (enable && disable) {
+		throw new Error(`The \`${enableFlag}\` and \`${disableFlag}\` options cannot be used together.`);
+	}
+	if (enable) return true;
+	if (disable) return false;
+	return undefined;
+}
+
+function parseInitCommandArgs(rawArgs) {
+	const { values, positionals } = parseArgs({
+		args: rawArgs,
+		options: initOptionDefinitions,
+		allowPositionals: true,
+		strict: true,
+	});
+
+	if (values.help) {
+		console.log(withBrandBanner(pkg.version, getInitCommandHelpText()));
+		return { help: true };
+	}
+
+	if (positionals.length > 1) {
+		throw new Error('The `init` command accepts at most one target directory argument.');
+	}
+
+	if (values.template && values.from) {
+		throw new Error('The `--template` and `--from` options cannot be used together.');
+	}
+
+	if (values.repo) {
+		throw new Error('The `--repo` option was removed. Use `--from <source>` instead.');
+	}
+
+	const interactive = parseExclusiveBoolean(
+		values.interactive,
+		values['no-interactive'],
+		'--interactive',
+		'--no-interactive',
+	);
+	const install = parseExclusiveBoolean(values.install, values['no-install'], '--install', '--no-install');
+	const start = parseExclusiveBoolean(values.start, values['no-start'], '--start', '--no-start');
+
+	if (start && install === false) {
+		throw new Error('The `--start` option requires dependency installation.');
+	}
+
+	const dir = positionals[0];
+	const useInteractive = interactive ?? (!dir && Boolean(process.stdin.isTTY));
+
+	if (!dir && !useInteractive) {
+		throw new Error(
+			'A target directory is required outside a TTY. Run `ecopages init --interactive` to use prompts.',
+		);
+	}
+
+	return {
+		dir,
+		template: values.template,
+		from: values.from,
+		interactive: useInteractive,
+		install,
+		start,
+	};
+}
+
+function findOfficialTemplate(templateId) {
+	const template = officialTemplates.find((candidate) => candidate.id === templateId);
+	if (!template) {
+		const available = officialTemplates.map((candidate) => candidate.id).join(', ');
+		throw new Error(`Unknown official template '${templateId}'. Available templates: ${available}`);
+	}
+
+	return template;
+}
+
+function detectPackageManager() {
+	const userAgent = process.env.npm_config_user_agent || '';
+	if (userAgent.startsWith('bun/')) return 'bun';
+	if (userAgent.startsWith('pnpm/')) return 'pnpm';
+	return 'npm';
+}
+
+function getTemplateSource(templateId, source) {
+	if (source) return normalizeGitSource(source);
+	const officialTemplate = findOfficialTemplate(templateId);
+	return `github:ecopages/ecopages/templates/${officialTemplate.source}#v${pkg.version}`;
+}
+
+function runChildCommand(command, args, cwd) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, { cwd, stdio: 'inherit' });
+		child.on('error', reject);
+		child.on('exit', (code, signal) => {
+			if (signal) {
+				reject(new Error(`${command} was terminated by ${signal}.`));
+				return;
+			}
+
+			if (code !== 0) {
+				reject(new Error(`${command} exited with code ${code ?? 1}.`));
+				return;
+			}
+
+			resolve();
+		});
+	});
+}
+
+function rewriteWorkspaceDependencies(projectPkg) {
+	for (const blockName of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+		const block = projectPkg[blockName];
+		if (!block || typeof block !== 'object') continue;
+		for (const [name, version] of Object.entries(block)) {
+			if (version === 'workspace:*') block[name] = pkg.version;
+		}
+	}
+}
+
+function updateProjectManifest(targetDir, packageDirectory, isOfficial) {
+	const packagePath = join(targetDir, packageDirectory, 'package.json');
+	if (!existsSync(packagePath)) {
+		throw new Error(`Template package directory '${packageDirectory}' does not contain a package.json.`);
+	}
+
+	const projectPkg = JSON.parse(readFileSync(packagePath, 'utf-8'));
+	projectPkg.name = basename(targetDir);
+	if (isOfficial) rewriteWorkspaceDependencies(projectPkg);
+
+	if (isOfficial) {
+		for (const blockName of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+			const block = projectPkg[blockName];
+			if (!block || typeof block !== 'object') continue;
+			if (
+				Object.values(block).some((version) => typeof version === 'string' && version.startsWith('workspace:'))
+			) {
+				throw new Error(`Template package still contains workspace dependencies in ${packagePath}.`);
+			}
+		}
+	}
+
+	writeFileSync(packagePath, `${JSON.stringify(projectPkg, null, 2)}\n`);
+	return packagePath;
+}
+
+function isCancelled(value) {
+	if (prompts.isCancel(value)) {
+		prompts.cancel('Project creation cancelled.');
+		return true;
+	}
+	return false;
+}
+
+async function collectInitAnswers(parsed) {
+	const packageManager = detectPackageManager();
+	let dir = parsed.dir;
+	let templateId = parsed.template;
+	let source = parsed.from;
+
+	if (parsed.interactive) {
+		if (!dir) {
+			const answer = await prompts.text({
+				message: 'Project directory:',
+				placeholder: 'my-app',
+				validate: (value) => (value.trim().length === 0 ? 'Enter a project directory.' : undefined),
+			});
+			if (isCancelled(answer)) return null;
+			dir = answer.trim();
+		}
+
+		if (!templateId && !source) {
+			const answer = await prompts.select({
+				message: 'Select a template:',
+				options: [
+					...officialTemplates.map((template) => ({
+						label: template.displayName,
+						value: template.id,
+						hint: template.description,
+					})),
+					{
+						label: 'Community template',
+						value: '__community__',
+						hint: 'Use a Git repository or provider source.',
+					},
+				],
+			});
+			if (isCancelled(answer)) return null;
+			if (answer === '__community__') {
+				const sourceAnswer = await prompts.text({
+					message: 'Template source:',
+					placeholder: 'github:owner/repository#v1.0.0',
+					validate: (value) => (value.trim().length === 0 ? 'Enter a Git template source.' : undefined),
+				});
+				if (isCancelled(sourceAnswer)) return null;
+				source = sourceAnswer.trim();
+			} else {
+				templateId = answer;
+			}
+		}
+	}
+
+	if (!templateId && !source) templateId = defaultOfficialTemplate.id;
+	if (parsed.interactive) {
+		prompts.log.step(`Resolved template source: ${getTemplateSource(templateId, source)}`);
+	}
+
+	let install = parsed.start ? true : parsed.install;
+	if (install === undefined && parsed.interactive) {
+		const answer = await prompts.confirm({
+			message: `Install dependencies with ${packageManager}?`,
+			initialValue: true,
+		});
+		if (isCancelled(answer)) return null;
+		install = answer;
+	}
+	install ??= false;
+
+	let start = parsed.start;
+	if (start === undefined && parsed.interactive && install) {
+		const answer = await prompts.confirm({ message: 'Start the development server now?', initialValue: false });
+		if (isCancelled(answer)) return null;
+		start = answer;
+	}
+	start ??= false;
+
+	return { dir, templateId, source, packageManager, install, start };
+}
+
+export async function runInitCommand(rawArgs, logger) {
+	const parsed = parseInitCommandArgs(rawArgs);
+	if (parsed.help) return;
+
+	printBrandBanner(pkg.version);
+	const answers = await collectInitAnswers(parsed);
+	if (!answers) return;
+
+	const { dir, templateId, source, packageManager, install, start } = answers;
+	if (existsSync(dir)) throw new Error(`Target directory already exists: ${dir}`);
+
+	const officialTemplate = source ? null : findOfficialTemplate(templateId);
+	const templateSource = getTemplateSource(templateId, source);
+	const packageDirectory = officialTemplate?.packageDirectory ?? '.';
+	let targetCreated = false;
+
+	try {
+		if (!parsed.interactive) prompts.log.step(`Resolved template source: ${templateSource}`);
+		prompts.log.step(`Downloading ${officialTemplate?.displayName ?? 'community template'}...`);
+		targetCreated = true;
+		await downloadTemplate(templateSource, { dir, force: true });
+		prompts.log.step('Preparing project manifest...');
+		updateProjectManifest(dir, packageDirectory, Boolean(officialTemplate));
+		prompts.log.step(`Project created in ${dir}.`);
+
+		const packageCwd = join(dir, packageDirectory);
+		if (install) {
+			prompts.log.step(`Installing dependencies with ${packageManager}...`);
+			await runChildCommand(packageManager, ['install'], packageCwd);
+		}
+		if (start) {
+			prompts.log.step('Starting the development server...');
+			await runChildCommand(packageManager, ['run', 'dev'], packageCwd);
+		}
+
+		const relativeCwd = packageDirectory === '.' ? dir : join(dir, packageDirectory);
+		logger.info(
+			`Project initialized. Run 'cd "${relativeCwd}" && ${packageManager} install && ${packageManager} run dev'.`,
+		);
+	} catch (error) {
+		if (targetCreated) rmSync(dir, { recursive: true, force: true });
+		throw error;
+	}
+}

--- a/packages/ecopages/package.json
+++ b/packages/ecopages/package.json
@@ -39,6 +39,7 @@
 		"templates.json"
 	],
 	"dependencies": {
+		"@clack/prompts": "^1.7.0",
 		"@ecopages/core": "workspace:*",
 		"@ecopages/logger": "^0.2.3",
 		"giget": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,6 +413,9 @@ importers:
 
   packages/ecopages:
     dependencies:
+      '@clack/prompts':
+        specifier: ^1.7.0
+        version: 1.7.0
       '@ecopages/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary
- Split `cli.js` into init, git-template-source, and brand modules.
- Add interactive `ecopages init` with Clack prompts, official template IDs, and `--from` community sources.
- Stacked on #261. Merge last.

## Test plan
- [x] Merge or rebase onto #261 first
- [x] `ecopages init` with no args opens the template picker
- [x] `ecopages init my-app --template jsx` still scaffolds non-interactively
- [x] CLI tests cover git template source parsing