### PR TITLE
feat(templates/docs-starter): harden docs layout and theme toggle

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1371,6 +1371,9 @@ importers:
 
   templates/docs-starter:
     devDependencies:
+      '@ecopages/browser-router':
+        specifier: workspace:*
+        version: link:../../packages/browser-router
       '@ecopages/content-processor':
         specifier: workspace:*
         version: link:../../packages/processors/content-processor

--- a/templates/docs-starter/README.md
+++ b/templates/docs-starter/README.md
@@ -1,26 +1,32 @@
 # Docs starter template
 
-Minimal Ecopages docs site using `@ecopages/content-processor`, frontmatter-driven MDX, and a catch-all docs route.
+An Ecopages docs site using `@ecopages/content-processor`, frontmatter-driven MDX, and a catch-all docs route. Chrome uses `@ecopages/radiant-ui` (sidebar, TOC, breadcrumb, cycle theme toggle, alerts).
 
 ## Structure
 
 - `src/content/docs/**` — MDX with YAML frontmatter (`title`, `description`, `order`)
-- `src/content/docs.ts` — frontmatter schema, section order, and sort helpers
+- `src/content/docs.ts` — frontmatter schema, section order, icons, and sort helpers
 - `src/content-nav.ts` — sidebar navigation from `ecopages:content/docs`
-- `src/lib/docs/` — MDX component map and plugin options
-- `src/layouts/docs-layout/` — Radiant UI sidebar, mobile trigger, table of contents, and docs bar
+- `src/lib/docs/` — MDX plugin options and catch-all slug helpers
+- `src/layouts/docs-layout/` — sidebar, mobile trigger, table of contents, docs bar, pagination
+- `src/pages/index.tsx` — homepage with links into the docs set
 - `src/pages/docs/[...slug]/index.tsx` — catch-all route using `entries` and `getComponent`
+- `src/styles/components/prose.css` — markdown typography (skips `.unstyled`)
 
 ## Configuration
 
 - Register `contentProcessorPlugin()` from `@ecopages/content-processor/plugin` in `eco.config.ts`.
 - Add pages as `<section>/<slug>.mdx` with frontmatter; reorder with `order` and `DOCS_SECTION_ORDER`.
-- Add shared MDX components in `src/lib/docs/mdx-components.ts`.
+- Import each JSX component directly in the MDX document that uses it. Use `class="unstyled"` on alerts and other chrome so prose styles do not restyle them.
 
-## Docs bar
+## Docs chrome
 
+- `RuiSidebar` — section groups from `docsNav`
+- `RuiToc` — `h2` / `h3` on the current page
 - `RuiBreadcrumb` — resolved server-side from `docsNav`
-- `CopyForLlm` — Radiant clipboard component (`radiant-copy-for-llm`) that fetches the LLM export URL
+- Cycle theme toggle — system / light / dark, persisted in `localStorage`
+- `CopyForLlm` — fetches the LLM export URL for the current page
+- Previous / next pagination across the flattened docs set
 
 ## LLM exports
 
@@ -35,8 +41,8 @@ pnpm build
 pnpm run generate:llms
 ```
 
-Open `/docs/getting-started/introduction` after starting the dev server.
+Open `/` for the homepage and `/docs/getting-started/introduction` for the first docs page.
 
 ## Full docs app
 
-See `apps/docs` for the full docs app: sidebar icons, table of contents, and pagination.
+See `apps/docs` for the production docs app: more sections, code tabs, and syntax highlighting.

--- a/templates/docs-starter/README.md
+++ b/templates/docs-starter/README.md
@@ -7,7 +7,7 @@ An Ecopages docs site using `@ecopages/content-processor`, frontmatter-driven MD
 - `src/content/docs/**` — MDX with YAML frontmatter (`title`, `description`, `order`)
 - `src/content/docs.ts` — frontmatter schema, section order, icons, and sort helpers
 - `src/content-nav.ts` — sidebar navigation from `ecopages:content/docs`
-- `src/lib/docs/` — MDX plugin options and catch-all slug helpers
+- `src/lib/docs/` — MDX plugin options, catch-all slug helpers, and LLM URL generation
 - `src/layouts/docs-layout/` — sidebar, mobile trigger, table of contents, docs bar, pagination
 - `src/pages/index.tsx` — homepage with links into the docs set
 - `src/pages/docs/[...slug]/index.tsx` — catch-all route using `entries` and `getComponent`
@@ -23,9 +23,9 @@ An Ecopages docs site using `@ecopages/content-processor`, frontmatter-driven MD
 
 - `RuiSidebar` — section groups from `docsNav`
 - `RuiToc` — `h2` / `h3` on the current page
-- `RuiBreadcrumb` — resolved server-side from `docsNav`
+- `RuiBreadcrumb` — resolved server-side from `docsNav` and passed into the docs layout
 - Cycle theme toggle — system / light / dark, persisted in `localStorage`
-- `CopyForLlm` — fetches the LLM export URL for the current page
+- `CopyForLlm` — fetches the generated `/docs-llm/<section>/<slug>.md` URL for the current page
 - Previous / next pagination across the flattened docs set
 
 ## LLM exports

--- a/templates/docs-starter/eco.config.ts
+++ b/templates/docs-starter/eco.config.ts
@@ -12,6 +12,10 @@ const appRoot = path.resolve(import.meta.dirname);
 const config = await new ConfigBuilder()
 	.setRootDir(appRoot)
 	.setBaseUrl(process.env.ECOPAGES_BASE_URL ?? 'http://localhost:3000')
+	.setDefaultMetadata({
+		title: 'Docs starter',
+		description: 'An Ecopages docs template with MDX pages, sidebar navigation, and a theme toggle.',
+	})
 	.setIntegrations([
 		ecopagesJsxPlugin({
 			extensions: ['.tsx'],

--- a/templates/docs-starter/package.json
+++ b/templates/docs-starter/package.json
@@ -10,6 +10,7 @@
 		"preview": "ecopages preview"
 	},
 	"devDependencies": {
+		"@ecopages/browser-router": "workspace:*",
 		"@ecopages/content-processor": "workspace:*",
 		"@ecopages/core": "workspace:*",
 		"@ecopages/ecopages-jsx": "workspace:*",

--- a/templates/docs-starter/src/components/theme-toggle/theme-toggle.css
+++ b/templates/docs-starter/src/components/theme-toggle/theme-toggle.css
@@ -1,0 +1,6 @@
+theme-toggle {
+	display: inline-flex;
+	width: fit-content;
+	flex: 0 0 auto;
+	vertical-align: middle;
+}

--- a/templates/docs-starter/src/components/theme-toggle/theme-toggle.script.ts
+++ b/templates/docs-starter/src/components/theme-toggle/theme-toggle.script.ts
@@ -1,0 +1,107 @@
+import type { JsxCustomElementAttributes } from '@ecopages/jsx';
+import { customElement, onEvent } from '@ecopages/radiant';
+import {
+	RuiCycleToggleElement,
+	type ThemePreference,
+	type RuiCycleToggleProps,
+} from '@ecopages/radiant-ui/cycle-toggle';
+
+type ThemeChangeDetail = {
+	theme: ThemePreference;
+	isDark: boolean;
+};
+
+const THEME_TOGGLE_TAG = 'theme-toggle';
+const DARK_THEME_QUERY = '(prefers-color-scheme: dark)';
+const THEME_CHANGE_EVENT = 'eco:theme-change';
+const STORAGE_KEY = 'theme';
+
+function normalizePreference(stored: string | null): ThemePreference {
+	if (stored === 'light' || stored === 'dark' || stored === 'system') {
+		return stored;
+	}
+
+	return 'system';
+}
+
+function resolveIsDark(preference: ThemePreference): boolean {
+	if (preference === 'dark') {
+		return true;
+	}
+
+	if (preference === 'light') {
+		return false;
+	}
+
+	return typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+		? window.matchMedia(DARK_THEME_QUERY).matches
+		: false;
+}
+
+/**
+ * @remarks
+ * Persists `system` / `light` / `dark` in `localStorage`, mirrors `prefers-color-scheme`
+ * while `system` is selected, and broadcasts `eco:theme-change` so remounted toggles stay in sync.
+ */
+@customElement(THEME_TOGGLE_TAG)
+export class ThemeToggle extends RuiCycleToggleElement {
+	override connectedCallback(): void {
+		super.connectedCallback();
+		this.syncWithStoredPreference();
+	}
+
+	@onEvent({ mediaQuery: DARK_THEME_QUERY, type: 'change' })
+	onSystemThemeChange() {
+		if (normalizePreference(this.value) !== 'system') return;
+		this.applyEffectiveTheme();
+	}
+
+	@onEvent({ selector: THEME_TOGGLE_TAG, type: 'rui-change' })
+	onCycleChange() {
+		this.handlePreferenceChange();
+	}
+
+	@onEvent({ window: true, type: THEME_CHANGE_EVENT })
+	onThemeChange(event: CustomEvent<ThemeChangeDetail>) {
+		const { theme } = event.detail;
+		const preference = normalizePreference(theme);
+		if (normalizePreference(this.value) !== preference) {
+			this.value = preference;
+			this.resync();
+		}
+	}
+
+	private handlePreferenceChange() {
+		const preference = normalizePreference(this.value);
+		localStorage.setItem(STORAGE_KEY, preference);
+		this.applyEffectiveTheme();
+		window.dispatchEvent(
+			new CustomEvent<ThemeChangeDetail>(THEME_CHANGE_EVENT, {
+				detail: { theme: preference, isDark: resolveIsDark(preference) },
+			}),
+		);
+	}
+
+	private syncWithStoredPreference() {
+		const preference = normalizePreference(localStorage.getItem(STORAGE_KEY));
+		this.value = preference;
+		this.resync();
+		this.applyEffectiveTheme();
+	}
+
+	private applyEffectiveTheme() {
+		const preference = normalizePreference(this.value);
+		const isDark = resolveIsDark(preference);
+		const effective = isDark ? 'dark' : 'light';
+		document.documentElement.setAttribute('data-theme', effective);
+		document.documentElement.classList.toggle('dark', isDark);
+	}
+}
+
+export type ThemeToggleProps = RuiCycleToggleProps & { id?: string };
+
+declare module '@ecopages/jsx' {
+	interface JsxCustomIntrinsicElements {
+		'theme-toggle': JsxCustomElementAttributes<ThemeToggle, ThemeToggleProps>;
+	}
+}

--- a/templates/docs-starter/src/components/theme-toggle/theme-toggle.tsx
+++ b/templates/docs-starter/src/components/theme-toggle/theme-toggle.tsx
@@ -1,0 +1,39 @@
+import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+import {
+	RuiCycleToggleButton,
+	RuiCycleToggleItem,
+	ThemePreferenceItemContent,
+} from '@ecopages/radiant-ui/cycle-toggle';
+import type { ThemeToggleProps } from './theme-toggle.script';
+import './theme-toggle.script';
+
+export type ThemeToggleViewProps = ThemeToggleProps & {
+	label?: string;
+};
+
+export const ThemeToggle = eco.component<ThemeToggleViewProps, JsxRenderable>({
+	dependencies: {
+		stylesheets: ['./theme-toggle.css'],
+		scripts: ['./theme-toggle.script.ts'],
+	},
+	render: ({ label = 'Theme', value = 'system', variant = 'ghost', size = 'sm', disabled, ...props }) => {
+		const preference = value ?? 'system';
+
+		return (
+			<theme-toggle {...props} value={value} label={label} variant={variant} size={size} disabled={disabled}>
+				<RuiCycleToggleButton variant={variant} size={size} disabled={disabled}>
+					<RuiCycleToggleItem id="system" selected={preference === 'system'}>
+						<ThemePreferenceItemContent preference="system" showLabel={false} />
+					</RuiCycleToggleItem>
+					<RuiCycleToggleItem id="light" selected={preference === 'light'}>
+						<ThemePreferenceItemContent preference="light" showLabel={false} />
+					</RuiCycleToggleItem>
+					<RuiCycleToggleItem id="dark" selected={preference === 'dark'}>
+						<ThemePreferenceItemContent preference="dark" showLabel={false} />
+					</RuiCycleToggleItem>
+				</RuiCycleToggleButton>
+			</theme-toggle>
+		);
+	},
+});

--- a/templates/docs-starter/src/content-nav.ts
+++ b/templates/docs-starter/src/content-nav.ts
@@ -1,3 +1,4 @@
+import type { JsxRenderable } from '@ecopages/jsx';
 import { entries } from 'ecopages:content/docs';
 import {
 	compareDocsEntries,
@@ -9,6 +10,7 @@ import {
 
 export type DocsNavItem = {
 	title: string;
+	description: string;
 	href: string;
 	section: string;
 	slug: string;
@@ -17,6 +19,7 @@ export type DocsNavItem = {
 export type DocsNavSection = {
 	id: string;
 	title: string;
+	icon: JsxRenderable;
 	items: DocsNavItem[];
 };
 
@@ -34,6 +37,7 @@ for (const entry of [...entries].sort(compareDocsEntries)) {
 
 	items.push({
 		title: entry.title,
+		description: entry.description,
 		href: `${DOCS_ROOT}/${sectionId}/${pageSlug}`,
 		section: sectionId,
 		slug: pageSlug,
@@ -55,6 +59,7 @@ export const docsNav: DocsNav = {
 			{
 				id: sectionId,
 				title: config.title,
+				icon: config.icon,
 				items,
 			},
 		];

--- a/templates/docs-starter/src/content/docs.ts
+++ b/templates/docs-starter/src/content/docs.ts
@@ -1,10 +1,12 @@
 import type { ContentEntry } from '@ecopages/content-processor/types';
+import type { JsxRenderable } from '@ecopages/jsx';
 import { z } from 'zod';
+import { gettingStartedIcon, guidesIcon } from './section-icons';
 
 /** Public URL prefix for docs pages. */
 export const DOCS_ROOT = '/docs';
 
-export const DOCS_SECTION_ORDER = ['getting-started'] as const;
+export const DOCS_SECTION_ORDER = ['getting-started', 'guides'] as const;
 
 export type DocsSectionId = (typeof DOCS_SECTION_ORDER)[number];
 
@@ -14,8 +16,15 @@ export const DOCS_SECTION_ORDER_INDEX = new Map<string, number>(
 
 export const LLM_SECTION_ORDER = [...DOCS_SECTION_ORDER] as const;
 
-export const DOCS_SECTION_CONFIG: Record<DocsSectionId, { title: string }> = {
-	'getting-started': { title: 'Getting Started' },
+export const DOCS_SECTION_CONFIG: Record<
+	DocsSectionId,
+	{
+		title: string;
+		icon: JsxRenderable;
+	}
+> = {
+	'getting-started': { title: 'Getting Started', icon: gettingStartedIcon },
+	guides: { title: 'Guides', icon: guidesIcon },
 };
 
 export const docsFrontmatterSchema = z.object({

--- a/templates/docs-starter/src/content/docs/getting-started/introduction.mdx
+++ b/templates/docs-starter/src/content/docs/getting-started/introduction.mdx
@@ -1,16 +1,37 @@
 ---
 title: 'Introduction'
-description: 'Welcome to the docs starter — a minimal Ecopages docs site template.'
+description: 'Welcome to the docs starter — MDX pages, sidebar navigation, and a theme toggle.'
 order: 1
 ---
 
+import { RuiAlert, RuiAlertDescription, RuiAlertTitle } from '@ecopages/radiant-ui/alert';
+
 # Introduction
 
-Welcome to the docs starter. Content files live under `src/content/docs` and are rendered through one catch-all route.
+This template is a minimal docs site: MDX files under `src/content/docs`, one catch-all route, and Radiant UI chrome for the sidebar, table of contents, breadcrumbs, and theme toggle.
 
-LLM exports: [`llms.txt`](/llms.txt) lists every page; full bodies live at `/docs-llm/<section>/<slug>.md`. Both are generated before `dev` and `build`.
+<RuiAlert variant="info" layout="banner" class="unstyled">
+	<RuiAlertTitle>Copy and extend</RuiAlertTitle>
+	<RuiAlertDescription>
+		<p>
+			Replace this content with your product docs. Keep the frontmatter fields (`title`, `description`, `order`)
+			so the sidebar and SEO metadata stay in sync.
+		</p>
+	</RuiAlertDescription>
+</RuiAlert>
 
-## Add a page
+## What you get
 
-1. Add MDX under `src/content/docs/<section>/<slug>.mdx` with frontmatter (`title`, `description`, `order`).
-2. Register new sections in `DOCS_SECTION_ORDER` (`src/content/docs.ts`) when needed.
+- **Sidebar navigation** built from `ecopages:content/docs` in `src/content-nav.ts`
+- **On this page** table of contents from `h2` and `h3` headings
+- **Cycle theme toggle** for system, light, and dark
+- **Copy for LLM** plus [`llms.txt`](/llms.txt) generated before `dev` and `build`
+- **Previous / next** pagination across the docs set
+
+## How a page is rendered
+
+1. Add MDX at `src/content/docs/<section>/<slug>.mdx` with YAML frontmatter.
+2. The catch-all page at `src/pages/docs/[...slug]/index.tsx` resolves the entry and renders `<Content />`.
+3. `DocsLayout` supplies the sidebar, docs bar, prose styles, and pagination.
+
+LLM exports: [`llms.txt`](/llms.txt) lists every page; full bodies live at `/docs-llm/<section>/<slug>.md`. Set `llms: false` in frontmatter to exclude a page.

--- a/templates/docs-starter/src/content/docs/getting-started/next-steps.mdx
+++ b/templates/docs-starter/src/content/docs/getting-started/next-steps.mdx
@@ -1,11 +1,53 @@
 ---
 title: 'Next steps'
-description: 'Extend the starter with more sections, pages, and MDX content.'
+description: 'Add sections, register them in the sidebar, and customize the docs chrome.'
 order: 2
 ---
 
 # Next steps
 
-- Copy this example into your own app.
-- Add MDX pages under `src/content/docs/<section>/`.
-- Import each JSX component directly in the MDX document that uses it.
+Use this page as a checklist after you copy the starter.
+
+## Add a page
+
+1. Create `src/content/docs/<section>/<slug>.mdx`.
+2. Set `title`, `description`, and `order` in frontmatter.
+3. If the section is new, add its id to `DOCS_SECTION_ORDER` and a title (and icon) in `DOCS_SECTION_CONFIG` (`src/content/docs.ts`).
+
+```mdx
+---
+title: 'Installation'
+description: 'Install the CLI and run the docs site locally.'
+order: 2
+---
+
+# Installation
+
+Run `pnpm dev` from the project root.
+```
+
+## Import components in MDX
+
+Each MDX file imports the interactive components it renders. Shared chrome such as alerts is registered from `DocsLayout` so custom elements are defined on every docs page.
+
+```mdx
+import { RuiAlert, RuiAlertDescription, RuiAlertTitle } from '@ecopages/radiant-ui/alert';
+
+<RuiAlert variant="info" layout="banner" class="unstyled">
+	<RuiAlertTitle>Note</RuiAlertTitle>
+	<RuiAlertDescription>
+		<p>Use `unstyled` so prose styles do not restyle the alert.</p>
+	</RuiAlertDescription>
+</RuiAlert>
+```
+
+## Customize the shell
+
+| File | Owns |
+| --- | --- |
+| `src/layouts/docs-layout/` | Sidebar, TOC, pagination, theme toggle |
+| `src/styles/components/prose.css` | Markdown typography |
+| `src/styles/theme.css` | Fonts and semantic color aliases |
+| `src/content-nav.ts` | Sidebar groups from content entries |
+
+See [Writing content](/docs/guides/writing) for a prose sample with headings, lists, tables, and code.

--- a/templates/docs-starter/src/content/docs/guides/writing.mdx
+++ b/templates/docs-starter/src/content/docs/guides/writing.mdx
@@ -1,0 +1,73 @@
+---
+title: 'Writing content'
+description: 'Author MDX with headings, lists, tables, code, and alerts that respect prose styles.'
+order: 1
+---
+
+import { RuiAlert, RuiAlertDescription, RuiAlertTitle } from '@ecopages/radiant-ui/alert';
+
+# Writing content
+
+Docs pages are MDX. Headings, lists, tables, and fenced code pick up styles from `.prose`. Interactive chrome (alerts, buttons) should use the `unstyled` class so those rules do not leak.
+
+## Headings drive the TOC
+
+`h2` and `h3` headings appear in the **On this page** sidebar. Keep titles short; nest `h3` under the `h2` they belong to.
+
+### A nested heading
+
+This `h3` is a child of **Headings drive the TOC**. Click it in the TOC to jump here.
+
+## Lists and emphasis
+
+Use **bold** for UI labels and `inline code` for file paths and APIs.
+
+- Sidebar items come from frontmatter `title`
+- Order within a section comes from `order`
+- Section order comes from `DOCS_SECTION_ORDER`
+
+1. Write the MDX.
+2. Reload the catch-all route.
+3. Confirm the TOC and pagination.
+
+> Keep callouts in `RuiAlert` with `class="unstyled"`. Blockquotes are for quotations, not warnings.
+
+<RuiAlert variant="info" layout="banner" class="unstyled">
+	<RuiAlertTitle>Prose exclusions</RuiAlertTitle>
+	<RuiAlertDescription>
+		<p>
+			`.prose` skips `.unstyled` and `.unstyled *` so alerts, tabs, and other chrome keep their own styles.
+		</p>
+	</RuiAlertDescription>
+</RuiAlert>
+
+## Code
+
+Fence a block when the example is more than one line:
+
+```ts
+export const docsFrontmatterSchema = z.object({
+	title: z.string(),
+	description: z.string(),
+	order: z.coerce.number().optional(),
+});
+```
+
+## Tables
+
+GitHub-flavored markdown tables work via `remark-gfm`.
+
+| Field | Required | Used for |
+| --- | --- | --- |
+| `title` | yes | Sidebar, pagination, `<title>` |
+| `description` | yes | SEO and homepage cards |
+| `order` | no | Sort within a section |
+| `llms` | no | Set `false` to skip LLM export |
+
+## Horizontal rule
+
+Use a rule between major topics when a heading would be too heavy.
+
+---
+
+That is enough to start. Add pages under `src/content/docs` and they show up in the sidebar automatically.

--- a/templates/docs-starter/src/content/section-icons.tsx
+++ b/templates/docs-starter/src/content/section-icons.tsx
@@ -1,0 +1,38 @@
+import type { JsxRenderable } from '@ecopages/jsx';
+
+export const gettingStartedIcon: JsxRenderable = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width="16"
+		height="16"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		aria-hidden="true"
+	>
+		<path d="M7 8l-4 4l4 4" />
+		<path d="M17 8l4 4-4 4" />
+		<path d="M14 4l-4 16" />
+	</svg>
+);
+
+export const guidesIcon: JsxRenderable = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width="16"
+		height="16"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		aria-hidden="true"
+	>
+		<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+		<path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+	</svg>
+);

--- a/templates/docs-starter/src/layouts/base-layout/base-layout.css
+++ b/templates/docs-starter/src/layouts/base-layout/base-layout.css
@@ -1,7 +1,23 @@
 .site-header {
-	@apply border-b border-border bg-background-accent px-6 py-4;
+	@apply sticky top-0 z-50 w-full border-b border-border bg-background/80 backdrop-blur-sm;
 }
 
-.site-header a {
-	@apply font-semibold text-on-background no-underline;
+.header-content {
+	@apply mx-auto flex h-16 w-full max-w-7xl items-center justify-between px-4 md:px-8;
+}
+
+.header-actions {
+	@apply flex items-center gap-1;
+}
+
+.logo {
+	@apply font-heading text-lg font-semibold tracking-tight text-on-background no-underline;
+}
+
+.logo:hover {
+	@apply text-on-background/70;
+}
+
+main {
+	@apply mx-auto w-full max-w-7xl px-4 py-8 md:px-8 md:py-12;
 }

--- a/templates/docs-starter/src/layouts/base-layout/base-layout.script.ts
+++ b/templates/docs-starter/src/layouts/base-layout/base-layout.script.ts
@@ -1,0 +1,6 @@
+import { createRouter } from '@ecopages/browser-router/client';
+
+createRouter({
+	viewTransitions: true,
+	prefetch: { strategy: 'hover' },
+});

--- a/templates/docs-starter/src/layouts/base-layout/base-layout.tsx
+++ b/templates/docs-starter/src/layouts/base-layout/base-layout.tsx
@@ -1,5 +1,8 @@
 import { eco } from '@ecopages/core';
 import type { JsxRenderable } from '@ecopages/jsx';
+import { RuiButton } from '@ecopages/radiant-ui/button';
+import { ThemeToggle } from '@/components/theme-toggle/theme-toggle';
+import { docsNav } from '@/content-nav';
 
 export type BaseLayoutProps = {
 	children: JsxRenderable;
@@ -8,16 +11,48 @@ export type BaseLayoutProps = {
 	showHeader?: boolean;
 };
 
-export const BaseLayout = eco.component<BaseLayoutProps>({
+const docsIndexHref = docsNav.sections[0]?.items[0]?.href ?? '/docs/getting-started/introduction';
+
+export const BaseLayout = eco.component<BaseLayoutProps, JsxRenderable>({
 	dependencies: {
-		stylesheets: ['../../styles/tailwind.css', './base-layout.css'],
+		stylesheets: ['./base-layout.css'],
+		scripts: ['./base-layout.script.ts'],
+		components: [ThemeToggle],
 	},
 	render: ({ children, class: className, showHeader = true }) => {
 		return (
 			<body>
 				{showHeader ? (
 					<header class="site-header">
-						<a href="/">Docs starter</a>
+						<div class="header-content">
+							<a href="/" class="logo">
+								Docs starter
+							</a>
+							<nav class="header-actions" aria-label="Site">
+								<RuiButton href={docsIndexHref} variant="ghost" size="sm">
+									Docs
+								</RuiButton>
+								<RuiButton
+									href="https://github.com/ecopages/ecopages"
+									target="_blank"
+									rel="noopener noreferrer"
+									variant="ghost"
+									size="sm"
+									aria-label="GitHub repository"
+								>
+									<svg
+										viewBox="0 0 98 96"
+										width="20"
+										height="20"
+										fill="currentColor"
+										aria-hidden="true"
+									>
+										<path d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" />
+									</svg>
+								</RuiButton>
+								<ThemeToggle id="toggle-dark-mode" label="Theme" data-eco-persist="theme-toggle" />
+							</nav>
+						</div>
 					</header>
 				) : null}
 				{showHeader ? <main class={className}>{children}</main> : children}

--- a/templates/docs-starter/src/layouts/docs-layout/components/docs-pagination/docs-pagination.script.tsx
+++ b/templates/docs-starter/src/layouts/docs-layout/components/docs-pagination/docs-pagination.script.tsx
@@ -1,0 +1,99 @@
+import { RadiantElement } from '@ecopages/radiant/core/radiant-element';
+import { customElement } from '@ecopages/radiant/decorators/custom-element';
+import { onEvent } from '@ecopages/radiant/decorators/on-event';
+import { state } from '@ecopages/radiant/decorators/state';
+import type { JsxCustomElementAttributes } from '@ecopages/jsx';
+
+type PaginationLink = {
+	href: string;
+	title: string;
+};
+
+type PaginationData = {
+	pages: Array<{
+		href: string;
+		title: string;
+	}>;
+};
+
+function readPaginationPages(): PaginationData['pages'] {
+	const node = document.getElementById('docs-pagination-data');
+	if (!node?.textContent) {
+		return [];
+	}
+
+	try {
+		const parsed = JSON.parse(node.textContent) as PaginationData;
+		return parsed.pages ?? [];
+	} catch {
+		return [];
+	}
+}
+
+@customElement('radiant-docs-pagination')
+export class RadiantDocsPagination extends RadiantElement {
+	@state prevLink: PaginationLink | null = null;
+	@state nextLink: PaginationLink | null = null;
+
+	override connectedCallback(): void {
+		super.connectedCallback();
+		this.renderPagination();
+	}
+
+	@onEvent({ document: true, type: 'eco:page-load' })
+	onPageLoad(): void {
+		this.renderPagination();
+	}
+
+	@onEvent({ document: true, type: 'eco:after-swap' })
+	onAfterSwap(): void {
+		this.renderPagination();
+	}
+
+	renderPagination(): void {
+		const pages = readPaginationPages();
+		const currentPath = window.location.pathname;
+		const currentIndex = pages.findIndex((page) => page.href === currentPath);
+		if (currentIndex === -1) {
+			this.prevLink = null;
+			this.nextLink = null;
+			return;
+		}
+
+		const prevPage = currentIndex > 0 ? pages[currentIndex - 1] : null;
+		const nextPage = currentIndex < pages.length - 1 ? pages[currentIndex + 1] : null;
+		this.prevLink = prevPage ? { href: prevPage.href, title: prevPage.title } : null;
+		this.nextLink = nextPage ? { href: nextPage.href, title: nextPage.title } : null;
+	}
+
+	override render() {
+		if (!this.prevLink && !this.nextLink) {
+			return null;
+		}
+
+		return (
+			<>
+				{this.prevLink ? (
+					<a href={this.prevLink.href} class="group prev">
+						<span class="pagination-label">Previous</span>
+						<span class="pagination-title">{this.prevLink.title}</span>
+					</a>
+				) : (
+					<div></div>
+				)}
+				{this.nextLink ? (
+					<a href={this.nextLink.href} class="group next">
+						<span class="pagination-label">Next</span>
+						<span class="pagination-title">{this.nextLink.title}</span>
+					</a>
+				) : null}
+			</>
+		);
+	}
+}
+
+declare module '@ecopages/jsx' {
+	interface JsxCustomIntrinsicElements {
+		'radiant-docs-pagination': JsxCustomElementAttributes<RadiantDocsPagination>;
+	}
+}

--- a/templates/docs-starter/src/layouts/docs-layout/components/docs-pagination/index.tsx
+++ b/templates/docs-starter/src/layouts/docs-layout/components/docs-pagination/index.tsx
@@ -1,0 +1,12 @@
+import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
+import './docs-pagination.script';
+
+export const DocsPagination = eco.component<Record<string, never>, JsxRenderable>({
+	dependencies: {
+		scripts: ['./docs-pagination.script.tsx'],
+	},
+	render: () => {
+		return <radiant-docs-pagination class="docs-layout__pagination" />;
+	},
+});

--- a/templates/docs-starter/src/layouts/docs-layout/docs-layout.css
+++ b/templates/docs-starter/src/layouts/docs-layout/docs-layout.css
@@ -1,9 +1,14 @@
 @import '@ecopages/radiant-ui/sidebar/docs.css';
 
+/**
+ * Keep `@reference` after the skin `@import` so postcss-import inlines the package
+ * CSS before Tailwind sees a leading `@reference` (which would drop the import).
+ */
 @reference '../../styles/tailwind.css';
 
 .docs-layout {
-	@apply min-h-svh h-svh min-w-0;
+	@apply h-svh min-h-svh min-w-0;
+	--rui-sidebar-background: var(--color-background);
 
 	.rui-sidebar-provider__site-header-inner {
 		@apply px-4 md:px-8;
@@ -14,10 +19,38 @@
 	}
 
 	.docs-layout__content {
-		@apply min-w-0 flex-1 overflow-y-auto px-6 py-6 md:px-10 md:py-10 lg:px-12;
+		@apply min-w-0 flex-1 overflow-y-auto px-6 py-8 md:px-10 md:py-10 lg:px-12;
 	}
 
 	.docs-layout__toc {
 		@apply hidden w-62 shrink-0 overflow-y-auto border-l border-border/60 px-6 py-8 xl:block;
+	}
+
+	.docs-layout__pagination {
+		@apply mt-16 flex flex-col justify-between gap-4 border-t border-border/40 pt-8 sm:flex-row;
+
+		a {
+			@apply flex flex-1 flex-col gap-1 rounded-lg border border-border/40 bg-background-accent/10 p-4 no-underline transition-colors duration-200;
+
+			@media (hover: hover) {
+				@apply hover:border-border/80 hover:bg-background-accent/40;
+			}
+
+			.pagination-label {
+				@apply font-mono text-[10px] uppercase tracking-widest text-on-background/75;
+			}
+
+			.pagination-title {
+				@apply text-sm font-medium text-on-background;
+			}
+
+			&.prev {
+				@apply items-start text-left;
+			}
+
+			&.next {
+				@apply items-end text-right;
+			}
+		}
 	}
 }

--- a/templates/docs-starter/src/layouts/docs-layout/docs-layout.script.ts
+++ b/templates/docs-starter/src/layouts/docs-layout/docs-layout.script.ts
@@ -1,4 +1,22 @@
 /** Registers the Radiant UI custom elements rendered by the docs shell. */
+import '@ecopages/radiant-ui/alert';
 import '@ecopages/radiant-ui/breadcrumb';
 import '@ecopages/radiant-ui/sidebar';
 import '@ecopages/radiant-ui/toc';
+
+const docsContentSelector = '.docs-layout__content';
+
+type DocsNavigationEvent = CustomEvent<{ url: URL }>;
+
+function scrollDocsToTop(): void {
+	document.querySelector<HTMLElement>(docsContentSelector)?.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+}
+
+document.addEventListener('eco:after-swap', (event) => {
+	const { url } = (event as DocsNavigationEvent).detail;
+	if (url.hash) {
+		return;
+	}
+
+	scrollDocsToTop();
+});

--- a/templates/docs-starter/src/layouts/docs-layout/docs-layout.tsx
+++ b/templates/docs-starter/src/layouts/docs-layout/docs-layout.tsx
@@ -20,6 +20,7 @@ import type { BreadcrumbItem } from '@/components/breadcrumb/breadcrumb';
 import { ThemeToggle } from '@/components/theme-toggle/theme-toggle';
 import { docsNav } from '@/content-nav';
 import { BaseLayout } from '@/layouts/base-layout';
+import { getDocsLlmUrl } from '@/lib/docs/docs-llm-url';
 import { DocsPagination } from './components/docs-pagination';
 import { DocsBar } from './docs-bar';
 
@@ -138,7 +139,7 @@ export const DocsLayout = eco.layout<JsxRenderable>({
 		components: [BaseLayout, DocsBar, DocsPagination, ThemeToggle],
 	},
 	render: ({ children, section, slug }: DocsLayoutRenderProps) => {
-		const llmUrl = section && slug ? `/docs-llm/${section}/${slug}.md` : undefined;
+		const llmUrl = section && slug ? getDocsLlmUrl(section, slug) : undefined;
 		const crumbs = breadcrumbForPage(section, slug);
 
 		return (

--- a/templates/docs-starter/src/layouts/docs-layout/docs-layout.tsx
+++ b/templates/docs-starter/src/layouts/docs-layout/docs-layout.tsx
@@ -1,6 +1,7 @@
 import { eco } from '@ecopages/core';
 import type { LayoutProps } from '@ecopages/core';
 import type { JsxRenderable } from '@ecopages/jsx';
+import { RuiButton } from '@ecopages/radiant-ui/button';
 import {
 	RuiSidebar,
 	RuiSidebarContent,
@@ -16,8 +17,10 @@ import {
 } from '@ecopages/radiant-ui/sidebar';
 import { RuiToc } from '@ecopages/radiant-ui/toc';
 import type { BreadcrumbItem } from '@/components/breadcrumb/breadcrumb';
+import { ThemeToggle } from '@/components/theme-toggle/theme-toggle';
 import { docsNav } from '@/content-nav';
 import { BaseLayout } from '@/layouts/base-layout';
+import { DocsPagination } from './components/docs-pagination';
 import { DocsBar } from './docs-bar';
 
 type DocsLayoutPageProps = {
@@ -29,6 +32,10 @@ type DocsLayoutRenderProps = LayoutProps<JsxRenderable> & DocsLayoutPageProps;
 
 const DOCS_SIDEBAR_ID = 'docs-sidebar';
 const ECO_NAVIGATION_EVENTS = 'eco:page-load,eco:after-swap';
+
+const paginationData = JSON.stringify({
+	pages: docsNav.sections.flatMap((section) => section.items).map(({ href, title }) => ({ href, title })),
+});
 
 function breadcrumbForPage(section: string | undefined, slug: string | undefined): BreadcrumbItem[] {
 	if (!section || !slug) {
@@ -58,11 +65,77 @@ function breadcrumbForPage(section: string | undefined, slug: string | undefined
 	];
 }
 
+const DocsNavigation = () => (
+	<>
+		{docsNav.sections.map((section, index) => (
+			<>
+				{index > 0 ? <RuiSidebarSeparator aria-label="Section divider" /> : null}
+				<RuiSidebarGroup aria-label={section.title}>
+					<RuiSidebarGroupHeader
+						label={
+							<>
+								<span class="rui-sidebar__group-icon">{section.icon}</span>
+								<span>{section.title}</span>
+							</>
+						}
+					/>
+					<RuiSidebarMenu aria-label={`${section.title} links`}>
+						{section.items.map((page) => (
+							<RuiSidebarMenuItem>
+								<RuiSidebarMenuButton as="a" href={page.href}>
+									{page.title}
+								</RuiSidebarMenuButton>
+							</RuiSidebarMenuItem>
+						))}
+					</RuiSidebarMenu>
+				</RuiSidebarGroup>
+			</>
+		))}
+	</>
+);
+
+const DocsSiteHeader = () => (
+	<div class="rui-sidebar-provider__site-header-inner">
+		<div class="rui-sidebar-provider__site-header-start">
+			<RuiSidebarTrigger
+				class="md:hidden rui-sidebar-trigger-placement--header"
+				placement="header"
+				controls={DOCS_SIDEBAR_ID}
+				triggerLabel="Close documentation navigation"
+			/>
+			<RuiSidebarTrigger
+				class="md:hidden rui-sidebar-trigger-placement--inset"
+				placement="inset"
+				controls={DOCS_SIDEBAR_ID}
+				triggerLabel="Open documentation navigation"
+			/>
+			<a class="rui-sidebar-provider__site-header-brand" href="/">
+				Docs starter
+			</a>
+		</div>
+		<nav class="rui-sidebar-provider__site-header-nav" aria-label="Site">
+			<RuiButton
+				href="https://github.com/ecopages/ecopages"
+				target="_blank"
+				rel="noopener noreferrer"
+				variant="ghost"
+				size="sm"
+				aria-label="GitHub repository"
+			>
+				<svg viewBox="0 0 98 96" width="20" height="20" fill="currentColor" aria-hidden="true">
+					<path d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" />
+				</svg>
+			</RuiButton>
+			<ThemeToggle id="toggle-dark-mode" label="Theme" data-eco-persist="theme-toggle" />
+		</nav>
+	</div>
+);
+
 export const DocsLayout = eco.layout<JsxRenderable>({
 	dependencies: {
 		stylesheets: ['./docs-layout.css'],
 		scripts: ['./docs-layout.script.ts'],
-		components: [BaseLayout, DocsBar],
+		components: [BaseLayout, DocsBar, DocsPagination, ThemeToggle],
 	},
 	render: ({ children, section, slug }: DocsLayoutRenderProps) => {
 		const llmUrl = section && slug ? `/docs-llm/${section}/${slug}.md` : undefined;
@@ -70,24 +143,13 @@ export const DocsLayout = eco.layout<JsxRenderable>({
 
 		return (
 			<BaseLayout showHeader={false}>
+				<script type="application/json" id="docs-pagination-data" safe>
+					{paginationData}
+				</script>
 				<RuiSidebarProvider
 					layout="docs"
 					class="docs-layout"
-					siteHeader={
-						<div class="rui-sidebar-provider__site-header-inner">
-							<div class="rui-sidebar-provider__site-header-start">
-								<RuiSidebarTrigger
-									class="md:hidden"
-									placement="inset"
-									controls={DOCS_SIDEBAR_ID}
-									triggerLabel="Toggle documentation navigation"
-								/>
-								<a class="rui-sidebar-provider__site-header-brand" href="/">
-									Docs starter
-								</a>
-							</div>
-						</div>
-					}
+					siteHeader={<DocsSiteHeader />}
 					sidebar={
 						<RuiSidebar
 							id={DOCS_SIDEBAR_ID}
@@ -102,23 +164,7 @@ export const DocsLayout = eco.layout<JsxRenderable>({
 							navigationEvents={ECO_NAVIGATION_EVENTS}
 						>
 							<RuiSidebarContent aria-label="Documentation navigation">
-								{docsNav.sections.map((section, index) => (
-									<>
-										{index > 0 ? <RuiSidebarSeparator aria-label="Section divider" /> : null}
-										<RuiSidebarGroup aria-label={section.title}>
-											<RuiSidebarGroupHeader label={section.title} />
-											<RuiSidebarMenu aria-label={`${section.title} links`}>
-												{section.items.map((page) => (
-													<RuiSidebarMenuItem>
-														<RuiSidebarMenuButton as="a" href={page.href}>
-															{page.title}
-														</RuiSidebarMenuButton>
-													</RuiSidebarMenuItem>
-												))}
-											</RuiSidebarMenu>
-										</RuiSidebarGroup>
-									</>
-								))}
+								<DocsNavigation />
 							</RuiSidebarContent>
 						</RuiSidebar>
 					}
@@ -127,6 +173,7 @@ export const DocsLayout = eco.layout<JsxRenderable>({
 						<div class="docs-layout__content">
 							<DocsBar crumbs={crumbs} llmUrl={llmUrl} />
 							<div class="prose">{children}</div>
+							<DocsPagination />
 						</div>
 					</RuiSidebarInset>
 					<RuiToc

--- a/templates/docs-starter/src/lib/docs/docs-llm-url.ts
+++ b/templates/docs-starter/src/lib/docs/docs-llm-url.ts
@@ -1,0 +1,6 @@
+/**
+ * Maps a docs page to the generated static markdown URL used by the LLM copy action.
+ */
+export function getDocsLlmUrl(section: string, slug: string): string {
+	return `/docs-llm/${section}/${slug}.md`;
+}

--- a/templates/docs-starter/src/pages/docs/[...slug]/index.tsx
+++ b/templates/docs-starter/src/pages/docs/[...slug]/index.tsx
@@ -4,7 +4,7 @@ import { HttpError } from '@ecopages/core/errors';
 import type { JsxRenderable } from '@ecopages/jsx';
 import { entries } from 'ecopages:content/docs';
 import { getComponent, getEntryDependencies } from 'ecopages:content/docs/server';
-import { parseDocsCatchAllSegments } from '@/lib/docs/resolve-from-catch-all';
+import { parseDocsCatchAllSegments, resolveFromCatchAll } from '@/lib/docs/resolve-from-catch-all';
 import { DocsLayout } from '@/layouts/docs-layout';
 
 type DocsCatchAllProps = {
@@ -39,7 +39,10 @@ const staticProps: GetStaticProps<DocsCatchAllProps> = async ({ pathname }) => {
 };
 
 export default eco.page<DocsCatchAllProps, JsxRenderable>({
-	layout: DocsLayout,
+	layout: {
+		component: DocsLayout,
+		props: ({ params }) => resolveFromCatchAll(params?.slug),
+	},
 	staticPaths: async () => ({
 		paths: entries.map((entry) => ({
 			params: {

--- a/templates/docs-starter/src/pages/index.css
+++ b/templates/docs-starter/src/pages/index.css
@@ -1,0 +1,54 @@
+.home-layout {
+	@apply flex flex-col gap-12;
+}
+
+.home-hero {
+	@apply flex max-w-3xl flex-col gap-8 border-b border-border pb-10;
+}
+
+.home-hero__heading .rui-heading__title {
+	text-wrap: balance;
+}
+
+.home-hero__actions {
+	@apply flex flex-wrap items-center gap-3;
+}
+
+.home-path__list {
+	@apply mt-4 list-decimal space-y-3 pl-5 text-sm leading-relaxed text-on-background/80;
+}
+
+.home-cards {
+	@apply mt-8 grid gap-3 sm:grid-cols-2;
+}
+
+.home-card {
+	@apply flex flex-col gap-1 rounded-sm border border-border bg-background p-4 text-on-background no-underline transition-colors duration-200;
+}
+
+@media (hover: hover) {
+	.home-card:hover {
+		@apply bg-secondary-container/30;
+	}
+}
+
+.home-card:focus-visible {
+	@apply rounded-sm outline-2 outline-offset-2 outline-primary;
+}
+
+.home-card__section {
+	@apply m-0 text-xs font-medium tracking-wide text-on-background/60 uppercase;
+}
+
+.home-card__title {
+	@apply m-0 text-sm font-semibold text-on-background;
+}
+
+.home-card__description {
+	@apply m-0 text-sm text-on-background/70;
+}
+
+.home-hero code,
+.home-path__list code {
+	@apply rounded-md border border-border/30 bg-muted px-1.5 py-0.5 font-mono text-[0.875em];
+}

--- a/templates/docs-starter/src/pages/index.tsx
+++ b/templates/docs-starter/src/pages/index.tsx
@@ -1,17 +1,71 @@
 import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
 import { RuiButton } from '@ecopages/radiant-ui/button';
+import { RuiHeading, RuiHeadingDescription, RuiHeadingEyebrow, RuiHeadingTitle } from '@ecopages/radiant-ui/heading';
+import { docsNav } from '@/content-nav';
 import { BaseLayout } from '@/layouts/base-layout';
 
-export default eco.page({
+const docsIndexHref = docsNav.sections[0]?.items[0]?.href ?? '/docs/getting-started/introduction';
+const writingHref =
+	docsNav.sections.flatMap((section) => section.items).find((page) => page.slug === 'writing')?.href ??
+	'/docs/guides/writing';
+
+export default eco.page<{}, JsxRenderable>({
 	layout: BaseLayout,
-	render: () => {
-		return (
-			<div class="prose">
-				<h1>Docs starter</h1>
-				<p>
-					<RuiButton href="/docs/getting-started/introduction">Open the docs</RuiButton>
-				</p>
-			</div>
-		);
+	dependencies: {
+		stylesheets: ['./index.css'],
 	},
+	metadata: () => ({
+		title: 'Docs starter',
+		description: 'An Ecopages docs template with MDX pages, sidebar navigation, prose, and a theme toggle.',
+	}),
+	render: () => (
+		<div class="home-layout">
+			<header class="home-hero">
+				<RuiHeading size="xl" class="home-hero__heading">
+					<RuiHeadingEyebrow>Documentation starter</RuiHeadingEyebrow>
+					<RuiHeadingTitle as="h1">
+						MDX docs with a sidebar, table of contents, and a theme toggle.
+					</RuiHeadingTitle>
+					<RuiHeadingDescription>
+						Author pages under <code>src/content/docs</code>. One catch-all route renders every entry with
+						breadcrumbs, copy-for-LLM, and previous/next pagination.
+					</RuiHeadingDescription>
+				</RuiHeading>
+				<div class="home-hero__actions">
+					<RuiButton href={docsIndexHref}>Read introduction</RuiButton>
+					<RuiButton href={writingHref} variant="outline">
+						See prose
+					</RuiButton>
+				</div>
+			</header>
+
+			<section class="home-path" aria-label="Start here">
+				<RuiHeading as="header" size="sm">
+					<RuiHeadingEyebrow>In this starter</RuiHeadingEyebrow>
+					<RuiHeadingTitle as="h2">Start here</RuiHeadingTitle>
+				</RuiHeading>
+				<ol class="home-path__list">
+					<li>Open a docs page and switch theme with the cycle toggle in the header.</li>
+					<li>
+						Add MDX under <code>src/content/docs/&lt;section&gt;/&lt;slug&gt;.mdx</code>.
+					</li>
+					<li>
+						Register new sections in <code>DOCS_SECTION_ORDER</code>.
+					</li>
+				</ol>
+				<div class="home-cards">
+					{docsNav.sections.flatMap((section) =>
+						section.items.map((page) => (
+							<a href={page.href} class="home-card">
+								<p class="home-card__section">{section.title}</p>
+								<p class="home-card__title">{page.title}</p>
+								<p class="home-card__description">{page.description}</p>
+							</a>
+						)),
+					)}
+				</div>
+			</section>
+		</div>
+	),
 });

--- a/templates/docs-starter/src/styles/components/prose.css
+++ b/templates/docs-starter/src/styles/components/prose.css
@@ -1,0 +1,120 @@
+.prose {
+	@apply text-on-background/90 text-base leading-[1.65];
+
+	h1:not(.unstyled, .unstyled *) {
+		@apply mt-12 mb-6 font-heading text-4xl leading-tight font-extrabold tracking-tight text-on-background-accent;
+	}
+
+	h2:not(.unstyled, .unstyled *) {
+		@apply mt-10 mb-5 font-heading text-3xl leading-tight font-bold tracking-tight text-on-background-accent;
+		scroll-margin-top: 7.5rem;
+	}
+
+	h3:not(.unstyled, .unstyled *) {
+		@apply mt-8 mb-4 font-heading text-2xl leading-snug font-bold tracking-tight text-on-background-accent;
+		scroll-margin-top: 7.5rem;
+	}
+
+	h4:not(.unstyled, .unstyled *) {
+		@apply mt-6 mb-4 font-heading text-xl leading-snug font-bold tracking-tight text-on-background-accent;
+	}
+
+	h5:not(.unstyled, .unstyled *) {
+		@apply mt-6 mb-4 font-heading text-lg leading-snug font-bold text-on-background-accent;
+	}
+
+	h6:not(.unstyled, .unstyled *) {
+		@apply mt-6 mb-4 font-heading text-base leading-snug font-bold text-on-background-accent;
+	}
+
+	p:not(.unstyled, .unstyled *) {
+		@apply mt-2 mb-7;
+	}
+
+	a:not(.unstyled, .unstyled *, .rui-button) {
+		@apply text-link font-medium underline decoration-link/30 underline-offset-4 transition-colors duration-200 hover:decoration-link;
+	}
+
+	strong:not(.unstyled, .unstyled *) {
+		@apply font-semibold;
+	}
+
+	ul:not(.unstyled, .unstyled *),
+	ol:not(.unstyled, .unstyled *) {
+		@apply my-6 pl-6 text-on-background;
+
+		li {
+			@apply my-2 pl-2;
+		}
+	}
+
+	ul:not(.unstyled, .unstyled *) {
+		@apply list-disc;
+
+		li::marker {
+			@apply text-on-background/40;
+		}
+	}
+
+	ol:not(.unstyled, .unstyled *) {
+		@apply list-decimal;
+
+		li::marker {
+			@apply font-medium text-on-background/60;
+		}
+	}
+
+	blockquote:not(.unstyled, .unstyled *) {
+		@apply my-8 rounded-r-xl border-l-[3px] border-primary/50 bg-primary/5 py-2 pl-5 font-serif text-on-background/80 italic;
+
+		p {
+			@apply my-0;
+		}
+	}
+
+	code:not(.unstyled, .unstyled *, :where(figure[data-rehype-pretty-code-figure] *)) {
+		@apply rounded-md border border-border/30 bg-muted px-1.5 py-0.5 font-mono text-[0.875em] text-on-background-accent;
+	}
+
+	pre:not(.unstyled, .unstyled *, :where(figure[data-rehype-pretty-code-figure] *)) {
+		@apply my-8 overflow-x-auto rounded-md border border-border bg-background-accent p-5 shadow-sm;
+
+		code {
+			@apply rounded-none border-none bg-transparent p-0 text-[0.875em] leading-relaxed text-inherit;
+		}
+	}
+
+	hr:not(.unstyled, .unstyled *) {
+		@apply my-10 border-t border-border/40;
+	}
+
+	table:not(.unstyled, .unstyled *) {
+		@apply my-8 block w-full border-collapse overflow-hidden rounded-xl border border-border/30 text-left text-sm ring-1 ring-border/20 md:table;
+
+		thead {
+			@apply border-b border-border/50 bg-background-accent/20;
+
+			th {
+				@apply px-4 py-3 font-semibold whitespace-nowrap text-on-background-accent;
+			}
+		}
+
+		tbody {
+			tr {
+				@apply border-b border-border/30 transition-colors hover:bg-background-accent/10;
+
+				td {
+					@apply px-4 py-3 align-top text-on-background;
+
+					code {
+						@apply whitespace-nowrap;
+					}
+				}
+
+				&:last-child {
+					@apply border-0;
+				}
+			}
+		}
+	}
+}

--- a/templates/docs-starter/src/styles/tailwind.css
+++ b/templates/docs-starter/src/styles/tailwind.css
@@ -1,4 +1,6 @@
 @import 'tailwindcss';
 @import '@ecopages/radiant-ui/themes/default';
 @import './theme.css';
+@import './components/prose.css';
 @import '@ecopages/radiant-ui/styles.css';
+@import 'ecopages/css/view-transitions.css';

--- a/templates/docs-starter/src/styles/theme.css
+++ b/templates/docs-starter/src/styles/theme.css
@@ -1,13 +1,27 @@
+@custom-variant dark (&:where([data-theme='dark'], [data-theme='dark'] *, .dark, .dark *));
+
 @theme {
 	--font-heading: ui-sans-serif, system-ui, sans-serif;
-	--color-background: hsl(0 0% 100%);
-	--color-background-accent: hsl(210 20% 98%);
-	--color-on-background: hsl(222 47% 11%);
-	--color-primary: hsl(221 83% 53%);
-	--color-secondary: hsl(0 84% 60%);
-	--color-border: color-mix(in oklab, var(--color-on-background) 15%, transparent);
+	--color-background-accent: var(--surface);
+	--color-on-background-accent: var(--on-surface);
+	--color-muted: var(--surface-container-low);
+}
+
+html {
+	@apply bg-background;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	html {
+		scroll-behavior: smooth;
+	}
 }
 
 body {
-	@apply bg-background text-on-background min-h-svh font-sans;
+	@apply relative z-0 min-h-svh font-sans text-on-background antialiased;
+}
+
+::selection {
+	background: color-mix(in oklab, var(--color-primary) 18%, transparent);
+	color: var(--color-on-background);
 }


### PR DESCRIPTION
## Summary
- Add theme toggle component with persistence script
- Improve docs layout, pagination, and prose styling
- Expand starter content and navigation

## Test plan
- [x] `pnpm --filter docs-starter-template dev`
- [x] Verify docs nav, pagination, and theme toggle
- [x] Check new writing guide page renders