### PR TITLE
test(browser): default checks to headless

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -69,6 +69,8 @@ Or `pnpm test:e2e:ui` for the Playwright UI.
 - **Parity** — bun, vite+node, vite+bun run only `parity.test.e2e.ts` (`@parity`), isolated `.e2e-tmp` workspace each.
 - **HMR** — `includes-hmr.test.e2e.ts`, own workspace.
 
+Browsers stay headless for `pnpm test:all` / `pnpm test:e2e` (`playwright.config.ts` `use.headless`, Vitest `browser.headless`). Use `pnpm test:e2e:ui` or `playwright test --headed` when you want a visible window.
+
 ## Environment variables
 
 | Variable                                   | Effect                                               |

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,6 +30,15 @@ export default defineConfig({
 	retries: process.env.CI ? 2 : 0,
 	reporter: 'list',
 	use: {
+		/**
+		 * `test:all` and `test:e2e` must stay on chrome-headless-shell.
+		 *
+		 * @remarks
+		 * Playwright 1.57+ ships Chrome for Testing as the Chromium binary. A headed
+		 * launch opens that `.app` in the macOS Dock. `pnpm test:e2e:ui` and `--headed`
+		 * still override this for local debugging.
+		 */
+		headless: true,
 		trace: 'on-first-retry',
 	},
 	projects: [

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -26,6 +26,7 @@ export default defineProject({
 			enabled: true,
 			provider: playwright(),
 			headless: true,
+			ui: false,
 			instances: [{ browser: 'chromium' }],
 		},
 	},


### PR DESCRIPTION
## Summary

- force Playwright and Vitest browser checks to run headlessly by default
- document how to opt into visible browser debugging

## Validation

- pnpm run test:vitest
- pnpm run typecheck