### PR TITLE
chore(changelog): trim 0.2.0 release notes

### DIFF
--- a/apps/docs/src/content/docs/ecosystem/react-router.mdx
+++ b/apps/docs/src/content/docs/ecosystem/react-router.mdx
@@ -238,10 +238,9 @@ The router uses a **pluggable adapter pattern** that separates concerns:
 ```typescript
 interface ReactRouterAdapter {
 	name: string;
-	bundle: { importPath; outputName; externals };
-	importMapKey: string;
-	components: { router; pageContent };
-	getRouterProps(page, props): string;
+	bundle: { importPath: string; outputName: string; externals: string[] };
+	components: { router: string; pageContent: string };
+	getRouterProps(page: string, props: string): string;
 }
 ```
 

--- a/packages/browser-router/CHANGELOG.md
+++ b/packages/browser-router/CHANGELOG.md
@@ -12,17 +12,5 @@ All notable changes to `@ecopages/browser-router` are documented here.
 
 ### Bug Fixes
 
-- Fixed navigation races, duplicate script injection, and stale cleanup during repeated page swaps.
-- Fixed mixed-runtime document ownership, script reruns, persisted head scripts, and client-managed `<html>` state during browser-router navigations.
-- Fixed skipped View Transition lifecycle aborts leaking as unhandled browser-router test errors.
-- Fixed body morph swaps retaining stale content when pages contain duplicate `id` attributes by limiting morphdom keying to explicitly persisted nodes.
-- Fixed browser-router stylesheet prefetching to warm future page CSS without injecting unused `preload` hints that trigger browser console warnings.
-- Fixed stable-id external rerun scripts to reuse registered bootstraps instead of cache-busting shared module chunks on every navigation.
-
-### Refactoring
-
-- Routed handoff and current-page reload behavior through the shared navigation coordinator.
-
-### Documentation
-
-- Updated the README examples for the current router API.
+- Fixed navigation races, duplicate script injection, mixed-runtime document ownership, and persisted head scripts during browser-router navigations.
+- Fixed body morph swaps with duplicate `id` attributes, stylesheet prefetch console warnings, and stable-id external rerun script cache busting.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,74 +8,35 @@ All notable changes to `@ecopages/core` are documented here.
 
 ### Breaking Changes
 
-- Removed the built-in ghtml Integration, `@ecopages/core/html`, and `@ecopages/core/integrations/ghtml`. Apps must register an Integration that owns their route file extensions. `ghtml` is no longer a core dependency.
-- Removed `@ecopages/core/build/runtime-build-executor`. Use `@ecopages/core/build/build-runtime` (`installBuildRuntime`, `requireBuildRuntime`) instead.
+- Removed the built-in ghtml Integration, `@ecopages/core/html`, and `@ecopages/core/integrations/ghtml`. Apps must register an Integration that owns their route file extensions.
 - `BuildRuntime` profiles no longer inject app plugins. Pass complete `BuildOptions`, including required app plugins and transforms, before calling `getProfile(...).build()`.
-- Removed the open index signature from `BuildOptions` and `BrowserBundleOptions` so request identity can cover every field exhaustively.
-- Removed write-only Page Browser Graph disk manifest persistence (`.browser-pages-graph`). Production static export still prebuilds graphs into the in-memory `page-browser-graph-session`.
+- Removed the open index signature from `BuildOptions` and `BrowserBundleOptions`.
 - Removed deprecated `config.layout` innermost alias on page configs. Use `config.layouts` and `config.layoutEntries` instead.
-- `createAliasResolverPlugin` now takes the app **project root** (not `srcDir`) and resolves aliases from tsconfig `compilerOptions.paths` only. Apps without tsconfig `paths` get no alias resolver handlers. Hardcoded `@/` → `srcDir` mapping is removed.
-- Removed dev HMR entrypoint disk cache, grouped cold-graph prewarm, and `ECOPAGES_DEV_COLD_CLIENT_GRAPH*` env vars. Dev client modules are transpiled per source file on demand with in-memory caching and lazy `/assets/vendors` prebundles.
-- Removed `ECOPAGES_DEV_PREWARM_ALL_STATIC_ROUTES`. Dev SSR prewarm only renders processor-declared pathnames from `collectDevPrewarmPlan()`.
-
-### Bug Fixes
-
-- Unknown content lookups that throw `HttpError.NotFound` keep that status through page render wrapping, so the request matcher serves a 404 without a 500 stack dump.
-- Browser vendor prebundles now prefer ESM `module` / `import` entries for third-party packages (legacy `browser` export conditions are omitted) while keeping browser-first resolution for `@ecopages/core`.
-- Semantic `404.*` / `500.*` templates now receive safe empty `locals` / `pageLocals` instead of the throwing locals proxy.
-- Development rendered HTML cache keys now include browser-runtime asset generation so rebuilt bootstrap/vendor script URLs cannot go stale.
+- `createAliasResolverPlugin` now takes the app **project root** (not `srcDir`) and resolves aliases from tsconfig `compilerOptions.paths` only. Hardcoded `@/` → `srcDir` mapping is removed.
 
 ### Features
 
-- Page HTML cache in watch mode uses Cache Strategy admission on a bounded memory store: static pages may be retained, dynamic pages never are. Set `cache.enabled: false` to disable watch-mode HTML caching entirely. Source-path edits invalidate only registered HTML keys; shared or unmapped dependencies clear the full page cache.
-- Page Browser Graph per-route reuse is disabled while HMR is enabled; session graphs still cache after build with dependency invalidation.
-- Watch mode SSR-prewarms processor-declared content paths after the HMR-ready response pipeline is configured (`routePrefix` + `devPrewarm`). Optional `devPrewarmReadiness: 'beforeReady'` blocks the framework ready signal until prewarm completes. Concurrent prewarm uses `ECOPAGES_DEV_PREWARM_STATIC_ROUTES_PARALLELISM` (default `3`).
+- Added `createApp()` as the recommended runtime entrypoint with Bun-first execution and Node fallback.
+- Added app-owned build and runtime ownership: host module loading, browser-safe `eco` export, `eco.html()`, `eco.layout()`, and published `EcoPagesAppConfig`.
+- Replaced filesystem route discovery with `RouteRegistry` for matching, static-generation planning, and dev reload.
+- Added Page Browser Graph orchestration, browser runtime asset manifest, and import rewrite so runtime modules resolve to concrete public URLs.
+- Added boundary-plan metadata and mixed-renderer `renderBoundary()` payload contract for cross-integration pages.
+- Added `@ecopages/core/dev/host-runtime` for Vite and other host integrations.
+- Added `@ecopages/core/plugins/tsconfig-import-resolver` for tsconfig `paths` resolution and bare npm import classification.
 - Added nested `layout` arrays on `eco.page()` with normalization to `config.layouts` / `config.layoutEntries`.
 - Added `composeChildren` hook on `composeDocumentShell` for integration-owned unified layout+page composition.
 - Added `EcoDeclaredComponent` validation for `dependencies.components` entries.
-- Added `createApp()` as the recommended runtime entrypoint with Bun-first execution and Node fallback.
-- Added app-owned build and runtime ownership: host module loading, browser-safe `eco` export, `eco.html()`, `eco.layout()`, and published `EcoPagesAppConfig`.
-- Added Page Browser Graph orchestration so integrations declare browser graph contributions and routes share grouped browser assets where appropriate.
-- Added browser runtime asset manifest and import rewrite so runtime modules resolve to concrete public URLs instead of import-map aliases.
-- Added boundary-plan metadata and mixed-renderer `renderBoundary()` payload contract for cross-integration pages.
-- Added `@ecopages/core/dev/host-runtime` for Vite and other host integrations.
-- Replaced filesystem route discovery with `RouteRegistry` for matching, static-generation planning, and dev reload.
-- Added `@ecopages/core/plugins/tsconfig-import-resolver` for tsconfig `paths` resolution, project module path resolution, and bare npm import classification via oxc-resolver.
+- Page HTML cache in watch mode uses Cache Strategy admission on a bounded memory store. Set `cache.enabled: false` to disable watch-mode HTML caching entirely.
+- Watch mode SSR-prewarms processor-declared content paths (`routePrefix` + `devPrewarm`). Optional `devPrewarmReadiness: 'beforeReady'` blocks the framework ready signal until prewarm completes. Concurrent prewarm uses `ECOPAGES_DEV_PREWARM_STATIC_ROUTES_PARALLELISM` (default `3`).
+- Dev client modules are transpiled per source file on demand with in-memory caching and lazy `/assets/vendors` prebundles.
 
 ### Bug Fixes
 
-- Dev transform vendor prebundles resolve bare packages with `"browser"` export conditions so dual packages such as `@ecopages/core` do not pull Node builtins into the client graph.
-- Dev transform vendor prebundles apply integration client-graph boundary plugins, disable code splitting, and exclude app build plugins so server-only package graphs cannot reach the browser.
-- Browser-target Rolldown builds fail hard on `node:*` builtins instead of emitting them as external script URLs.
-- Dev transform vendor registry merges runtime manifest specifiers from all contributors and rejects server-only package main entries (for example `@ecopages/react` plugin paths).
-- Dev transform externalize pass skips namespaced virtual modules (`ecopages:images`) so they inline instead of emitting a broken bare `images` import.
-- React HMR broadcasts `layout-update` for layout file changes even when no page module update URLs are queued.
-- Resolve project import aliases from tsconfig `paths` via oxc-resolver instead of a hardcoded `@/` → `srcDir` mapping.
-- Fixed RouteRegistry static path expansion to load page modules through integration renderers so Radiant SSR setup runs before JSX page imports during build.
-- Fixed app-owned server module loading so integration loaders (including React MDX) participate during request-time and static generation.
-- Fixed Node and Bun adapter stability for preview, static generation, HMR, and mixed-integration rendering across built-in integrations.
-- Fixed grouped page-browser graph builds so sibling routes reuse shared assets without cross-route leakage or stale partial caches.
-- Fixed Node bootstrap for bare package linking, `import.meta.env` compatibility, streaming responses, preview shutdown, and `.mjs` server-module output.
-- Fixed foreign-child and mixed-integration rendering so delegated children serialize in the owning integration during server rendering.
-- Fixed page-module import caching to respect JSX ownership and plugin inputs across preview and static builds.
-- Fixed development HMR to reload layouts, includes, and script entrypoints without stale caches or over-broad rebuilds.
-- Fixed page dependency packaging so stylesheets and scripts emit correctly for static, dynamic, and HMR flows.
-- Fixed `ecopages build` failing when the configured serve port is already in use.
-
-### Refactoring
-
-- Consolidated HMR, preview hosts, runtime binding, and route rendering behind shared services; Bun and Node adapters now differ only at transport hooks.
-- Narrowed published package surface: removed legacy `@ecopages/core/internal-types`, duplicate navigation-coordinator export, and unused escape-hatch entrypoints.
-- Re-exported integration and processor plugin types through plugin entrypoints instead of internal build modules.
-
-### Documentation
-
-- Added architecture and API documentation for config, plugins, services, adapters, HMR, routing, and rendering.
-
-### Tests
-
-- Added regression coverage for `RouteRegistry`, explicit static routes, mixed boundaries, Node fallback, and cross-runtime invalidation.
-- Added regression coverage for RouteRegistry page module loading through integration renderers during static path expansion.
+- Fixed Node and Bun adapter stability for preview, static generation, HMR, and mixed-integration rendering.
+- Fixed grouped page-browser graph builds, foreign-child delegation, page-module import caching, and page dependency packaging across static, dynamic, and HMR flows.
+- Fixed dev transform vendor prebundles, browser-target Rolldown builds, and development HMR invalidation for layouts, includes, and script entrypoints.
+- Unknown content lookups that throw `HttpError.NotFound` keep that status through page render wrapping.
+- Semantic `404.*` / `500.*` templates now receive safe empty `locals` / `pageLocals`.
 
 ---
 
@@ -83,7 +44,6 @@ All notable changes to `@ecopages/core` are documented here.
 
 - `createApp` is now the recommended entrypoint. Import it from `@ecopages/core/create-app`.
 - `defineApiHandler` keeps the same call shape, but the handler context is now explicitly runtime-agnostic.
-- The old explicit `renderingMode` config option has been removed and full orchestration is always active.
 - `eco.page({ layout })` accepts one layout or an **outer → inner** array. Arrays normalize to `config.layouts` and `config.layoutEntries`.
 - Entries in `dependencies.components` (including layouts merged from `eco.page({ layout })`) must be declared with `eco.component()`, `eco.layout()`, or `eco.html()` so `config.identity` is present.
-- `DefaultHmrContext` now requires a `getEntrypointDependencyGraph(): EntrypointDependencyGraph` method. This enables selective HMR invalidation so integrations can rebuild only the entrypoints affected by a changed dependency instead of all watched entrypoints. Implementations should return the shared `EntrypointDependencyGraph` instance from `@ecopages/core/services/runtime-state/entrypoint-dependency-graph.service`.
+- `DefaultHmrContext` now requires a `getEntrypointDependencyGraph(): EntrypointDependencyGraph` method. Implementations should return the shared `EntrypointDependencyGraph` instance from `@ecopages/core/services/runtime-state/entrypoint-dependency-graph.service`.

--- a/packages/ecopages/CHANGELOG.md
+++ b/packages/ecopages/CHANGELOG.md
@@ -6,15 +6,19 @@ All notable changes to `ecopages` are documented here.
 
 ## [UNRELEASED] — TBD
 
+### Breaking Changes
+
+- Positional entry-file arguments are rejected in favor of `--entry-file`.
+
+### Features
+
+- Simplified CLI runtime startup: runtime selection follows explicit `--runtime` overrides, package-manager hints, and Bun availability.
+- Replaced the `ecopages` bin command parser with Node's built-in `parseArgs` and normalized CLI option names onto the launch-plan contract.
+- Added GitHub sign-in to the react-better-auth template via Better Auth social providers.
+
 ### Bug Fixes
 
-- Restored `ecopages build` and `preview` source-entry execution, kept `start` on built output, and rejected positional entry-file arguments in favor of `--entry-file`.
-- Restored app-level `require(...)` support for Node runtime launches while keeping direct `tsx` execution.
-- Loaded standard `.env` files for Node runtime launches so `ecopages ... --runtime node` sees app-local environment values.
-- Restored shared server/build option parsing for `ecopages build` so documented flags like `--base-url` and `--hostname` still flow through to the launch environment.
-
-### Refactoring
-
-- Simplified CLI runtime startup and removed the thin-host bootstrap path; runtime selection now follows explicit `--runtime` overrides, package-manager hints, and Bun availability.
-- Replaced the Node app-entry bridge with direct Node execution through `tsx` and narrowed Node bootstrap behavior to native package and `import.meta` semantics.
-- Replaced the `ecopages` bin command parser with Node's built-in `parseArgs`, normalized CLI option names onto the launch-plan contract, and removed the dead direct-runtime execution-strategy wrapper from the launch plan.
+- Restored `ecopages build` and `preview` source-entry execution; `start` runs built output.
+- Restored app-level `require(...)` support and standard `.env` loading for Node runtime launches.
+- Restored shared server/build option parsing so documented flags like `--base-url` and `--hostname` flow through to the launch environment.
+- Switched the react-better-auth template from `bun:sqlite` to libSQL so `pnpm dev` runs on Node.

--- a/packages/integrations/ecopages-jsx/CHANGELOG.md
+++ b/packages/integrations/ecopages-jsx/CHANGELOG.md
@@ -9,41 +9,14 @@ All notable changes to `@ecopages/ecopages-jsx` are documented here.
 ### Features
 
 - Added the Ecopages JSX integration with optional Radiant runtime support and optional MDX routes compiled against `@ecopages/jsx`.
-- Publish `@ecopages/ecopages-jsx` to npm. JSR is no longer a release channel.
 - Added the `@ecopages/ecopages-jsx/eco-embed` helper for Ecopages-JSX-owned mixed-integration authoring on top of `eco.embed()`.
+
+### Breaking Changes
+
+- Removed the shared JSX runtime bundle and browser import-map asset in favor of per-script browser entries that prepend `@ecopages/radiant/client/install-hydrator` when Radiant SSR is enabled.
+- Intrinsic custom-element loading now follows explicit `dependencies.scripts` ownership instead of implicit tag-to-script discovery.
 
 ### Bug Fixes
 
-- Render Ecopages JSX page shells in plain SSR mode and keep hydrate markers scoped to intrinsic Radiant hosts that actually hydrate on the client.
-- Restored the explicit Radiant client hydrator bootstrap head script so Ecopages JSX hydration can reconnect SSR marker bindings after the shared runtime bundle removal.
-- Switched Ecopages JSX SSR to hydrate mode when calling `@ecopages/jsx/server` so Radiant hosts emit the hydration markers expected by the current JSX runtime.
-- Preserve normalized child HTML when Ecopages JSX keeps delegated children inline inside mixed-integration server renders.
-- Fixed Radiant SSR runtime resolution to import the server bridge from the published `@ecopages/radiant/server` package layout instead of a non-existent `dist/server` path.
-- Moved Ecopages JSX intrinsic custom-element asset bookkeeping into the active JSX SSR render scope and reinstalls the Radiant light-DOM shim whenever SSR runtime setup reruns so nested renders stay aligned with the current server render contract.
-- Fixed intrinsic custom-element SSR asset hooks to fall back cleanly when they run after the active JSX render frame has already unwound, avoiding spurious server warnings during docs renders.
-- Fixed lazy Ecopages JSX custom-element dependencies to stay as standalone assets instead of being folded into page-owned bundles, restoring trigger-driven loading for docs components like `theme-toggle`.
-- Fixed Ecopages JSX page-owned browser bundles to inline their JSX and Radiant runtime imports while skipping separate intrinsic custom-element script tags when the current component tree already imports those scripts.
-- Fixed intrinsic custom-element script suppression to honor dependency-declared script ownership instead of relying only on source import scanning.
-- Fixed Radiant custom-element SSR bridging so `prop:` values like array props render through the server host bridge without requiring wrapper-level attribute serialization fallbacks.
-- Aligned the Ecopages JSX browser runtime bundle with the upstream `@ecopages/jsx` runtime shipped by current alpha releases.
-- Aligned Ecopages JSX peer dependency ranges with the current `@ecopages/jsx` and `@ecopages/radiant` beta releases (`0.3.0-beta.3`).
-- Aligned Radiant SSR and hydration wiring with the public `@ecopages/radiant/server/render-component` and `@ecopages/radiant/client/hydrator` entrypoints so JSX apps install an explicit client hydrator bootstrap instead of relying on implicit side effects.
-- Updated the Ecopages JSX Radiant browser runtime for the `RadiantElement` and `RadiantController` API surface and switched the explicit hydrator bootstrap to `@ecopages/radiant/client/install-hydrator`.
-- Fixed Radiant SSR page inspection to install the light-DOM shim before JSX page modules are imported outside the normal render pass.
-- Restored direct `EcopagesJsxPlugin` construction so the exported class still accepts the public plugin options shape.
-- Aligned Ecopages JSX intrinsic custom-element loading with explicit `dependencies.scripts` ownership instead of implicit tag-to-script discovery.
-- Removed implicit JSX integration-generated intrinsic custom-element browser entries so client custom-element loading now follows the normal asset pipeline.
-- Fixed the Ecopages JSX browser runtime bundle so Radiant custom-element scripts no longer fail on a duplicate `jsxDEV` export cycle.
-- Fixed Ecopages JSX foreign-subtree payload compatibility coverage and removed the plugin/renderer integration-name import cycle.
-
-### Refactoring
-
-- MDX loader imports now use `@ecopages/mdx/core` instead of internal `@ecopages/mdx-core`.
-- Removed the shared JSX runtime bundle service and browser import-map asset in favor of per-script browser entries that prepend `@ecopages/radiant/client/install-hydrator` only when Radiant SSR is enabled.
-- Replaced Ecopages JSX renderer static and post-construction configuration with instance-owned renderer wiring and extracted shared plugin and renderer types into a dedicated module.
-- Extracted JSX renderer SSR asset-frame scope handling into a dedicated render-session module.
-
-### Tests
-
-- Added a kitchen-sink preview e2e regression that asserts Ecopages JSX shell tags stay marker-free while nested Radiant hosts still hydrate and remove their local markers.
-- Added renderer-level coverage for the foreign-subtree payload compatibility contract.
+- Fixed Ecopages JSX SSR/hydration wiring for Radiant hosts, intrinsic custom-element assets, mixed-integration delegated children, and page-owned browser bundles.
+- Fixed lazy custom-element dependencies to stay as standalone assets instead of being folded into page-owned bundles.

--- a/packages/integrations/kitajs/CHANGELOG.md
+++ b/packages/integrations/kitajs/CHANGELOG.md
@@ -13,13 +13,3 @@ All notable changes to `@ecopages/kitajs` are documented here.
 ### Bug Fixes
 
 - Fixed Kita full-route and direct `ctx.render()` rendering to stay on the renderer-owned page/layout/document path while resolving mixed boundaries inside the owning renderer.
-- Fixed Kita foreign-subtree payload compatibility coverage and removed the plugin/renderer integration-name import cycle.
-
-### Documentation
-
-- Updated the README to document `.kita.tsx` route ownership and Kita's role as an outer shell in mixed-renderer apps.
-
-### Tests
-
-- Updated integration coverage for explicit foreign-subtree composition and Node/Rolldown compatibility.
-- Added renderer-level coverage for the foreign-subtree payload compatibility contract.

--- a/packages/integrations/lit/CHANGELOG.md
+++ b/packages/integrations/lit/CHANGELOG.md
@@ -8,19 +8,5 @@ All notable changes to `@ecopages/lit` are documented here.
 
 ### Bug Fixes
 
-- Wrapped the inline Lit hydrate-support bootstrap in its own scope so preview pages do not leak minified helper globals like `x` and `i` across other scripts.
-- Fixed Lit document-shell composition, declarative shadow DOM SSR, nested child serialization, lazy preload handling, explicit render paths, and mixed-renderer foreign-subtree resolution.
-- Fixed Lit foreign-subtree payload compatibility coverage and removed the plugin/renderer integration-name import cycle.
-
-### Documentation
-
-- Updated the README to document `.lit.tsx` route ownership, standalone setup, and mixed-renderer Lit foreign-subtree handling.
-
-### Tests
-
-- Updated integration coverage for explicit foreign-subtree composition and Node/Rolldown compatibility.
-- Added renderer-level coverage for the foreign-subtree payload compatibility contract.
-
-### Refactoring
-
-- Moved Lit HTML serialization and child-slot reinjection mechanics into a dedicated utility so the renderer stays focused on preload and foreign-subtree orchestration.
+- Fixed Lit document-shell composition, declarative shadow DOM SSR, nested child serialization, lazy preload handling, and mixed-renderer foreign-subtree resolution.
+- Wrapped the inline Lit hydrate-support bootstrap in its own scope so preview pages do not leak minified helper globals across other scripts.

--- a/packages/integrations/mdx/CHANGELOG.md
+++ b/packages/integrations/mdx/CHANGELOG.md
@@ -6,34 +6,19 @@ All notable changes to `@ecopages/mdx` are documented here.
 
 ## [UNRELEASED] — TBD
 
-### Breaking
+### Breaking Changes
 
 - Standalone `mdxPlugin()` now **requires** `compilerOptions.jsxImportSource` (no `@kitajs/html` default).
 - Standalone `mdxPlugin()` rejects `react` and `@ecopages/jsx` — use `reactPlugin({ mdx: { enabled: true } })` or `ecopagesJsxPlugin({ mdx: { enabled: true } })`.
-- Internal `@ecopages/mdx-core` removed; shared loader utilities moved to `@ecopages/mdx/core`.
-
-### Bug Fixes
-
-- Fixed Bun/npm 404 when installing `@ecopages/react` (phantom `@ecopages/mdx-core` dependency).
-- Fixed loader registration, Node `source-map` interop, and renderer-owned mixed foreign-subtree rendering for standalone MDX routes.
-- Fixed standalone MDX foreign-subtree payload compatibility coverage and removed the plugin/renderer integration-name import cycle.
+- Dropped `@kitajs/html` peer from standalone MDX. Shared loader utilities live in `@ecopages/mdx/core`.
 
 ### Features
 
 - Added standalone non-React MDX server rendering with async compilation and opt-in `.md` support.
 
-### Documentation
+### Bug Fixes
 
-- Updated the README for standalone non-React MDX usage, `.md` opt-in handling, and compiler configuration.
-
-### Tests
-
-- Added renderer-level coverage for the foreign-subtree payload compatibility contract.
-
-### Refactoring
-
-- Consolidated MDX kernel into `@ecopages/mdx/core`; dropped `@kitajs/html` peer from standalone MDX.
-- Replaced the standalone MDX renderer factory with explicit renderer-owned compiler configuration and collected shared MDX plugin and renderer types into a dedicated module.
+- Fixed loader registration, Node `source-map` interop, and renderer-owned mixed foreign-subtree rendering for standalone MDX routes.
 
 ---
 

--- a/packages/integrations/react/CHANGELOG.md
+++ b/packages/integrations/react/CHANGELOG.md
@@ -6,71 +6,30 @@ All notable changes to `@ecopages/react` are documented here.
 
 ## [UNRELEASED] — TBD
 
-### Breaking
+### Breaking Changes
 
-- `@ecopages/mdx` is now a normal runtime dependency (replaces vendored `@ecopages/mdx-core` / `bundleDependencies`). Consumers do not need to add it manually; npm installs it transitively.
-
-### Bug Fixes
-
-- Dev transform vendor prebundles register client-graph boundary plugins and redirect `@ecopages/react-router`, `@ecopages/react/layout-compose`, and related framework imports through the browser runtime manifest instead of naive package-main prebundling.
-- Fixed React HMR dependency-hit handling to rebuild the page cohort when a changed component is only reachable through an owned layout entrypoint.
-- Grouped router-managed React page entries and HMR rebuilds so persisted layouts and context providers stay on one shared module graph during cross-route navigation.
-- Fixed router-managed React dev page entries to rewrite grouped shared chunk imports to served `/_hmr` asset URLs during initial registration and HMR rebuilds.
-- Kept non-page React HMR entrypoints such as island component entries on the per-entrypoint rebuild path while page-route cohorts use grouped page HMR builds.
-- Rewrite bare React runtime imports to vendor asset URLs for router-managed hosted start builds instead of leaving unresolved `react` specifiers in emitted page assets.
-
-- Fixed router-managed production React hydration to reuse the shared vendor React runtime instead of bundling a second page-local copy.
-- Fixed router-managed production page bundles to emit shared chunks for reused layout/client graphs so heavy modules like Tone are not reinitialized on navigation.
-- Fixed full-document `renderToResponse()` hydration asset resolution to reuse the shared Page Browser Graph path instead of a renderer-local builder seam.
-- Fixed React MDX page-module loading under Node-style ESM builds so compiled MDX routes resolve emitted `.mjs` outputs instead of assuming `.js` runtime artifacts.
-- Fixed React MDX loader initialization under the Node `tsx` runtime by resolving the internal loader helper through static imports instead of lazy module imports.
-- Fixed React HMR ownership matching so non-React compound template files like explicit `.kita.tsx` server views no longer emit stale React module updates instead of full route reloads.
-- Fixed router-managed React HMR page entries to reload the active route with a cleared persisted-layout cache so shared layout edits apply while the current page stays mounted.
-- Fixed router-managed React HMR handlers to forward the active page HMR entry when reloading the current route through React Router.
-- Fixed production React route hydration bundles to inline React runtime dependencies and import the router through the emitted page browser graph instead of a published import-map key.
-- Fixed React browser bundles to resolve `use-sync-external-store/shim*` through runtime-manifest vendor mappings, including a dedicated vendor runtime for `with-selector`, instead of relying on a bespoke shim build plugin.
-- Removed the redundant React page props bootstrap script so route hydration relies on the canonical `__ECO_PAGE_DATA__` payload.
-- Fixed React hydration, Fast Refresh, module loading, doctype handling, island asset reuse, and mixed-renderer foreign-subtree resolution across Bun, Vite, and Nitro flows.
-- Restored direct `ReactPlugin` construction so the exported class still accepts the public plugin options shape.
-- Fixed React foreign-subtree payload compatibility coverage and removed the plugin/renderer integration-name import cycle.
+- `@ecopages/mdx` is now a normal runtime dependency for built-in React MDX support. Consumers do not need to add it manually.
+- Removed the router adapter `importMapKey` contract. Development and production route hydration follow the router bundle import path.
 
 ### Features
 
-- Added background React HMR entrypoint prewarm at dev startup with grouped Rolldown batches, registrar seeding, and cross-session disk cache reuse.
-- Auto-vendor npm packages reachable from `eco.layout()` client render graphs under configured `layouts/` and `components/` directories when `router` is enabled; optional `runtimeModules` overrides manual entries for the same specifier.
+- Added built-in React MDX support and reachability-based hydration analysis for React page bundles.
 - Added nested layout arrays on `eco.page()` with unified React SSR composition via `composeDocumentShell` `composeChildren`.
 - Added `composeLayoutPageTree` and `serializePageDataScript` exports for shared client/SSR layout and hydration payloads.
 - Added per-tier `persistLayouts` support in `@ecopages/react-router` for nested layout stacks.
-- Added built-in React MDX support and reachability-based hydration analysis for React page bundles.
+- Auto-vendor npm packages reachable from `eco.layout()` client render graphs under configured `layouts/` and `components/` directories when `router` is enabled; optional `runtimeModules` overrides manual entries.
 - Added the `@ecopages/react/eco-embed` helper for React-owned mixed-integration authoring on top of `eco.embed()`.
 
-### Refactoring
+### Bug Fixes
 
-- Collapsed React route hydration into one page-owned entry module that re-exports the page component and bundles runtime dependencies in production.
-- Removed the router adapter `importMapKey` contract so both development and production route hydration follow the router bundle import path instead of split import-map and bundle-path models.
-- Replaced the positional `ReactHmrStrategy` constructor with an options object so React HMR wiring can evolve without argument-order churn.
-- Renamed the remaining React runtime alias internals away from `specifierMap` terminology now that import-map-era core seams are gone.
-- Consolidated React bundling, hydration, and runtime state behind shared service boundaries and `window.__ECO_PAGES__`.
-- Moved React plugin option/default resolution into the factory and replaced renderer static config with instance-owned runtime wiring.
-- Extracted React page-payload and locals serialization into a dedicated service to keep the renderer focused on orchestration.
-- Centralized recursive React component-config traversal so module discovery and MDX SSR-lazy asset collection no longer reimplement graph walking.
-- Moved MDX config dependency resolution out of the renderer into a dedicated React service.
-- Collected shared React plugin and renderer config types into a dedicated module while keeping renderer-local runtime types close to implementation.
-
-### Tests
-
-- Added Vitest browser coverage for the React `dynamic()` utility using React Testing Library.
-- Added browser execution coverage for the generated React hydration bootstrap, including router ownership registration and page-root cleanup.
-- Added renderer-level coverage for the foreign-subtree payload compatibility contract, including non-attachable fragment roots.
-
-### Documentation
-
-- Updated the README to document React-owned mixed boundaries, React MDX setup, SSR client-only constraints, and `runtimeModules` for persisted layout context providers.
+- Fixed React hydration, Fast Refresh, grouped page HMR, router-managed production bundles, and mixed-renderer foreign-subtree resolution across Bun and Vite hosts.
+- Fixed React MDX page-module loading and loader initialization under Node-style ESM and `tsx` runtimes.
+- Dev transform vendor prebundles register client-graph boundary plugins and redirect framework imports through the browser runtime manifest.
 
 ---
 
 ## Migration Notes
 
-- React MDX support is built in via `reactPlugin({ mdx: { enabled: true } })`. You do not need to install `@ecopages/mdx` separately — it is installed transitively as a dependency of `@ecopages/react`. The standalone `@ecopages/mdx` plugin is for non-React JSX runtimes only.
-- For nested route layouts, use `eco.page({ layout: [Outer, Inner] })` (outer → inner). React SSR and `@ecopages/react-router` compose the same stack; with `ecoRouter()`, outer tiers persist across SPA navigation when routes share the same layout key.
+- React MDX support is built in via `reactPlugin({ mdx: { enabled: true } })`. The standalone `@ecopages/mdx` plugin is for non-React JSX runtimes only.
+- For nested route layouts, use `eco.page({ layout: [Outer, Inner] })` (outer → inner). With `ecoRouter()`, outer tiers persist across SPA navigation when routes share the same layout key.
 - Import `composeLayoutPageTree` from `@ecopages/react/layout-compose` when building custom client or SSR trees that must match router hydration.

--- a/packages/processors/content-processor/CHANGELOG.md
+++ b/packages/processors/content-processor/CHANGELOG.md
@@ -8,13 +8,7 @@ All notable changes to `@ecopages/content-processor` are documented here.
 
 ### Features
 
-- Server collection modules (`ecopages:content/<collection>/server`) lazy-load MDX entries per slug via dynamic `import()`; `getComponent` and `getEntryDependencies` are async. Concurrent `getComponent` calls for the same slug share one in-flight load.
-- Collection `routePrefix` + `devPrewarm` declare URL pathnames for core's single `collectDevPrewarmPlan()` hook (parallel rendering stays in `@ecopages/core`).
-- `devPrewarmReadiness: 'beforeReady'` optionally blocks the framework ready signal until prewarm completes.
-- Added build-time content collections exposed as `ecopages:content/<collection>` virtual modules.
-- Added Standard Schema frontmatter validation, generated manifest modules, and virtual-module TypeScript declarations.
+- Added build-time content collections exposed as `ecopages:content/<collection>` virtual modules with Standard Schema frontmatter validation, generated manifest modules, and virtual-module TypeScript declarations.
+- Server collection modules lazy-load MDX entries per slug via dynamic `import()`; `getComponent` and `getEntryDependencies` are async.
+- Collection `routePrefix` + `devPrewarm` declare URL pathnames for core's `collectDevPrewarmPlan()` hook. Optional `devPrewarmReadiness: 'beforeReady'` blocks the framework ready signal until prewarm completes.
 - Added `ContentScanner` for reuse in build scripts and `withContentMdxPlugins()` for MDX frontmatter wiring.
-
-### Tests
-
-- Added coverage for codegen, virtual-module plugins, scanner validation, and processor build contributions.

--- a/packages/processors/image-processor/CHANGELOG.md
+++ b/packages/processors/image-processor/CHANGELOG.md
@@ -13,7 +13,3 @@ All notable changes to `@ecopages/image-processor` are documented here.
 ### Bug Fixes
 
 - Fixed ESM internal imports, generated declaration bundling, and exported image outputs in static builds.
-
-### Tests
-
-- Added image processor and renderer coverage for the current build pipeline.

--- a/packages/processors/postcss-processor/CHANGELOG.md
+++ b/packages/processors/postcss-processor/CHANGELOG.md
@@ -12,10 +12,4 @@ All notable changes to `@ecopages/postcss-processor` are documented here.
 
 ### Bug Fixes
 
-- Fixed runtime PostCSS config loading and stylesheet rebuilds for Tailwind-driven template changes.
-
-- Fixed direct stylesheet processing and preset output so Tailwind v4 preserves injected references and nested BEM selectors.
-
-### Tests
-
-- Added processor and preset coverage for the runtime CSS loader and build adapter flow.
+- Fixed runtime PostCSS config loading, stylesheet rebuilds for Tailwind-driven template changes, and Tailwind v4 preset output for injected references and nested BEM selectors.

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -6,26 +6,17 @@ All notable changes to `@ecopages/react-router` are documented here.
 
 ## [UNRELEASED] — TBD
 
+### Breaking Changes
+
+- Removed the React router adapter `importMapKey` field. The adapter now exposes only the browser bundle import path used by both development and production hydration.
+
 ### Features
 
-- Added per-tier `persistLayouts` caching for nested `eco.page({ layout: [...] })` stacks via `resolvePersistedLayoutStack`.
-- Routes that share an outer layout (for example `[AppShell, Docs]` and `[AppShell, Settings]`) reuse the same mounted outer instance on SPA navigation while inner tiers swap.
+- Added per-tier `persistLayouts` caching for nested `eco.page({ layout: [...] })` stacks via `resolvePersistedLayoutStack`. Routes that share an outer layout reuse the same mounted outer instance on SPA navigation while inner tiers swap.
 
 ### Bug Fixes
 
-- Fixed grouped React route navigations to resolve the destination page bootstrap from explicit document markers instead of relying on legacy asset filename patterns.
-- Fixed same-page hash links and Shadow DOM TOC clicks to bypass React Router interception so anchor navigation preserves the URL fragment without a document fetch.
-- Extended page-module extraction to honor explicit hydration markers and self-owned React page entry bundles during navigation.
-- Fixed current-page reloads to accept HMR module overrides so persisted-layout refreshes import the rebuilt active page entry.
-- Fixed React-to-browser-router handoffs, queued-click replay, and stale-navigation races during mixed-router navigations.
-- Standardized route payload reads, document-owner markers, rerun scripts, and current-page HMR refreshes for persisted React layouts.
-- Fixed stable-id external rerun scripts to reuse registered bootstraps instead of cache-busting shared module chunks on every navigation.
-
-### Refactoring
-
-- Routed browser handoff and current-page reloads through the shared navigation coordinator.
-- Removed the React router adapter `importMapKey` field so the adapter now exposes only the browser bundle import path used by both development and production hydration.
-- Updated package metadata for the current core, Rolldown build adapter, and React peer dependency surface.
+- Fixed grouped React route navigations, same-page hash links, page-module extraction, current-page HMR reloads, and React-to-browser-router handoffs.
 
 ---
 

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -9,22 +9,8 @@ All notable changes to `@ecopages/vite-plugin` are documented here.
 ### Features
 
 - Added the composed `ecopages()` Vite entrypoint, built-in dev-server bridging, and HTML normalization helpers for Vite-hosted Ecopages apps.
-- Added a public `EcoPagesAppConfig` export in `@ecopages/core` for published integration packages.
 
 ### Bug Fixes
 
 - Fixed Ecopages config merging to preserve array aliases and `ssr.noExternal: true`.
-- Fixed bridged HTML responses to drop stale body-derived headers after rewriting.
-- Fixed HTML normalization to avoid injecting duplicate `/@vite/client` scripts into already-instrumented documents.
-- Fixed Vite embedded development apps to register the host module loader through Vite SSR so include-template HMR reloads use fresh server modules.
-- Fixed Vite dev-server and hot-update setup to fail fast when required Vite capabilities are unavailable.
-- Fixed Vite dev-server request bridging to convert Node headers and request bodies into Fetch-compatible `Request` inputs.
-
-### Documentation
-
-- Added package documentation for installing and using `@ecopages/vite-plugin` with `eco.config`.
-
-### Refactoring
-
-- Refactored the Vite plugin to depend on the public core app config export instead of `@ecopages/core/internal-types`.
-- Narrowed the public API surface to only export the `ecopages()` entrypoint and its option types.
+- Fixed bridged HTML responses, duplicate `/@vite/client` injection, include-template HMR reloads, and Fetch-compatible request bridging for the Vite dev server.


### PR DESCRIPTION
## Summary
- Trim package changelogs ahead of the 0.2.0 release
- Align react-router adapter interface docs with current types

## Test plan
- [x] Review changelog entries for accuracy
- [x] Confirm no functional code changes