### PR TITLE
feat(templates/blog-react): harden starter theme and MDX wiring

### DIFF
--- a/apps/docs/src/content/docs/ecosystem/content-processor.mdx
+++ b/apps/docs/src/content/docs/ecosystem/content-processor.mdx
@@ -37,7 +37,7 @@ Peer dependency: `@ecopages/core`.
 
 ## Configuration
 
-Register the processor in `eco.config.ts` and wire MDX frontmatter into your JSX integration:
+Register the processor in `eco.config.ts` and wire MDX frontmatter into your JSX or React integration:
 
 ```typescript
 import { ConfigBuilder } from '@ecopages/core/config-builder';
@@ -75,6 +75,8 @@ export default await new ConfigBuilder()
 	])
 	.build();
 ```
+
+React apps use the same helper on `reactPlugin({ mdx: { enabled: true, ...withContentMdxPlugins() } })`.
 
 Collection keys must be kebab-case. Each key becomes `ecopages:content/<key>`.
 

--- a/packages/processors/content-processor/README.md
+++ b/packages/processors/content-processor/README.md
@@ -275,11 +275,11 @@ Watch config drives manifest regeneration only. Asset ownership (which would ski
 
 ## MDX integration
 
-Content files are MDX components. Ensure your JSX/MDX integration (for example, `@ecopages/ecopages-jsx`) is configured in `eco.config.ts` so `getComponent()` returns a renderable component.
+Content files are MDX components. Ensure your JSX or React integration is configured in `eco.config.ts` with MDX enabled so collection entries compile as components.
 
 Content collections with YAML frontmatter need `remark-frontmatter` in the **MDX compile pipeline**. The processor validates frontmatter at scan time (`vfile-matter`); MDX render time needs the remark plugin so `---` blocks are not emitted as content.
 
-Use `@ecopages/content-processor/mdx`:
+Use `@ecopages/content-processor/mdx` on whichever integration compiles the MDX:
 
 ```typescript
 import { withContentMdxPlugins } from '@ecopages/content-processor/mdx';
@@ -292,6 +292,13 @@ ecopagesJsxPlugin({
 			remarkPlugins: [remarkGfm],
 			rehypePlugins: [/* app-specific rehype plugins */],
 		}),
+	},
+});
+
+reactPlugin({
+	mdx: {
+		enabled: true,
+		...withContentMdxPlugins(),
 	},
 });
 ```

--- a/templates/blog-react/README.md
+++ b/templates/blog-react/README.md
@@ -14,6 +14,10 @@ The template runs without external services. Posts live in
 `src/content/posts`, where each MDX file uses `title`, `description`, `excerpt`,
 and optional numeric `order` frontmatter.
 
+The content processor validates that frontmatter at scan time. `reactPlugin`
+also needs `withContentMdxPlugins()` so MDX compile strips the `---` block
+instead of rendering it as content. See `src/lib/mdx-plugin-options.ts`.
+
 To customize the site, start with `src/pages/index.tsx`, the post layout in
 `src/lib/post-page.tsx`, and the shared styles under `src/pages` and
 `src/styles`.

--- a/templates/blog-react/eco.config.ts
+++ b/templates/blog-react/eco.config.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { ConfigBuilder } from '@ecopages/core/config-builder';
 import { comparePosts, postsFrontmatterSchema } from './src/content/posts';
+import { blogMdxPluginOptions } from './src/lib/mdx-plugin-options';
 import { contentProcessorPlugin } from '@ecopages/content-processor/plugin';
 import { imageProcessorPlugin } from '@ecopages/image-processor';
 import { postcssProcessorPlugin } from '@ecopages/postcss-processor';
@@ -16,9 +17,7 @@ const config = await new ConfigBuilder()
 	.setIntegrations([
 		reactPlugin({
 			router: ecoRouter(),
-			mdx: {
-				enabled: true,
-			},
+			mdx: blogMdxPluginOptions,
 		}),
 	])
 	.setProcessors([

--- a/templates/blog-react/src/components/icons.tsx
+++ b/templates/blog-react/src/components/icons.tsx
@@ -47,3 +47,23 @@ export const Sun: EcoComponent<IconProps, JSX.Element> = ({ className, size = 24
 		<path d="m19.07 4.93-1.41 1.41" />
 	</svg>
 );
+
+export const Monitor: EcoComponent<IconProps, JSX.Element> = ({ className, size = 24 }) => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+		className={className}
+		aria-hidden="true"
+	>
+		<rect width="20" height="14" x="2" y="3" rx="2" />
+		<line x1="8" x2="16" y1="21" y2="21" />
+		<line x1="12" x2="12" y1="17" y2="21" />
+	</svg>
+);

--- a/templates/blog-react/src/components/theme-toggle.css
+++ b/templates/blog-react/src/components/theme-toggle.css
@@ -1,10 +1,15 @@
 .theme-toggle {
 	appearance: none;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
 	border: 1px solid var(--color-border);
 	background: var(--color-surface-elevated);
 	border-radius: 0.375rem;
 	padding: 0.375rem 0.625rem;
-	font-size: var(--text-base);
+	font-size: var(--text-sm, 0.875rem);
+	font-weight: 500;
+	color: var(--color-text);
 	cursor: pointer;
 	transition:
 		border-color 0.15s ease,
@@ -13,4 +18,8 @@
 
 .theme-toggle:hover {
 	border-color: var(--color-accent);
+}
+
+.theme-toggle__label {
+	line-height: 1;
 }

--- a/templates/blog-react/src/components/theme-toggle.tsx
+++ b/templates/blog-react/src/components/theme-toggle.tsx
@@ -1,11 +1,45 @@
 import { eco } from '@ecopages/core';
 import { type ReactNode, useEffect, useState } from 'react';
-import { Moon, Sun } from './icons';
+import { Monitor, Moon, Sun } from './icons';
+
+const PREFERENCES = ['system', 'light', 'dark'] as const;
+type ThemePreference = (typeof PREFERENCES)[number];
+
+const DARK_THEME_QUERY = '(prefers-color-scheme: dark)';
+const STORAGE_KEY = 'theme';
+
+function normalizePreference(value: string | null): ThemePreference {
+	return PREFERENCES.includes(value as ThemePreference) ? (value as ThemePreference) : 'system';
+}
+
+function resolveIsDark(preference: ThemePreference): boolean {
+	if (preference === 'dark') return true;
+	if (preference === 'light') return false;
+	return window.matchMedia(DARK_THEME_QUERY).matches;
+}
+
+function applyTheme(preference: ThemePreference): void {
+	const isDark = resolveIsDark(preference);
+	document.documentElement.classList.toggle('dark', isDark);
+	document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
+}
+
+function preferenceLabel(preference: ThemePreference): string {
+	return `${preference[0].toUpperCase()}${preference.slice(1)}`;
+}
+
+function PreferenceIcon({ preference }: { preference: ThemePreference }): ReactNode {
+	if (preference === 'light') return <Sun size={18} />;
+	if (preference === 'dark') return <Moon size={18} />;
+	return <Monitor size={18} />;
+}
 
 /**
- * Theme toggle button that switches between light and dark modes.
- * Uses a mounted state to prevent hydration mismatches since the theme
- * is determined client-side from the DOM/localStorage.
+ * Cycles `system` → `light` → `dark`.
+ *
+ * @remarks
+ * Preference is read from `localStorage` after mount to avoid hydration mismatch.
+ * While `system` is selected, `prefers-color-scheme` updates the effective theme.
  */
 export const ThemeToggle = eco.component<{}, ReactNode>({
 	dependencies: {
@@ -14,38 +48,42 @@ export const ThemeToggle = eco.component<{}, ReactNode>({
 
 	render: () => {
 		const [mounted, setMounted] = useState(false);
-		const [isDark, setIsDark] = useState(false);
+		const [preference, setPreference] = useState<ThemePreference>('system');
 
 		useEffect(() => {
-			const isDarkTheme = document.documentElement.classList.contains('dark');
-			setIsDark(isDarkTheme);
+			const next = normalizePreference(localStorage.getItem(STORAGE_KEY));
+			setPreference(next);
+			applyTheme(next);
 			setMounted(true);
 		}, []);
 
-		const toggle = () => {
-			const next = !isDark;
-			setIsDark(next);
-			document.documentElement.classList.toggle('dark', next);
-			document.documentElement.setAttribute('data-theme', next ? 'dark' : 'light');
-			localStorage.setItem('theme', next ? 'dark' : 'light');
+		useEffect(() => {
+			if (!mounted || preference !== 'system') return;
+
+			const media = window.matchMedia(DARK_THEME_QUERY);
+			const onChange = () => applyTheme('system');
+			media.addEventListener('change', onChange);
+			return () => media.removeEventListener('change', onChange);
+		}, [mounted, preference]);
+
+		const cycle = () => {
+			const next = PREFERENCES[(PREFERENCES.indexOf(preference) + 1) % PREFERENCES.length];
+			setPreference(next);
+			localStorage.setItem(STORAGE_KEY, next);
+			applyTheme(next);
 		};
 
-		if (!mounted) {
-			return (
-				<button type="button" aria-label="Toggle theme" className="theme-toggle">
-					<span style={{ width: 18, height: 18 }} />
-				</button>
-			);
-		}
+		const label = preferenceLabel(preference);
 
 		return (
 			<button
 				type="button"
-				onClick={toggle}
-				aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+				onClick={mounted ? cycle : undefined}
+				aria-label={`Theme: ${label}`}
 				className="theme-toggle"
 			>
-				{isDark ? <Sun size={18} /> : <Moon size={18} />}
+				<PreferenceIcon preference={preference} />
+				<span className="theme-toggle__label">{label}</span>
 			</button>
 		);
 	},

--- a/templates/blog-react/src/includes/head.tsx
+++ b/templates/blog-react/src/includes/head.tsx
@@ -11,7 +11,7 @@ export const Head = eco.component<PageHeadProps, ReactNode>({
 	render: ({ metadata, children }) => {
 		return (
 			<head>
-				<meta charset="UTF-8" />
+				<meta charSet="UTF-8" />
 				<meta name="viewport" content="width=device-width, initial-scale=1" />
 				<Seo {...metadata} />
 				{children}

--- a/templates/blog-react/src/lib/mdx-plugin-options.ts
+++ b/templates/blog-react/src/lib/mdx-plugin-options.ts
@@ -1,0 +1,7 @@
+import { withContentMdxPlugins } from '@ecopages/content-processor/mdx';
+
+/** MDX plugin options wired into `reactPlugin({ mdx: blogMdxPluginOptions })`. */
+export const blogMdxPluginOptions = {
+	enabled: true as const,
+	...withContentMdxPlugins(),
+};


### PR DESCRIPTION
## Summary
- Centralize MDX plugin options for content collections
- Harden theme toggle behavior and icon set
- Update content-processor docs for React MDX integration

## Test plan
- [x] `pnpm --filter blog-react-template dev`
- [x] Verify theme toggle and MDX post rendering
- [x] Spot-check content-processor docs changes