### PR TITLE
docs(sitemap): document static export behavior

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,6 +7,7 @@ A file-based web framework for building HTML-first multi-page applications, with
 - [Language](#language)
 - [Relationships](#relationships)
 - [Flagged ambiguities](#flagged-ambiguities)
+- [Further reading](#further-reading)
 
 ## Language
 
@@ -118,6 +119,10 @@ _Avoid_: island wrapper, hydration target
 A development-only in-browser inspector injected during `ecopages dev`. It surfaces navigation, dependency, island, and accessibility diagnostics without shipping to production. Extend it by replacing `devToolbar.package` with a custom client package; integrations do not register dock apps.
 _Avoid_: dev overlay, debug widget
 
+**Sitemap**:
+An optional `sitemap.xml` written during static export when enabled in app config. It lists absolute URLs for successfully exported, indexable pages plus configured `extraUrls`.
+_Avoid_: URL list, crawl map
+
 ## Relationships
 
 - A **Page** is composed from a **Component** tree, optionally wrapped by a **Layout**, all rendered within an **Html** shell
@@ -137,6 +142,9 @@ _Avoid_: dev overlay, debug widget
 - When an **Integration** encounters a **Foreign Child**, it must hand off the corresponding **Foreign Subtree** to the owning **Integration** before final HTML is returned
 - Each **Page** may produce one **Page Browser Graph**, including any lazy browser entries that belong to that Page
 - An **Integration** may apply an **SSR Policy** per Page or Component without forcing one global browser runtime bundle for every Page
+- When enabled, a **Sitemap** is written after static export hooks complete; it lists eligible **Static Path Expansions** and other exported static routes whose page metadata allows indexing
+- **Page** metadata `robots.index: false` removes a route from the **Sitemap** when metadata resolves during export; metadata resolution failures omit the URL as well (fail-closed)
+- `sitemap.exclude` filters eligible pathnames; `extraUrls` append non-page URLs that bypass `exclude` and page-level robots checks
 
 ## Flagged ambiguities
 
@@ -148,4 +156,5 @@ _Avoid_: dev overlay, debug widget
 
 - [AGENTS.md](./AGENTS.md) — coding standards, documentation routing, and README maintenance
 - [packages/core/README.md](./packages/core/README.md) — subsystem architecture index
+- [Sitemap](./apps/docs/src/content/docs/core/sitemap.mdx) — user guide for automatic `sitemap.xml` generation
 - [docs/adr/](./docs/adr/) — accepted product and release decisions

--- a/apps/docs/src/content/docs/core/build-and-host.mdx
+++ b/apps/docs/src/content/docs/core/build-and-host.mdx
@@ -44,5 +44,6 @@ See [Starting the server](/docs/server/server-api#starting-the-server) for a ful
 ## Further reading
 
 - [Architecture](/docs/core/architecture)
+- [Sitemap](/docs/core/sitemap) — optional `sitemap.xml` during static export
 - [Vite Plugin](/docs/ecosystem/vite-plugin)
 - [Build layer README](https://github.com/ecopages/ecopages/blob/main/packages/core/src/build/README.md) in the repository

--- a/apps/docs/src/content/docs/core/concepts.mdx
+++ b/apps/docs/src/content/docs/core/concepts.mdx
@@ -117,9 +117,11 @@ const MyComponent = eco.component({
 });
 ```
 
-## Robots.txt Generation
+## Robots.txt and sitemap
 
-Ecopages automatically generates a robots.txt file based on your configuration. You can customize this in your `eco.config.ts` file.
+Ecopages writes `robots.txt` on every static export from `setRobotsTxt()` preferences.
+
+Optional `sitemap.xml` generation is separate and disabled by default. Enable it with `setSitemap({ enabled: true })` — see [Sitemap](/docs/core/sitemap) for eligibility, `exclude`, `extraUrls`, and page-level `metadata.robots.index`.
 
 ## Import CSS as String in JS Files
 

--- a/apps/docs/src/content/docs/core/sitemap.mdx
+++ b/apps/docs/src/content/docs/core/sitemap.mdx
@@ -1,0 +1,165 @@
+---
+title: "Sitemap"
+description: "Generate sitemap.xml during static export — eligibility rules, exclude patterns, extra URLs, and page-level noindex."
+order: 14
+---
+
+import { RuiAlert, RuiAlertDescription, RuiAlertTitle } from '@ecopages/radiant-ui/alert';
+
+# Sitemap
+
+Ecopages can emit a [sitemaps.org](https://www.sitemaps.org/protocol.html) `urlset` during static export. The file lists absolute `<loc>` URLs for indexable pages plus any non-page URLs you add in config.
+
+Sitemap generation is **opt in** and **disabled by default**. Enable it when you want search engines to discover your statically exported routes without maintaining `sitemap.xml` by hand.
+
+## Enable sitemap generation
+
+Add `setSitemap()` to `eco.config.ts`:
+
+```typescript
+import { ConfigBuilder } from '@ecopages/core/config-builder';
+
+const config = await new ConfigBuilder()
+	.setRootDir(process.cwd())
+	.setBaseUrl(process.env.ECOPAGES_BASE_URL ?? 'https://example.com')
+	.setSitemap({
+		enabled: true,
+		extraUrls: ['/rss.xml'],
+		exclude: ['/admin/**'],
+	})
+	.build();
+
+export default config;
+```
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `enabled` | `false` | Write a sitemap file during static export |
+| `fileName` | `sitemap.xml` | Output file name inside `dist/` |
+| `exclude` | `[]` | Pathname patterns to omit after eligibility checks |
+| `extraUrls` | `[]` | Additional URLs to append (feeds, manifests, integration artifacts) |
+
+Set `ECOPAGES_BASE_URL` (or `setBaseUrl()`) to your production origin before `ecopages build`. Every page URL in the sitemap is resolved against that base.
+
+See [Configuration](/docs/getting-started/configuration) and [Canonical Base URL](/docs/reference/cli-reference#canonical-base-url) for precedence rules.
+
+## What gets included
+
+During static export, Ecopages builds the sitemap in two passes:
+
+1. **Eligibility** — collect pathnames for pages that exported successfully and pass metadata robots checks.
+2. **Assembly** — apply `exclude`, resolve absolute locations, append `extraUrls`, dedupe.
+
+Pipeline for each page URL:
+
+1. Static export renders the page (or reuses a cached render).
+2. Metadata must resolve; resolution errors omit the URL.
+3. `metadata.robots.index: false` omits the URL.
+4. Matching `exclude` patterns omit the URL.
+5. Remaining pathnames become `<loc>` entries; `extraUrls` append afterward.
+6. `sitemap.xml` is written after `afterStaticExport`.
+
+### Eligible pages
+
+A pathname is eligible when all of the following are true:
+
+- The page is part of the static export run (filesystem routes and `app.static()` views with a static cache strategy).
+- Static HTML for that pathname was written or reused from the incremental static cache.
+- Page metadata resolves during export.
+- `metadata.robots.index` is not `false`.
+
+Ecopages is **fail-closed** on metadata: if metadata resolution throws, the URL is omitted even when HTML was generated.
+
+<RuiAlert variant="info" layout="banner" class="unstyled">
+	<RuiAlertTitle>Dynamic pages are out of scope</RuiAlertTitle>
+	<RuiAlertDescription>
+		Pages with <code>cache: 'dynamic'</code> are skipped during static generation and never appear in the sitemap.
+		Request-time-only routes are not listed either.
+	</RuiAlertDescription>
+</RuiAlert>
+
+### Page-level noindex
+
+Use `metadata.robots.index: false` to keep a page out of the sitemap and emit a noindex robots meta tag:
+
+```tsx
+import { eco } from '@ecopages/core';
+
+export default eco.page({
+	metadata: () => ({
+		title: 'Draft',
+		description: 'Not ready for indexing',
+		robots: { index: false },
+	}),
+	render: () => <p>Draft content</p>,
+});
+```
+
+The same rule applies to explicit static views registered with `app.static()` when they expose `metadata`.
+
+### Bulk exclusion with `exclude`
+
+After eligibility, `exclude` removes matching pathnames. Supported patterns:
+
+| Pattern | Matches |
+| --- | --- |
+| `/admin` | Exact pathname `/admin` |
+| `/admin/**` | `/admin` and every descendant (`/admin/users`, …) |
+
+This is not a full glob engine. Patterns outside these forms are treated as exact pathnames.
+
+### Extra URLs with `extraUrls`
+
+`extraUrls` append non-page URLs after page URLs. Typical uses:
+
+- RSS or Atom feeds (`/rss.xml`)
+- Web app manifests
+- Files an integration writes in `afterStaticExport`
+
+Relative paths resolve against `baseUrl`. Absolute `http(s)` URLs pass through unchanged.
+
+<RuiAlert variant="warning" layout="banner" class="unstyled">
+	<RuiAlertTitle>extraUrls bypass exclude and page robots</RuiAlertTitle>
+	<RuiAlertDescription>
+		URLs in <code>extraUrls</code> are always appended (deduped). They are not filtered by <code>exclude</code> or
+		<code>metadata.robots.index</code>. Use this deliberately — for example to list <code>/admin/manifest.json</code>{' '}
+		while excluding <code>/admin/**</code> pages.
+	</RuiAlertDescription>
+</RuiAlert>
+
+## Build timing
+
+Static export runs in this order:
+
+1. `beforeStaticExport`
+2. `robots.txt` generation
+3. Static page rendering
+4. `afterStaticExport` (integration hooks)
+5. **Sitemap write** (when `enabled: true`)
+
+The sitemap is written **after** `afterStaticExport` so integrations can finish generating artifacts before you list them in `extraUrls`.
+
+`StaticExportContext.routes` exposes the full static-generation route list without sitemap filtering. Integrations that emit custom files should add those URLs to `extraUrls` (or maintain a separate sitemap) rather than assuming every route in `routes` appears in `sitemap.xml`.
+
+## Output format
+
+Ecopages writes a sitemap.org 0.9 `urlset` with one `<url><loc>…</loc></url>` entry per location. XML special characters in URLs are escaped.
+
+The generator does **not** emit `lastmod`, `changefreq`, or `priority`, and does not produce sitemap index files. For large sites that need those fields, generate a custom sitemap in an integration hook or check in a static file under `public/`.
+
+## Verify the output
+
+After a production build:
+
+```bash
+ECOPAGES_BASE_URL=https://example.com pnpm run build
+grep -o '<loc>[^<]*</loc>' dist/sitemap.xml
+```
+
+Confirm production `robots.txt` references the sitemap if you want crawlers to discover it automatically — Ecopages does not add a `Sitemap:` directive for you.
+
+## Related configuration
+
+- [Configuration](/docs/getting-started/configuration) — `setSitemap()` and `setRobotsTxt()`
+- [Pages](/docs/core/pages) — page metadata and cache strategies
+- [Deployment](/docs/reference/deployment) — set `ECOPAGES_BASE_URL` before building for production

--- a/apps/docs/src/content/docs/getting-started/configuration.mdx
+++ b/apps/docs/src/content/docs/getting-started/configuration.mdx
@@ -106,6 +106,17 @@ No template filename setter is required in `eco.config.ts`. If `500.*` is missin
 	Configuration for the robots.txt file.
 </ApiField>
 
+<ApiField
+	name="sitemap"
+	type="SitemapConfig"
+	defaultValue="{ enabled: false, fileName: 'sitemap.xml', extraUrls: [], exclude: [] }"
+	setter="setSitemap"
+>
+	Automatic <code>sitemap.xml</code> generation during static export. Disabled by default. See{' '}
+	<a href="/docs/core/sitemap">Sitemap</a> for eligibility rules, <code>exclude</code> patterns, and{' '}
+	<code>extraUrls</code>.
+</ApiField>
+
 <ApiField name="integrations" type="IntegrationPlugin[]" defaultValue="[]" setter="setIntegrations">
 	An array of integration plugins to enhance Ecopages functionality.
 </ApiField>

--- a/apps/docs/src/content/docs/reference/cli-reference.mdx
+++ b/apps/docs/src/content/docs/reference/cli-reference.mdx
@@ -109,7 +109,7 @@ Ecopages listens to environment variables for configuration. When these are set,
 
 ### Canonical Base URL
 
-Used for generating absolute URLs in production builds (meta tags, sitemaps, etc.).
+Used for generating absolute URLs in production builds (meta tags, [sitemap](/docs/core/sitemap) locations, etc.).
 
 1. **CLI flag**: `--base-url <url>`.
 2. **`ConfigBuilder.setBaseUrl()`**: Set directly in `eco.config.ts`.

--- a/apps/docs/src/content/docs/reference/deployment.mdx
+++ b/apps/docs/src/content/docs/reference/deployment.mdx
@@ -25,8 +25,9 @@ This command will:
 1. Set `NODE_ENV=production`.
 2. Clean the `dist` directory.
 3. Generate static HTML for all files in `src/pages`.
-4. Process images and CSS.
-5. Collect all necessary server-side files.
+4. Write `robots.txt` (and optional `sitemap.xml` when enabled — see [Sitemap](/docs/core/sitemap)).
+5. Process images and CSS.
+6. Collect all necessary server-side files.
 
 ---
 

--- a/apps/docs/src/public/skill/reference/core.md
+++ b/apps/docs/src/public/skill/reference/core.md
@@ -79,6 +79,20 @@ export default eco.page({
 });
 ```
 
+### Sitemap (opt in)
+
+Disabled by default. Enable in `eco.config.ts`:
+
+```typescript
+.setSitemap({
+	enabled: true,
+	extraUrls: ['/rss.xml'],
+	exclude: ['/admin/**'],
+})
+```
+
+Included URLs: successfully exported static pages whose metadata resolves and `robots.index !== false`. Omitted when metadata throws (fail-closed) or `cache: 'dynamic'`. `exclude` filters eligible pathnames; `extraUrls` always append (not filtered by exclude or page robots). Written after `afterStaticExport`. Requires correct `baseUrl` / `ECOPAGES_BASE_URL` at build time. Output is sitemap.org 0.9 `<loc>` only (no `lastmod`). Full rules: `/docs/core/sitemap`.
+
 ## Common patterns
 
 **Dynamic routes:** `src/pages/blog/[slug].tsx` with `staticProps` reading `pathname.params`.

--- a/packages/core/src/static-site-generator/README.md
+++ b/packages/core/src/static-site-generator/README.md
@@ -65,3 +65,5 @@ Sitemap eligibility is decided during successful page export (`activeStaticPathn
 `StaticExportContext.routes` is the unfiltered static-generation route list. Sitemap filtering is applied separately.
 
 See `StaticExportContext` in `static-export-context.ts`.
+
+User-facing guide: [Sitemap](https://github.com/ecopages/ecopages/blob/main/apps/docs/src/content/docs/core/sitemap.mdx) in the docs app.


### PR DESCRIPTION
## Summary

- document sitemap eligibility, configuration, build order, and verification
- link sitemap behavior from core docs and the project context

## Validation

- pnpm run typecheck
- pnpm run test:vitest